### PR TITLE
Inclusion of RF433T with Full Jammer and Intermittent Jammer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,15 @@ For more information on each function supported by Bruce, [read our wiki here](h
 - [X] BT Maelstrom
 
 ## RF
+- [x] Jammer Full (New) - @incursiohack
+- [x] Jammer Intermittent (New) - @incursiohack
+- [x] Spectrum (New) - @incursiohack
 - [ ] Scan/Copy (New)
 - [ ] Replay
-- [x] Spectrum (New)
+
 
 ## RFID
-- [x] Read and Write
+- [x] Read and Write - @incursiohack
 
 ## Others
 - [x] TV-B-Gone

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,7 +231,9 @@ void loop() {
           options = {
             //{"Scan/copy", [=]()   { displayRedStripe("Scan/Copy"); }},
             //{"Replay", [=]()      { displayRedStripe("Replay"); }},
-            {"Spectrum", [=]()    { rf_spectrum(); }}, //@IncursioHack
+            {"Spectrum", [=]()            { rf_spectrum(); }}, //@IncursioHack
+            {"Jammer Itmt", [=]() { rf_jammerIntermittent(); }}, //@IncursioHack
+            {"Jammer Full", [=]()         { rf_jammerFull(); }}, //@IncursioHack                
             {"Main Menu", [=]()   { backToMenu(); }},
           };
           delay(200);

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -89,6 +89,7 @@ void rf_spectrum() { //@IncursioHack - https://github.com/IncursioHack ----thank
 
 
 void rf_jammerFull() { //@IncursioHack - https://github.com/IncursioHack -  thanks @EversonPereira - rfcardputer
+    pinMode(GROVE_SDA, OUTPUT);
     tft.fillScreen(TFT_BLACK);
     tft.println("");    
     tft.println("  RF433 - Jammer Full");
@@ -98,28 +99,20 @@ void rf_jammerFull() { //@IncursioHack - https://github.com/IncursioHack -  than
     sendRF = true;
     digitalWrite(GROVE_SDA, HIGH); // Turn on Jammer
     int tmr0=millis();             // control total jammer time;
-    int tmr1=0;                    // short LOW pulse
     tft.println("Sending... Press ESC to stop.");
-            while (sendRF) {
-                if (checkEscPress() || (millis() - tmr0 >20000)) {
-                    sendRF = false;
-                    returnToMenu=true;
-                    break;                       
-                }
-                if((millis()-tmr1>500)) {           //keep jammer on for 500ms, jammer off for 50ms, and restart
-                    digitalWrite(GROVE_SDA, LOW);   
-                    delay(50);
-                    digitalWrite(GROVE_SDA, HIGH);
-                    tmr1=millis();
-                }
-
-  }
-  digitalWrite(GROVE_SDA, LOW); // Turn Jammer OFF
-
+    while (sendRF) {
+        if (checkEscPress() || (millis() - tmr0 >20000)) {
+            sendRF = false;
+            returnToMenu=true;
+            break;                       
+        }
+    }
+    digitalWrite(GROVE_SDA, LOW); // Turn Jammer OFF
 }
 
 
 void rf_jammerIntermittent() { //@IncursioHack - https://github.com/IncursioHack -  thanks @EversonPereira - rfcardputer
+    pinMode(GROVE_SDA, OUTPUT);
     tft.fillScreen(TFT_BLACK);
     tft.println("");    
     tft.println("  RF433 - Jammer Intermittent");
@@ -130,7 +123,7 @@ void rf_jammerIntermittent() { //@IncursioHack - https://github.com/IncursioHack
     tft.println("Sending... Press ESC to stop.");
     int tmr0 = millis();
     while (sendRF) {
-        for (int sequence = 1; sequence < 500; sequence++) {
+        for (int sequence = 1; sequence < 50; sequence++) {
             for (int duration = 1; duration <= 3; duration++) {
                 // Moved Escape check into this loop to check every cycle
                 if (checkEscPress() || (millis()-tmr0)>20000) {

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -39,6 +39,8 @@ void initRMT() {
     ESP_ERROR_CHECK(rmt_driver_install(rxconfig.channel, 2048, 0));
 }
 
+bool sendRF = false;
+
 void rf_spectrum() { //@IncursioHack - https://github.com/IncursioHack ----thanks @aat440hz - RF433ANY-M5Cardputer
 
     tft.fillScreen(TFT_BLACK);
@@ -70,10 +72,85 @@ void rf_spectrum() { //@IncursioHack - https://github.com/IncursioHack ----thank
                 }
                 vRingbufferReturnItem(rb, (void*)item);
             }
+                    if (checkEscPress()) {
+                    rmt_rx_stop(RMT_RX_CHANNEL);
+                    returnToMenu=true;
+                    break;                       
+                }
         }
             // Checks para sair do while
         
     rmt_rx_stop(RMT_RX_CHANNEL);
     delay(10);
+
+
+
+}
+
+
+void rf_jammerFull() { //@IncursioHack - https://github.com/IncursioHack -  thanks @EversonPereira - rfcardputer
+    tft.fillScreen(TFT_BLACK);
+    tft.println("");    
+    tft.println("  RF433 - Jammer Full");
+    tft.println(""); 
+    tft.println("");         
+    tft.setTextSize(2);
+    sendRF = true;
+    tft.println("Sending... Press ESC to stop.");
+            while (sendRF) {
+                delay(1000);
+                if (checkEscPress()) {
+                    sendRF = false;
+                    returnToMenu=true;
+                    break;                       
+                }
+            
+  
+  digitalWrite(GROVE_SDA, HIGH);
+    delay(20000);
+
+  }
+  digitalWrite(GROVE_SDA, LOW);
+             
+
+
+}
+
+
+void rf_jammerIntermittent() { //@IncursioHack - https://github.com/IncursioHack -  thanks @EversonPereira - rfcardputer
+    tft.fillScreen(TFT_BLACK);
+    tft.println("");    
+    tft.println("  RF433 - Jammer Intermittent");
+    tft.println("");
+    tft.println("");         
+    tft.setTextSize(2);
+    sendRF = true;
+    tft.println("Sending... Press ESC to stop.");
+            while (sendRF) {
+                delay(1000);
+                if (checkEscPress()) {
+                    sendRF = false;
+                    returnToMenu=true;
+                    break;
+                }
+            
+                    for (int sequence = 1; sequence < 5000; sequence++) {
+                        for (int duration = 1; duration <= 3; duration++) {
+                            digitalWrite(GROVE_SDA, HIGH); // Ativa o pino
+                            // Mantém o pino ativo por um período que aumenta com cada sequência
+                            for (int widthsize = 1; widthsize <= (1 + sequence); widthsize++) {
+                                delayMicroseconds(50);
+                            }
+
+                            digitalWrite(GROVE_SDA, LOW); // Desativa o pino
+                            // Mantém o pino inativo pelo mesmo período
+                            for (int widthsize = 1; widthsize <= (1 + sequence); widthsize++) {
+                                delayMicroseconds(50);
+                            }
+            }
+            }    
+        }
+
+
 
 }

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -96,23 +96,25 @@ void rf_jammerFull() { //@IncursioHack - https://github.com/IncursioHack -  than
     tft.println("");         
     tft.setTextSize(2);
     sendRF = true;
+    digitalWrite(GROVE_SDA, HIGH); // Turn on Jammer
+    int tmr0=millis();             // control total jammer time;
+    int tmr1=0;                    // short LOW pulse
     tft.println("Sending... Press ESC to stop.");
             while (sendRF) {
-                delay(1000);
-                if (checkEscPress()) {
+                if (checkEscPress() || (millis() - tmr0 >20000)) {
                     sendRF = false;
                     returnToMenu=true;
                     break;                       
                 }
-            
-  
-  digitalWrite(GROVE_SDA, HIGH);
-    delay(20000);
+                if((millis()-tmr1>500)) {           //keep jammer on for 500ms, jammer off for 50ms, and restart
+                    digitalWrite(GROVE_SDA, LOW);   
+                    delay(50);
+                    digitalWrite(GROVE_SDA, HIGH);
+                    tmr1=millis();
+                }
 
   }
-  digitalWrite(GROVE_SDA, LOW);
-             
-
+  digitalWrite(GROVE_SDA, LOW); // Turn Jammer OFF
 
 }
 
@@ -126,31 +128,30 @@ void rf_jammerIntermittent() { //@IncursioHack - https://github.com/IncursioHack
     tft.setTextSize(2);
     sendRF = true;
     tft.println("Sending... Press ESC to stop.");
-            while (sendRF) {
-                delay(1000);
-                if (checkEscPress()) {
+    int tmr0 = millis();
+    while (sendRF) {
+        for (int sequence = 1; sequence < 500; sequence++) {
+            for (int duration = 1; duration <= 3; duration++) {
+                // Moved Escape check into this loop to check every cycle
+                if (checkEscPress() || (millis()-tmr0)>20000) {
                     sendRF = false;
                     returnToMenu=true;
                     break;
                 }
-            
-                    for (int sequence = 1; sequence < 5000; sequence++) {
-                        for (int duration = 1; duration <= 3; duration++) {
-                            digitalWrite(GROVE_SDA, HIGH); // Ativa o pino
-                            // Mantém o pino ativo por um período que aumenta com cada sequência
-                            for (int widthsize = 1; widthsize <= (1 + sequence); widthsize++) {
-                                delayMicroseconds(50);
-                            }
+                digitalWrite(GROVE_SDA, HIGH); // Ativa o pino
+                // Mantém o pino ativo por um período que aumenta com cada sequência
+                for (int widthsize = 1; widthsize <= (1 + sequence); widthsize++) {
+                    delayMicroseconds(50);
+                }
 
-                            digitalWrite(GROVE_SDA, LOW); // Desativa o pino
-                            // Mantém o pino inativo pelo mesmo período
-                            for (int widthsize = 1; widthsize <= (1 + sequence); widthsize++) {
-                                delayMicroseconds(50);
-                            }
+                digitalWrite(GROVE_SDA, LOW); // Desativa o pino
+                // Mantém o pino inativo pelo mesmo período
+                for (int widthsize = 1; widthsize <= (1 + sequence); widthsize++) {
+                    delayMicroseconds(50);
+                }
             }
-            }    
-        }
-
-
-
+        }    
+    }
+    
+    digitalWrite(GROVE_SDA, LOW); // Desativa o pino
 }

--- a/src/rf.h
+++ b/src/rf.h
@@ -14,3 +14,5 @@ const int PCA9554RSX_PIN = 4;
 const int PCA9554TRX_PIN = 0;
 
 void rf_spectrum();
+void rf_jammerIntermittent();
+void rf_jammerFull();

--- a/src/rfid.cpp
+++ b/src/rfid.cpp
@@ -100,14 +100,12 @@ void rfid_loop() {
         }
      }
     // Checks para sair do while
-    if(checkEscPress()) {
-      tft.fillScreen(BGCOLOR);
-      goto Exit;
-    }
+                if (checkEscPress()) {
+                    returnToMenu=true;
+                    break;
+                }
 
     }
-    Exit:
-    delay(300);
     Serial.println();
 }
 


### PR DESCRIPTION
I included the Full Jammer and the Intermittent Jammer to the RF433T, this is also the preparation for the CC1101 via PCA9554 which will come in a new PR.

I suggest that you carry out tests in different scenarios, if you have a HackRF you can visualize it in a more practical way.
A test can be performed using Spectrum (RF433R) on one device and Intermittent Jammer (RF433T) on another.

I'm accepting suggestions regarding the visual part of Jammer (texts or animation).

Note, I noticed that leaving I2C devices connected to the M5 ends up draining more energy, even if unused.

