### PR TITLE
Extern definition to declaration

### DIFF
--- a/src/wifi_atks.cpp
+++ b/src/wifi_atks.cpp
@@ -19,12 +19,7 @@
  * @attention This function is not meant to be called!
  * @see Project with original idea/implementation https://github.com/GANESH-ICMC/esp32-deauther
 */
-extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3){
-    if (arg == 31337)
-      return 1;
-    else
-      return 0;
-}
+extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3);
 
 
 uint8_t deauth_frame[sizeof(deauth_frame_default)]; // 26 = [sizeof(deauth_frame_default[])]


### PR DESCRIPTION
Compiling with platform-io, it complains about multiple definitions. This change is supposed to fix this.