### PR TITLE
Documentation and feature restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ For more information on each function supported by Bruce, [read our wiki here](h
 
 # List of Features
 
+## Clock
+- [X] Clock (New)
+
 ## WiFi
 - [x] Connect to WiFi (New)
 - [x] WiFi AP (New)
@@ -54,6 +57,8 @@ For more information on each function supported by Bruce, [read our wiki here](h
 - [x] Wireguard Tun
 
 ## BLE
+- [X] BLE Beacon (New)
+- [X] BLE Scan (New)
 - [X] AppleJuice
 - [X] SwiftPair
 - [X] Android Spam (New?)
@@ -62,21 +67,25 @@ For more information on each function supported by Bruce, [read our wiki here](h
 - [X] BT Maelstrom
 
 ## RF
+- [x] Scan/Copy (New)
+- [x] Custom SubGhz (New)
+- [x] Spectrum (New) - @incursiohack
 - [x] Jammer Full (New) - @incursiohack
 - [x] Jammer Intermittent (New) - @incursiohack
-- [x] Spectrum (New) - @incursiohack
-- [ ] Scan/Copy (New)
 - [ ] Replay
 
-
 ## RFID
-- [x] Read and Write - @incursiohack
+- [x] Read tag
+- [x] Load file
+- [x] Erase data
 
 ## IR
 - [x] TV-B-Gone
 - [x] Custom IR (NEC, NEC42, NECExt, SIRC, SIRC15, SIRC20, Samsung32, RC5, RC5X, RC6)
 
 ## Others
+- [X] Mic Spectrum (new)
+- [X] QRCcodes (new)
 - [x] SD Card Mngr (New)
 - [x] SPIFFS Mngr (New)
 - [x] WebUI (New)
@@ -90,8 +99,15 @@ For more information on each function supported by Bruce, [read our wiki here](h
 
 ## Settings
 - [x] Brightness
-- [x] Orientation
+- [x] Dim Time (new)
 - [x] Clock (New)
+- [x] Orientation
+- [X] UI Color
+- [X] Ir TX Pin
+- [X] Ir RX Pin
+- [X] RF TX Pin
+- [X] RF RX Pin
+- [x] Sleep
 - [x] Restart
 
 # Acknowledgements
@@ -105,6 +121,22 @@ For more information on each function supported by Bruce, [read our wiki here](h
 Bruce is a tool for cyber offensive and red team operations, distributed under the terms of the Affero General Public License (AGPL). It is intended for legal and authorized security testing purposes only. Use of this software for any malicious or unauthorized activities is strictly prohibited. By downloading, installing, or using Bruce, you agree to comply with all applicable laws and regulations. This software is provided free of charge, and we do not accept payments for copies or modifications. The developers of Bruce assume no liability for any misuse of the software. Use at your own risk.
 
 # Changelog
+* 1.2.2
+    * new clock icon
+    * clock redraw for a slightly better one
+    * add default ssid and password (values: Mobile-AP / mobile-ap) on WiFi connect (to not type pwd on M5StickC Plus 2)
+    * add password (brucenet) to WiFi AP feature, and add QRCode to connect to it (more secure and easy to connect with QRCode)
+    * simple BT connection (code from M5 demo)
+    * BLE recon / scanner 
+    * QRCodes display (code from Nemo) (BruceAP, RickRoll, HackerTyper, ZomboCom)
+    * Mic spectrum (code from M5 demo)
+    * center Bruce and version to splashscreen for better UI
+    * set & display clock from RTC
+    * UI bug fixes (like Wifi info drawn on top of the UI boders)
+    * return to main menu fixed and added when missing
+    * better shutdown to avoir rolling menu (code from M5 demo)
+    * add little tone / bip at startup (just because it can, and can be bypassed if key pressed while booting) 
+
 * 1.2.1:
     * Fixed EEPROM save
     * Fixed Custom IR commands

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -70,7 +70,7 @@ void wifiOptions() {
 **********************************************************************/
 void bleOptions() {
   options = {
-    #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
+    #if defined(STICK_C_PLUS2)
     {"BLE Beacon",  [=]() { ble_test(); }},
     {"BLE Scan",     [=]() { ble_scan(); }},
     #endif
@@ -143,7 +143,7 @@ void irOptions(){
 **********************************************************************/
 void otherOptions(){
   options = {
-    #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
+    #if defined(STICK_C_PLUS2)
     {"Mic Spectrum", [=]() { mic_test(); }},
     #endif
     {"QRCodes",      [=]() { qrcode_menu(); }},

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -70,8 +70,10 @@ void wifiOptions() {
 **********************************************************************/
 void bleOptions() {
   options = {
+    #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
     {"BLE Beacon",  [=]() { ble_test(); }},
     {"BLE Scan",     [=]() { ble_scan(); }},
+    #endif
     {"AppleJuice",   [=]() { aj_adv(0); }},
     {"SwiftPair",    [=]() { aj_adv(1); }},
     {"Samsung Spam", [=]() { aj_adv(2); }},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,11 +232,6 @@ void setup() {
 
   delay(200);
   previousMillis = millis();
-
-  // Run default loop view for M5StickC Plus 2
-  #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
-    runClockLoop();
-  #endif
 }
 
 /**********************************************************************


### PR DESCRIPTION
BLE Beacon, BLE Scan and mic spectrum are now only available for M5StickC Plus 2.
It seems there is hardware compatibility issues with other devices.

I will test it on other devices another time, but for now I think it's better to let those features only on working hardware.