### PR TITLE
Fix clock initialization missing

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -407,7 +407,6 @@ void runClockLoop() {
   #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
     RTC_TimeTypeDef _time;
     cplus_RTC _rtc;
-    _rtc.begin();
     _rtc.GetBm8563Time();
     _rtc.GetTime(&_time);
   #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,6 +201,19 @@ void load_eeprom() {
   EEPROM.end();
 }
 
+/*********************************************************************
+**  Function: init_clock
+**  Clock initialisation for propper display in menu
+*********************************************************************/
+void init_clock() {
+  #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
+    RTC_TimeTypeDef _time;
+    cplus_RTC _rtc;
+    _rtc.begin();
+    _rtc.GetBm8563Time();
+    _rtc.GetTime(&_time);
+  #endif
+}
 
 /*********************************************************************
 **  Function: setup
@@ -227,6 +240,7 @@ void setup() {
   begin_tft();
   load_eeprom();
   boot_screen();
+  init_clock();
 
   if(!LittleFS.begin(true)) { LittleFS.format(), LittleFS.begin();}
 


### PR DESCRIPTION
Just a little fix to init clock from RTC on M5StickC Plus 2.

Was working fine before when clock was shown at startup. Knowing this behaviour was not ok for everyone, I deleted it.
But as a noob, I also deleted the clock initialization that was done in runClockLoop() automatically.

It's now done on separate function, called in setup().