### PR TITLE
added initial support for CC1101 via SPI (#66)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,11 @@ default_envs =
 	m5stack-core2
 	m5stack-core16mb
 	m5stack-core4mb
+;uncomment to not use global dirs to avoid possible conflicts
+;platforms_dir = .pio/platforms
+;packages_dir = .pio/packages
+;build_cache_dir = .pio/buildcache
+;cache_dir = .pio/cache
 
 [common]
 build_flags = 
@@ -42,6 +47,7 @@ lib_deps =
 	ESP8266SAM
 	TinyGPSPlus
 	tinyu-zhao/FFT@^0.0.1
+	lsatan/SmartRC-CC1101-Driver-Lib@^2.5.7
 
 [env:m5stack-cplus2]
 platform = espressif32
@@ -632,6 +638,11 @@ board = esp32-s3-devkitc-1
 framework = arduino
 ;board_build.partitions = custom_16Mb.csv
 ;board_upload.flash_size = 16MB
+;monitor_speed = 115200
+;board_build.partitions = custom_16Mb.csv
+;board_build.f_flash = 40000000L
+;board_upload.flash_size = 16MB
+;board_upload.maximum_size = 16777216
 build_flags =
 	${common.build_flags}
 	-DESP32S3DEVKITC1
@@ -643,16 +654,18 @@ build_flags =
 	-DLED_ON=HIGH
 	-DLED_OFF=LOW
 	; sd card pins
+	; suggested https://github.com/espressif/esp-idf/tree/master/examples/storage/sd_card/sdmmc
 	-DSDCARD_CS=-1
 	-DSDCARD_SCK=-1
 	-DSDCARD_MISO=-1
 	-DSDCARD_MOSI=-1
-	; grove pins (SDA=default TX pin, SCL=default RX pin)
-	-DGROVE_SDA=35
-	-DGROVE_SCL=36
+	; grove pins (SDA=default TX pin, SCL=default RX pin, for both IR and RF)
+	; defaults from https://github.com/espressif/arduino-esp32/blob/master/variants/esp32s3/pins_arduino.h
+	-DGROVE_SDA=8  ; default RF TX pin
+	-DGROVE_SCL=9  ; default IR/RF RX pin
 	; tft vars
 	-DROTATION=1
-	-DBACKLIGHT=15  ; tft backlight pin
+	-DBACKLIGHT=-1  ; tft backlight pin
 	-DWIDTH=240
 	-DHEIGHT=135
 	-DMINBRIGHT=160  ; unused?
@@ -665,17 +678,25 @@ build_flags =
 	-DFM=2
 	-DFG=3
 	; ui control buttons
-	-DSEL_BTN=1
-	-DUP_BTN=2  ; also work as ESC
-	-DDW_BTN=3  ; also work as NEXT
-	-DTOUCH_THRESHOLD=20
+	;-DSEL_BTN=1
+	;-DUP_BTN=2  ; also work as ESC
+	;-DDW_BTN=3  ; also work as NEXT
 	-DBTN_ALIAS='"OK"'
 	;Microphone
 	;-DMIC_SPM1423=1 ; uncomment to enable Applicable for SPM1423 device
-    -DPIN_CLK=43
-    -DI2S_SCLK_PIN=43
-    -DI2S_DATA_PIN=46
-    -DPIN_DATA=46
+    ;-DPIN_CLK=-1
+    ;-DI2S_SCLK_PIN=-1
+    ;-DI2S_DATA_PIN=-1
+    ;-DPIN_DATA=-1
+    ;CC1101 SPI connection pins, can use any on this board https://esp32.com/viewtopic.php?t=37729
+    ; best connection pins for higher speed https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/spi_master.html#gpio-matrix-and-io-mux
+    -DUSE_CC1101_VIA_SPI
+	-DCC1101_GDO0_PIN=9  ; RFSend (SPI2_IOMUX_PIN_NUM_HD / FSPIHD)
+	-DCC1101_SS_PIN=10
+	-DCC1101_MOSI_PIN=11
+    -DCC1101_SCK_PIN=12
+	-DCC1101_MISO_PIN=13
+	-DCC1101_GDO2_PIN=14  ; RFRecv (SPI2_IOMUX_PIN_NUM_CS  / FSPIWP)
 lib_deps =
 	${common.lib_deps}
 


### PR DESCRIPTION
currently disabled, must be enabled via this define in the platformio.ini:
````
    -DUSE_CC1101_VIA_SPI
	-DCC1101_GDO0_PIN=9  ; RFSend (SPI2_IOMUX_PIN_NUM_HD / FSPIHD)
	-DCC1101_SS_PIN=10
	-DCC1101_MOSI_PIN=11
        -DCC1101_SCK_PIN=12
	-DCC1101_MISO_PIN=13
	-DCC1101_GDO2_PIN=14  ; RFRecv (SPI2_IOMUX_PIN_NUM_CS  / FSPIWP)
````

this only updates `RCSwitch_send()` to work with CC1101.


