### PR TITLE
Fix minor ambiguous press button while printing QRCodes

### DIFF
--- a/src/modules/others/qrcode_menu.cpp
+++ b/src/modules/others/qrcode_menu.cpp
@@ -37,6 +37,7 @@ void qrcode_display(String qrcodeUrl) {
     qrcode.init();
 
     qrcode.create(qrcodeUrl);
+    delay(300); //Due to M5 sel press, it could be confusing with next line
     while(!checkEscPress() && !checkSelPress()) delay(100);
     tft.fillScreen(BGCOLOR);
 #endif


### PR DESCRIPTION
Just a tiny fix in QRCode display.
When you press m5 / select button while choosing your QRCode, it can display then be interpreted as quit without button released.

I just added a little delay to be sure that pressing select button will not be misunderstood.