### PR TITLE
Fix upwards movement in megalodon for sticks

### DIFF
--- a/src/modules/others/tururururu.cpp
+++ b/src/modules/others/tururururu.cpp
@@ -65,7 +65,11 @@ void drawFish(Fish &f) {
 // Função para mover o tubarão
 void moveShark() {
 
+    #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2) // checkEscPress is the same of checkPrevPress in these devices
+    if (checkSelPress())
+    #else
     if (checkPrevPress())
+    #endif
     {
         sharkY -= 2;  // Move para cima
     }


### PR DESCRIPTION
Using `checkSelPress` instead of `checkPrevPress` on Sticks C plus devices.
Because `checkPrevPress` and `checkEscPress` are the same on Stick C Plus devices, it will just exit the game:
```cpp
// line 188
if(checkEscPress()) {
    returnToMenu=true;
    goto Exit;
}
```
Was changed here: https://github.com/pr3y/Bruce/commit/04bad3ad899cbfae4c1899cc2c96e7fed59d0c5b#diff-f5f2954aa88e842cf7167b26b403d632d2038b0b4790fd3a1b0a46a476a943fb