### PR TITLE
RF menu fixes + cardputer extra shortcuts

### DIFF
--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -31,9 +31,6 @@
 #ifdef HAS_RGB_LED
 #include "modules/others/led_control.h"
 #endif
-#ifdef USE_CC1101_VIA_SPI
-#include <ELECHOUSE_CC1101_SRC_DRV.h>
-#endif
 
 
 /**********************************************************************
@@ -187,17 +184,12 @@ void configOptions(){
     {"Ir RX Pin",     [=]() { gsetIrRxPin(true);     saveConfigs();}},
     {"RF TX Pin",     [=]() { gsetRfTxPin(true);     saveConfigs();}},
     {"RF RX Pin",     [=]() { gsetRfRxPin(true);     saveConfigs();}},
+    {"RF Module",     [=]() { setRFModuleMenu();     saveConfigs();}},
+    {"RF Frequency",  [=]() { setRFFreqMenu();       saveConfigs();}},
     {"Sleep",         [=]() { setSleepMode(); }},
     {"Restart",       [=]() { ESP.restart(); }},
     {"Main Menu",     [=]() { backToMenu(); }},
   };
-
-#ifdef USE_CC1101_VIA_SPI
-  if(ELECHOUSE_cc1101.getCC1101()) {  // show these options only if the cc1101 is detected
-    options.push_back({"RF Module",     [=]() { setRFModuleMenu(); saveConfigs();}});
-    options.push_back({"RF Frequency",  [=]() { setRFFreqMenu(); saveConfigs();}});
-  }
-#endif
 
   delay(200);
   loopOptions(options,false,true,"Config");

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -133,7 +133,7 @@ bool checkEscPress(){
     if(axp192.GetBtnPress())
   #elif defined (CARDPUTER)
     Keyboard.update();
-    if(Keyboard.isKeyPressed('`'))
+    if(Keyboard.isKeyPressed('`') || Keyboard.isKeyPressed(KEY_BACKSPACE))
   #elif ! defined(HAS_SCREEN)
     // always return false
     if(false)
@@ -161,6 +161,9 @@ bool checkAnyKeyPress() {
   #elif defined(M5STACK)
     M5.update();
     if(M5.BtnA.isHolding() || M5.BtnA.isPressed() || M5.BtnB.isHolding() || M5.BtnB.isPressed() || M5.BtnC.isHolding() || M5.BtnC.isPressed())    
+  #elif ! defined(HAS_SCREEN)
+    // always return false
+    if(false)
   #else
     if(digitalRead(SEL_BTN)==LOW)  // If M5 key is pressed, it'll jump the boot screen
   #endif
@@ -188,11 +191,22 @@ int checkNumberShortcutPress() {
     // shortctus to quickly select options
     Keyboard.update();
     char c;
-    for (c = '1'; c <= '9'; c++) {
+    for (c = '1'; c <= '9'; c++)
         if(Keyboard.isKeyPressed(c)) return(c - '1');
-      }
     // else
     return -1;
+}
+
+char checkLetterShortcutPress() {
+  // shortctus to quickly select options
+  Keyboard.update();
+  char c;
+  for (c = 'a'; c <= 'z'; c++)
+      if(Keyboard.isKeyPressed(c)) return(c);
+  for (c = 'A'; c <= 'Z'; c++)
+      if(Keyboard.isKeyPressed(c)) return(c);
+  // else
+  return -1;
 }
 #endif
 

--- a/src/core/mykeyboard.h
+++ b/src/core/mykeyboard.h
@@ -15,6 +15,7 @@ bool checkEscPress();
 #ifdef CARDPUTER
 void checkShortcutPress();
 int checkNumberShortcutPress();
+char checkLetterShortcutPress();
 #endif
 
 bool checkAnyKeyPress();

--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -570,7 +570,38 @@ String loopSD(FS &fs, bool filePicker, String allowed_ext) {
     }
 
     #ifdef CARDPUTER
+      /*
+      if(Keyboard.isKeyPressed(KEY_BACKSPACE)) {
+        // go back 1 level
+          if(Folder == "/") break;
+          Folder = fileList[index][1];
+          index = 0;
+          redraw=true;
+          continue;
+      }*/
       if(checkEscPress()) break;
+      char pressed_letter = checkLetterShortcutPress();
+      if(pressed_letter>0) {
+        //Serial.println(pressed_letter);
+        if(tolower(fileList[index][0].c_str()[0]) == pressed_letter) {
+          // already selected, go to the next
+          index += 1;
+          // check if index is still valid
+          if(index<=maxFiles && tolower(fileList[index][0].c_str()[0]) == pressed_letter)
+          {
+            redraw = true;
+            continue;
+          }
+        }
+        // else look again from the start
+        for(int i=0; i<maxFiles; i++) {
+          if(tolower(fileList[i][0].c_str()[0]) == pressed_letter) {  // check if 1st char matches
+            index = i; 
+            redraw = true;
+            break;  // quit on 1st match
+          }
+        }
+      }
     #endif
   }
   clearFileList(fileList);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ int IrTx;
 int IrRx;
 int RfTx;
 int RfRx;
-int RfModule=0;  // 0 - single-pinned, 1 - CC1101
+int RfModule=0;  // 0 - single-pinned, 1 - CC1101+SPI
 float RfFreq=433.92;
 int dimmerSet;
 int bright=100;
@@ -373,7 +373,6 @@ void loop() {
 void loop() {
   setupSdCard();
   getConfigs();
-  if(RfModule==1) initCC1101once();
   
   if(!wifiConnected) {
     Serial.println("wifiConnect");

--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -224,14 +224,7 @@ void RCSwitch_send(uint64_t data, unsigned int bits, int pulse, int protocol, in
 
     mySwitch.disableTransmit();
     
-    if(RfModule==1) 
-        #ifdef USE_CC1101_VIA_SPI
-            ELECHOUSE_cc1101.setSidle();
-        #else
-            return;
-        #endif
-    else
-        digitalWrite(RfTx, LED_OFF);
+    deinitRfModule();
 }
 
 
@@ -383,17 +376,30 @@ void initCC1101once() {
     return;
 }
 
+void deinitRfModule() {
+    if(RfModule==1) 
+        #ifdef USE_CC1101_VIA_SPI
+            ELECHOUSE_cc1101.setSidle();
+        #else
+            return;
+        #endif
+    else
+        digitalWrite(RfTx, LED_OFF);
+}
+
+
 bool initRfModule(String mode, float frequency) {
     
     if(RfModule == 1) { // CC1101 in use
         #ifdef USE_CC1101_VIA_SPI   
-            ELECHOUSE_cc1101.Init();
             if (ELECHOUSE_cc1101.getCC1101()){       // Check the CC1101 Spi connection.
                 Serial.println("cc1101 Connection OK");
             } else {
                 Serial.println("cc1101 Connection Error");
                 return false;
             }
+            
+            ELECHOUSE_cc1101.Init();
 
             // make sure it is in idle state when changing frequency and other parameters
             // "If any frequency programming register is altered when the frequency synthesizer is running, the synthesizer may give an undesired response. Hence, the frequency programming should only be updated when the radio is in the IDLE state." https://github.com/LSatan/SmartRC-CC1101-Driver-Lib/issues/65
@@ -820,6 +826,7 @@ void sendRfCommand(struct RfCodes rfcode) {
     }
 
     //digitalWrite(RfTx, LED_OFF);
+    deinitRfModule();
 }
 
 
@@ -923,7 +930,8 @@ bool txSubFile(FS *fs, String filepath) {
   addToRecentCodes(selected_code);
   sendRfCommand(selected_code);
 
-  digitalWrite(RfTx, LED_OFF);
+  //digitalWrite(RfTx, LED_OFF);
+  deinitRfModule();
   return true;
 }
 

--- a/src/modules/rf/rf.h
+++ b/src/modules/rf/rf.h
@@ -24,3 +24,4 @@ void addToRecentCodes(struct RfCodes rfcode);
 void sendRfCommand(struct RfCodes rfcode);
 bool initRfModule(String mode, float frequency=0);
 void initCC1101once();
+void deinitRfModule();


### PR DESCRIPTION
changes:

 - the "RF Module" config menu is always visible, so you can switch back to the  R433T/R  even if the CC1101 is not connected
 - reset default frequency on error
 - added new keyboard shortcuts for the cardputer: go back in the menus with backspace/esc, select files with letters (press multiple times to cycle)