### PR TITLE
Fix/startup sound

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,20 +178,8 @@ void boot_screen() {
     }
   }
 
-#if !defined(LITE_VERSION)
-  #if defined(BUZZ_PIN)
-    // Bip M5 just because it can. Does not bip if splashscreen is bypassed
-    _tone(5000, 50);
-    delay(200);
-    _tone(5000, 50);
-  /*  2fix: menu infinite loop */
-  #elif defined(HAS_NS4168_SPKR)
-    // play a boot sound
-    if(SD.exists("/boot.wav")) playAudioFile(&SD, "/boot.wav");
-    else if(LittleFS.exists("/boot.wav")) playAudioFile(&LittleFS, "/boot.wav");
-    setup_gpio(); // temp fix for menu inf. loop
-  #endif
-#endif
+  // Clear splashscreen
+  tft.fillScreen(TFT_BLACK);
 }
 
 
@@ -278,6 +266,27 @@ void init_clock() {
 }
 
 /*********************************************************************
+**  Function: startup_sound
+**  Play sound or tone depending on device hardware
+*********************************************************************/
+void startup_sound() {
+#if !defined(LITE_VERSION)
+  #if defined(BUZZ_PIN)
+    // Bip M5 just because it can. Does not bip if splashscreen is bypassed
+    _tone(5000, 50);
+    delay(200);
+    _tone(5000, 50);
+  /*  2fix: menu infinite loop */
+  #elif defined(HAS_NS4168_SPKR)
+    // play a boot sound
+    if(SD.exists("/boot.wav")) playAudioFile(&SD, "/boot.wav");
+    else if(LittleFS.exists("/boot.wav")) playAudioFile(&LittleFS, "/boot.wav");
+    setup_gpio(); // temp fix for menu inf. loop
+  #endif
+#endif
+}
+
+/*********************************************************************
 **  Function: setup
 **  Where the devices are started and variables set
 *********************************************************************/
@@ -306,6 +315,8 @@ void setup() {
   if(!LittleFS.begin(true)) { LittleFS.format(), LittleFS.begin();}
 
   boot_screen();
+  setupSdCard();
+  startup_sound();
 
   #if ! defined(HAS_SCREEN)
     // start a task to handle serial commands while the webui is running
@@ -330,7 +341,6 @@ void loop() {
   int opt = 9;
 
   tft.fillRect(0,0,WIDTH,HEIGHT,BGCOLOR);
-  setupSdCard();
   getConfigs();
 
 


### PR DESCRIPTION
#### Proposed Changes ####

Fixing startup sound for Cardputer.

#### Types of Changes ####

SD was setup after startup sound play, therefore it wasn't working (but wasn't crashing neither).
I put the startup sound in a dedicated function and call setupSdCard() just before.

#### Testing ####

Put a wav file named "boot.wav" at the root of the SD card. It should be played.

