### PR TITLE
Fix/sticks_slowed_down

### DIFF
--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -635,8 +635,8 @@ void checkReboot() {
                 }
             }
 
-            // clear text after releasing the button
-            delay(300);
+            // Clear text after releasing the button
+            delay(30);
             tft.fillRect(60, 12, WIDTH - 60, tft.fontHeight(1), TFT_BLACK);
         }
     #endif


### PR DESCRIPTION
#### Proposed Changes ####

With commit 2263c8e, the shutdown counter is now cleared if not reached.  
Unfortunately, a delay of 300ms was added just after that was slowing down the menu when pressing "prev" on M5Stickcs.

#### Testing ####

This annoying delay is now fixed (passed to 30ms which is almost not noticeable). You can press "prev" and see the difference.

#### Linked Issues ####

Introduced in commit 2263c8e.
