### PR TITLE
 Changes to FM Radio, working on StickC 1.1 and Cardputer.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -203,7 +203,7 @@ build_flags =
 	-DFM_RSTPIN=0
 	;Microphone
 	-DMIC_SPM1423=1 ;Applicable for SPM1423 device
-    -DPIN_CLK=0
+    -=0
     -DI2S_SCLK_PIN=0
     -DI2S_DATA_PIN=34
     -DPIN_DATA=34
@@ -317,7 +317,7 @@ build_flags =
 	;FM Radio
 	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
 	-DFM_RSTPIN=40
-    -DPIN_CLK=43
+    -=43
     -DI2S_SCLK_PIN=43
     -DI2S_DATA_PIN=46
     -DPIN_DATA=46
@@ -443,7 +443,7 @@ build_flags =
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
-	;-DFM_RSTPIN=18		
+	-DFM_RSTPIN=18		
 	;Microphone
 	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
     -DPIN_CLK=-1
@@ -564,7 +564,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
-	;-DFM_RSTPIN=18	
+	-DFM_RSTPIN=18	
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;Microphone
 	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
@@ -683,7 +683,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
-	;-DFM_RSTPIN=18		
+	-DFM_RSTPIN=18		
 	-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;Microphone
 	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
@@ -853,7 +853,7 @@ build_flags =
 	
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
-	;-DFM_RSTPIN=12		
+	-DFM_RSTPIN=12		
 	;Microphone
 	;-DMIC_SPM1423=1 ; uncomment to enable Applicable for SPM1423 device
     ;-DPIN_CLK=-1
@@ -906,7 +906,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
-	;-DFM_RSTPIN=18		
+	-DFM_RSTPIN=18		
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	
 	;Microphone
@@ -1029,7 +1029,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
-	;-DFM_RSTPIN=40	
+	-DFM_RSTPIN=40	
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;Microphone
 	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device

--- a/platformio.ini
+++ b/platformio.ini
@@ -203,7 +203,7 @@ build_flags =
 	-DFM_RSTPIN=0
 	;Microphone
 	-DMIC_SPM1423=1 ;Applicable for SPM1423 device
-    -=0
+    -DPIN_CLK=0
     -DI2S_SCLK_PIN=0
     -DI2S_DATA_PIN=34
     -DPIN_DATA=34
@@ -317,7 +317,7 @@ build_flags =
 	;FM Radio
 	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
 	-DFM_RSTPIN=40
-    -=43
+    -DPIN_CLK=43
     -DI2S_SCLK_PIN=43
     -DI2S_DATA_PIN=46
     -DPIN_DATA=46

--- a/platformio.ini
+++ b/platformio.ini
@@ -89,6 +89,7 @@ build_flags =
 	-DMIC_SPM1423=1 ;Applicable for SPM1423 device
 	;FM Radio
 	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=0
     -DPIN_CLK=0
     -DI2S_SCLK_PIN=0
     -DI2S_DATA_PIN=34
@@ -199,6 +200,7 @@ build_flags =
 	-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;FM Radio
 	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=0
 	;Microphone
 	-DMIC_SPM1423=1 ;Applicable for SPM1423 device
     -DPIN_CLK=0
@@ -313,7 +315,8 @@ build_flags =
 	;Microphone
 	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
 	;FM Radio
-	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=40
     -DPIN_CLK=43
     -DI2S_SCLK_PIN=43
     -DI2S_DATA_PIN=46
@@ -440,6 +443,7 @@ build_flags =
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	;-DFM_RSTPIN=18		
 	;Microphone
 	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
     -DPIN_CLK=-1
@@ -560,6 +564,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	;-DFM_RSTPIN=18	
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;Microphone
 	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
@@ -678,6 +683,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	;-DFM_RSTPIN=18		
 	-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;Microphone
 	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
@@ -847,6 +853,7 @@ build_flags =
 	
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	;-DFM_RSTPIN=12		
 	;Microphone
 	;-DMIC_SPM1423=1 ; uncomment to enable Applicable for SPM1423 device
     ;-DPIN_CLK=-1
@@ -899,6 +906,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	;-DFM_RSTPIN=18		
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	
 	;Microphone
@@ -1021,6 +1029,7 @@ build_flags =
 	;Features Enabled
 	;FM Radio
 	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	;-DFM_RSTPIN=40	
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
 	;Microphone
 	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device

--- a/src/core/menu_items/FMMenu.cpp
+++ b/src/core/menu_items/FMMenu.cpp
@@ -4,7 +4,8 @@
 
 void FMMenu::optionsMenu() {
     options = {
-    #if !defined(LITE_VERSION) and defined(FM_SI4713)
+//    #if !defined(LITE_VERSION) and defined(FM_SI4713)
+      #if defined(FM_SI4713)  
         {"Brdcast std",   [=]() { fm_live_run(false); }},
         {"Brdcast rsvd",  [=]() { fm_live_run(true); }},
         {"Brdcast stop",  [=]() { fm_stop(); }},

--- a/src/modules/fm/fm.cpp
+++ b/src/modules/fm/fm.cpp
@@ -1,11 +1,9 @@
 #include "fm.h"
 
-#define RESETPIN 0
-
 bool auto_scan = false;
 bool is_running = false;
 uint16_t fm_station = 10230; // Default set to 102.30 MHz
-Adafruit_Si4713 radio = Adafruit_Si4713(RESETPIN);
+Adafruit_Si4713 radio = Adafruit_Si4713(FM_RSTPIN);
 
 void set_auto_scan(bool new_value) {
   auto_scan = new_value;


### PR DESCRIPTION
#### Proposed Changes ####

Some changes were made to the pins and menu so that FM Radio would work on StickC 1.1 and on Cardputer with SD Card Sniffer.

#### Verification ####

2 Situations:
1 - The pins on the Wiki are inverted, I will change them.
2 - It broadcasts via FM Radio the audio that comes from the P2/P3 connector, it still does not reproduce the audio in MP3/WAV from the StickC/Cardputer, therefore, it needs an extra device (a cell phone or computer) sending the audio via P2 cable to the board.

#### Testing ####

It was tested with the Cardputer and the StickC 1.1 and I was successful, with a small wire as an antenna I was able to reach a few meters of distance with sound quality. Funnily enough, I have a MAONO audio card and in addition to the music playing, I was also able to add some effects and use the computer's microphone. It was very similar to a radio station :)

On the cardputer with the SD Card Sniffer, use the CLK pin connected to the RST of the FM transmission card.

![Cardputer FMRadio2](https://github.com/user-attachments/assets/da9564c0-9e85-4512-b287-095d8c9ebd12)
![Stick FMRadio1](https://github.com/user-attachments/assets/f6684241-ab79-4b4d-9e43-5eb8fbcb96b6)

#### Further Comments ####

In several countries, FM broadcasting is prohibited, check this information and carry it out in a controlled environment.
