### PR TITLE
[FM Transmitter] Removing the RST pin and releasing the MicroSD. 

### DIFF
--- a/src/modules/fm/fm.cpp
+++ b/src/modules/fm/fm.cpp
@@ -3,7 +3,7 @@
 bool auto_scan = false;
 bool is_running = false;
 uint16_t fm_station = 10230; // Default set to 102.30 MHz
-Adafruit_Si4713 radio = Adafruit_Si4713(FM_RSTPIN);
+Adafruit_Si4713 radio = Adafruit_Si4713();
 
 void set_auto_scan(bool new_value) {
   auto_scan = new_value;


### PR DESCRIPTION
I discovered a way to make the Si4713 (FM Transmitter) work without the RST pin plugged into the Cardputer and StcikC. It is necessary to take the cable connected to the RST pin of the FM Transmitter and quickly touch it to the GND pin, changing the state of the pin and activating the board. In the future it is possible to add some hardware to do this work.

Removing the RST pin from the code also allows the use of the MicroSD Card from the SD Card Sniffer or Cardputer, improving usability.

## PoC
https://www.veed.io/view/d70db376-0591-487c-88f9-bab03479010f?panel=share