### PR TITLE
NRF24 Dedicated Menu and 2,4Ghz Spectrum

### DIFF
--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -13,10 +13,13 @@ MainMenu::MainMenu() {
         &fmMenu,
         &othersMenu,
         &clockMenu,
-        &configMenu,
     #if !defined(CORE) && !defined(CORE2)
         &scriptsMenu,
     #endif
+    #if defined(USE_NRF24_VIA_SPI)
+        &nrf24Menu,
+    #endif
+        &configMenu,
     };
 
     _totalItems = _menuItems.size();

--- a/src/core/main_menu.h
+++ b/src/core/main_menu.h
@@ -13,6 +13,7 @@
 #include "menu_items/RFMenu.h"
 #include "menu_items/WifiMenu.h"
 #include "menu_items/ScriptsMenu.h"
+#include "menu_items/NRF24.h"
 
 
 class MainMenu {
@@ -27,6 +28,7 @@ public:
     RFMenu rfMenu;
     WifiMenu wifiMenu;
     ScriptsMenu scriptsMenu;
+    NRF24Menu nrf24Menu;
 
     MainMenu();
     ~MainMenu();

--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -3,7 +3,7 @@
 #include "core/display.h"
 #include "modules/ble/ble_spam.h"
 #include "modules/ble/ble_common.h"
-#include "modules/ble/ble_jammer.h"
+#include "modules/NRF24/nrf_jammer.h"
 #include "modules/ble/bad_ble.h"
 
 void BleMenu::optionsMenu() {
@@ -22,9 +22,6 @@ void BleMenu::optionsMenu() {
 #endif
 #if defined(CARDPUTER)
     options.push_back({"BLE Keyboard", [=]() { ble_keyboard(); }});
-#endif
-#if defined(USE_NRF24_VIA_SPI)
-    options.push_back({"NRF24 Jammer", [=]() { ble_jammer(); }});
 #endif
     options.push_back({"iOS Spam",     [=]() { aj_adv(0); }});
     options.push_back({"Windows Spam", [=]() { aj_adv(1); }});

--- a/src/core/menu_items/IRMenu.cpp
+++ b/src/core/menu_items/IRMenu.cpp
@@ -14,7 +14,9 @@ void IRMenu::optionsMenu() {
     };
 
     delay(200);
-    loopOptions(options,false,true,"Infrared");
+    String txt = "Infrared";
+    txt+=" Tx: " + String(IrTx) + " Rx: " + String(IrRx);
+    loopOptions(options,false,true,txt);
 }
 
 void IRMenu::configMenu() {

--- a/src/core/menu_items/NRF24.cpp
+++ b/src/core/menu_items/NRF24.cpp
@@ -6,7 +6,13 @@
 void NRF24Menu::optionsMenu() {
     options.clear();
     options.push_back({"Jammer 2.4G",  [=]() { nrf_jammer(); }});
-    options.push_back({"Spectrum",     [=]() { nrf_spectrum(); }});
+  #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
+    options.push_back({"Spectrum",     [=]() { nrf_spectrum(&CC_NRF_SPI); }});
+  #elif defined(CARDPUTER) || defined(ESP32S3DEVKITC1)
+    options.push_back({"Spectrum",     [=]() { nrf_spectrum(&sdcardSPI); }});
+  #else 
+    options.push_back({"Spectrum",     [=]() { nrf_spectrum(&SPI); }});
+  #endif
     
     options.push_back({"Main Menu",    [=]() { backToMenu(); }});
     delay(200);

--- a/src/core/menu_items/NRF24.cpp
+++ b/src/core/menu_items/NRF24.cpp
@@ -1,11 +1,12 @@
 #include "NRF24.h"
 #include "core/display.h"
+#include "modules/NRF24/nrf_common.h"
 #include "modules/NRF24/nrf_jammer.h"
 #include "modules/NRF24/nrf_spectrum.h"
 
 void NRF24Menu::optionsMenu() {
     options.clear();
-    options.push_back({"Jammer 2.4G",  [=]() { nrf_jammer(); }});
+    options.push_back({"Information",  [=]() { nrf_info(); }});
   #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
     options.push_back({"Spectrum",     [=]() { nrf_spectrum(&CC_NRF_SPI); }});
   #elif defined(CARDPUTER) || defined(ESP32S3DEVKITC1)
@@ -13,6 +14,7 @@ void NRF24Menu::optionsMenu() {
   #else 
     options.push_back({"Spectrum",     [=]() { nrf_spectrum(&SPI); }});
   #endif
+    options.push_back({"Jammer 2.4G",  [=]() { nrf_jammer(); }});
     
     options.push_back({"Main Menu",    [=]() { backToMenu(); }});
     delay(200);

--- a/src/core/menu_items/NRF24.cpp
+++ b/src/core/menu_items/NRF24.cpp
@@ -1,0 +1,43 @@
+#include "NRF24.h"
+#include "core/display.h"
+#include "modules/NRF24/nrf_jammer.h"
+#include "modules/NRF24/nrf_spectrum.h"
+
+void NRF24Menu::optionsMenu() {
+    options.clear();
+    options.push_back({"Jammer 2.4G",  [=]() { nrf_jammer(); }});
+    options.push_back({"Spectrum",     [=]() { nrf_spectrum(); }});
+    
+    options.push_back({"Main Menu",    [=]() { backToMenu(); }});
+    delay(200);
+    loopOptions(options,false,true,"Bluetooth");
+}
+
+String NRF24Menu::getName() {
+    return _name;
+}
+
+void NRF24Menu::draw() {
+    // Blank
+    tft.fillRect(iconX,iconY,80,80,BGCOLOR);
+
+    // Case
+    tft.drawRect(0+iconX,40+iconY,60,40,FGCOLOR);
+    tft.fillRect(60+iconX,55+iconY,10,10,FGCOLOR);
+    //Antenna
+    tft.fillRoundRect(70+iconX,10+iconY,10,55,5,FGCOLOR);
+
+    //Chip connecto
+    tft.fillCircle(10+iconX, 48+iconY,3,FGCOLOR);
+    tft.fillCircle(10+iconX, 56+iconY,3,FGCOLOR);
+    tft.fillCircle(10+iconX, 64+iconY,3,FGCOLOR);
+    tft.fillCircle(10+iconX, 72+iconY,3,FGCOLOR);
+
+    tft.fillCircle(20+iconX, 48+iconY,3,FGCOLOR);
+    tft.fillCircle(20+iconX, 56+iconY,3,FGCOLOR);
+    tft.fillCircle(20+iconX, 64+iconY,3,FGCOLOR);
+    tft.fillCircle(20+iconX, 72+iconY,3,FGCOLOR);
+    
+    //Chip
+    tft.fillRect(35+iconX,55+iconY,10,10,FGCOLOR);
+}

--- a/src/core/menu_items/NRF24.h
+++ b/src/core/menu_items/NRF24.h
@@ -1,0 +1,17 @@
+#ifndef __NRF24_MENU_H__
+#define __NRF24_MENU_H__
+
+#include "MenuItemInterface.h"
+
+
+class NRF24Menu : public MenuItemInterface {
+public:
+    void optionsMenu(void);
+    void draw(void);
+    String getName(void);
+
+private:
+    String _name = "NRF24";
+};
+
+#endif

--- a/src/core/menu_items/RFIDMenu.cpp
+++ b/src/core/menu_items/RFIDMenu.cpp
@@ -16,7 +16,12 @@ void RFIDMenu::optionsMenu() {
     };
 
     delay(200);
-    loopOptions(options,false,true,"RFID");
+
+    String txt = "RFID";
+    if(RfidModule==0)       txt+=" (RFID2)";
+    else if(RfidModule==1)  txt+=" (PN532-I2C)";
+    else if(RfidModule==2)  txt+=" (PN532-SPI)";
+    loopOptions(options,false,true,txt);
 }
 
 void RFIDMenu::configMenu() {

--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -15,7 +15,11 @@ void RFMenu::optionsMenu() {
     };
 
     delay(200);
-    loopOptions(options,false,true,"Radio Frequency");
+    String txt = "Radio Frequency";
+    if(RfModule)    txt+=" (CC1101)"; // Indicates if CC1101 is connected
+    else            txt+=" Tx: " + String(RfTx) + " Rx: " + String(RfRx);
+    
+    loopOptions(options,false,true,txt);
 }
 
 void RFMenu::configMenu() {

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -9,7 +9,7 @@
 #include "modules/wifi/sniffer.h"
 #include "modules/wifi/wardriving.h"
 #include "modules/wifi/wifi_atks.h"
-#include "modules/ble/ble_jammer.h"
+#include "modules/NRF24/nrf_jammer.h"
 
 #ifndef LITE_VERSION
 #include "modules/pwnagotchi/pwnagotchi.h"
@@ -39,9 +39,6 @@ void WifiMenu::optionsMenu() {
 #ifndef LITE_VERSION
     options.push_back({"Wireguard", [=]()     { wg_setup(); }});
     options.push_back({"Pwnagotchi",  [=]()   { pwnagotchi_start(); }});
-#endif
-#if defined(USE_NRF24_VIA_SPI)
-    options.push_back({"NRF24 Jammer", [=]() { ble_jammer(); }});
 #endif
     options.push_back({"Main Menu", [=]()     { backToMenu(); }});
 

--- a/src/modules/NRF24/nrf_common.cpp
+++ b/src/modules/NRF24/nrf_common.cpp
@@ -1,0 +1,33 @@
+#include "nrf_common.h"
+#if defined(USE_NRF24_VIA_SPI)	
+RF24 NRFradio(NRF24_CE_PIN, NRF24_SS_PIN);
+#endif
+bool nrf_start() {
+#if defined(USE_NRF24_VIA_SPI)	
+  #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
+    CC_NRF_SPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
+  #elif defined(CARDPUTER) || defined(ESP32S3DEVKITC1)
+    sdcardSPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
+  #else 
+    SPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
+  #endif
+
+  #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
+    if(NRFradio.begin(&CC_NRF_SPI))
+  #elif defined(CARDPUTER) || defined(ESP32S3DEVKITC1)
+    if(NRFradio.begin(&sdcardSPI))
+  #else 
+    if(NRFradio.begin(&SPI))
+  #endif
+  {
+    return true;
+  } 
+  else 
+  return false;
+
+
+
+#else // NRF24 not set in platfrmio.ini
+  return false;
+#endif
+}

--- a/src/modules/NRF24/nrf_common.cpp
+++ b/src/modules/NRF24/nrf_common.cpp
@@ -1,7 +1,7 @@
 #include "nrf_common.h"
-#if defined(USE_NRF24_VIA_SPI)	
+
 RF24 NRFradio(NRF24_CE_PIN, NRF24_SS_PIN);
-#endif
+
 bool nrf_start() {
 #if defined(USE_NRF24_VIA_SPI)	
   #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)

--- a/src/modules/NRF24/nrf_common.cpp
+++ b/src/modules/NRF24/nrf_common.cpp
@@ -1,9 +1,31 @@
 #include "nrf_common.h"
+#include "../../core/mykeyboard.h"
 
 RF24 NRFradio(NRF24_CE_PIN, NRF24_SS_PIN);
 
+void nrf_info() {
+  tft.fillScreen(BGCOLOR);
+  tft.setTextSize(FM);
+  tft.setTextColor(TFT_RED, BGCOLOR);
+  tft.drawCentreString("_Disclaimer_",WIDTH/2,10,1);
+  tft.setTextColor(TFT_WHITE, BGCOLOR);
+  tft.setTextSize(FP);
+  tft.setCursor(15,33);
+  tft.println("These functions were made to be used in a controlled environment for STUDY only.");
+  tft.println("\nDO NOT use these functions to harm people or companies, you can go to jail!");
+  tft.setTextColor(FGCOLOR, BGCOLOR);
+  tft.println("\nThis device is VERY sensible to noise, so long wires or passing near VCC line can make things go wrong.");
+  delay(1000);
+  while(!checkAnyKeyPress());
+}
+
 bool nrf_start() {
 #if defined(USE_NRF24_VIA_SPI)	
+  pinMode(NRF24_SS_PIN, OUTPUT);
+  digitalWrite(NRF24_SS_PIN, HIGH);
+  pinMode(NRF24_CE_PIN, OUTPUT);
+  digitalWrite(NRF24_CE_PIN, LOW);
+  
   #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
     CC_NRF_SPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
   #elif defined(CARDPUTER) || defined(ESP32S3DEVKITC1)

--- a/src/modules/NRF24/nrf_common.h
+++ b/src/modules/NRF24/nrf_common.h
@@ -12,3 +12,5 @@
 extern RF24 NRFradio;
 
 bool nrf_start();
+
+void nrf_info();

--- a/src/modules/NRF24/nrf_common.h
+++ b/src/modules/NRF24/nrf_common.h
@@ -1,0 +1,6 @@
+#include <RF24.h>
+#include "../../core/globals.h"
+
+extern RF24 NRFradio;
+
+bool nrf_start();

--- a/src/modules/NRF24/nrf_common.h
+++ b/src/modules/NRF24/nrf_common.h
@@ -1,6 +1,14 @@
 #include <RF24.h>
 #include "../../core/globals.h"
 
+//Define the Macros case it hasn't been declared
+#ifndef NRF24_CE_PIN
+  #define NRF24_CE_PIN -1
+#endif
+#ifndef NRF24_SS_PIN
+  #define NRF24_SS_PIN -1
+#endif
+
 extern RF24 NRFradio;
 
 bool nrf_start();

--- a/src/modules/NRF24/nrf_jammer.cpp
+++ b/src/modules/NRF24/nrf_jammer.cpp
@@ -1,41 +1,27 @@
-#include "ble_jammer.h"
+#include "nrf_common.h"
+#include "nrf_jammer.h"
 #include "core/globals.h"
 #include "core/mykeyboard.h"
 #include "core/display.h"
 
-
 /* **************************************************************************************
-** name : ble_jammer
+** name : nrf_jammer
 ** details : Starts 2.4Gz jammer usinf NRF24
 ************************************************************************************** */
-void ble_jammer() {
-  #if defined(USE_NRF24_VIA_SPI)
-  #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
-    CC_NRF_SPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
-  #elif defined(CARDPUTER) || defined(ESP32S3DEVKITC1)
-    sdcardSPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
-  #else 
-    SPI.begin(NRF24_SCK_PIN,NRF24_MISO_PIN,NRF24_MOSI_PIN,NRF24_SS_PIN);
-  #endif
-    
+void nrf_jammer() {
+  #if defined(NRF24_CE_PIN) && defined(NRF24_SS_PIN) && defined(USE_NRF24_VIA_SPI)
     RF24 radio(NRF24_CE_PIN, NRF24_SS_PIN);                                                               ///ce-csn
     byte hopping_channel[] = {32,34, 46,48, 50, 52, 0, 1, 2, 4, 6, 8, 22, 24, 26, 28, 30, 74, 76, 78, 80, 82, 84,86 };  // channel to hop
     byte ptr_hop = 0;  // Pointer to the hopping array
-  #if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
-    if(radio.begin(&CC_NRF_SPI))
-  #elif defined(CARDPUTER) || defined(ESP32S3DEVKITC1)
-    if(radio.begin(&sdcardSPI))
-  #else 
-    if(radio.begin(&SPI))
-  #endif
+    if(nrf_start())
     {
         Serial.println("NRF24 turned On");
         
-        radio.setPALevel(RF24_PA_MAX);
-        radio.startConstCarrier(RF24_PA_MAX, 45);
-        radio.setAddressWidth(3);//optional
-        radio.setPayloadSize(2);//optional
-        if(!radio.setDataRate(RF24_2MBPS)) Serial.println("Fail setting data Rate");
+        NRFradio.setPALevel(RF24_PA_MAX);
+        NRFradio.startConstCarrier(RF24_PA_MAX, 45);
+        NRFradio.setAddressWidth(3);//optional
+        NRFradio.setPayloadSize(2);//optional
+        if(!NRFradio.setDataRate(RF24_2MBPS)) Serial.println("Fail setting data Rate");
 
         drawMainBorder();
         tft.setCursor(10,28);
@@ -48,14 +34,13 @@ void ble_jammer() {
         while(!checkSelPress()) {
             ptr_hop++;                                            /// perform next channel change
             if (ptr_hop >= sizeof(hopping_channel)) ptr_hop = 0;  // To avoid array indexing overflow
-            radio.setChannel(hopping_channel[ptr_hop]);           // Change channel        
+            NRFradio.setChannel(hopping_channel[ptr_hop]);           // Change channel        
         }
-        radio.powerDown();
+        NRFradio.powerDown();
     } else { 
         Serial.println("Fail Starting radio");
         displayError("NRF24 not found");
         delay(500);
-        while(!checkAnyKeyPress()); // wait confirmation
     }
   #endif
 }

--- a/src/modules/NRF24/nrf_jammer.h
+++ b/src/modules/NRF24/nrf_jammer.h
@@ -20,4 +20,4 @@ FLAFS:
 */
 
 
-void ble_jammer();
+void nrf_jammer();

--- a/src/modules/NRF24/nrf_spectrum.cpp
+++ b/src/modules/NRF24/nrf_spectrum.cpp
@@ -1,0 +1,147 @@
+#include "nrf_common.h"
+#include "nrf_spectrum.h"
+#include "../../core/display.h"
+#include "../../core/mykeyboard.h"
+
+const uint8_t cacheMax = 4;
+const uint8_t numChannels = 126; // 0-125 are supported
+const uint16_t margin = 1;  // use 1 pixel margin for markers on each side of chart
+const uint16_t barWidth = (WIDTH - (margin * 2)) / numChannels;
+const uint16_t chartHeight = HEIGHT - 10;
+const uint16_t chartWidth = margin * 2 + (numChannels * barWidth);  
+
+struct ChannelHistory {
+  /// max peak value is (at most) 2 * CACHE_MAX to allow for half-step decays
+  uint8_t maxPeak = 0;
+
+  /// Push a signal's value into cached history while popping
+  /// oldest cached value. This also sets the maxPeak value.
+  /// @returns The sum of signals found in the cached history
+  uint8_t push(bool value) {
+    uint8_t sum = value;
+    for (uint8_t i = 0; i < cacheMax - 1; ++i) {
+      history[i] = history[i + 1];
+      sum += history[i];
+    }
+    history[cacheMax - 1] = value;
+    maxPeak = std::max(sum * 2, static_cast<int>(maxPeak));  // sum * 2 to allow half-step decay
+    return sum;
+  }
+
+private:
+  bool history[cacheMax] = { 0 };
+};
+/// Draw the chart axis and labels
+void displayChartAxis() {
+// constant chart size attributes
+  
+  // draw base line
+  tft.drawLine(0, chartHeight + 1, chartWidth - margin, chartHeight + 1, FGCOLOR);
+
+  // draw base line border
+  tft.drawLine(margin, HEIGHT, margin, chartHeight - 2, FGCOLOR);
+  tft.drawLine(chartWidth - margin, HEIGHT, chartWidth - margin, chartHeight - 2, FGCOLOR);
+
+  // draw scalar marks
+  for (uint8_t i = 0; i < cacheMax; ++i) {
+    uint8_t scalarHeight = chartHeight * i / cacheMax;
+    tft.drawLine(0, scalarHeight, chartWidth, scalarHeight, FGCOLOR);
+  }
+
+  // draw channel range labels
+  tft.setTextSize(1);
+  tft.setTextColor(FGCOLOR);
+  uint8_t maxChannelDigits = 0;
+  uint8_t tmp = numChannels;
+  while (tmp) {
+    maxChannelDigits += 1;
+    tmp /= 10;
+  }
+  tft.setCursor(chartWidth - (7 * maxChannelDigits), chartHeight + 3);
+  tft.print(numChannels - 1);
+  tft.setCursor(margin + 2, chartHeight + 3);
+  tft.print(0);
+
+
+}
+
+
+/// Scan a specified channel and return the resulting flag
+bool scanChannel(uint8_t channel) {
+  NRFradio.setChannel(channel);
+
+  // Listen for a little
+  NRFradio.startListening();
+  delayMicroseconds(130);
+  bool foundSignal = NRFradio.testRPD();
+  NRFradio.stopListening();
+
+  // Did we get a signal?
+  if (foundSignal || NRFradio.testRPD() || NRFradio.available()) {
+    NRFradio.flush_rx();  // discard packets of noise
+    return true;
+  }
+  return false;
+}
+
+
+void nrf_spectrum() {
+#if defined(HAS_SCREEN)
+    if(nrf_start()) {
+        const uint8_t noiseAddress[][2] = { { 0x55, 0x55 }, { 0xAA, 0xAA }, { 0xA0, 0xAA }, { 0xAB, 0xAA }, { 0xAC, 0xAA }, { 0xAD, 0xAA } };
+        NRFradio.setAutoAck(false);   // Don't acknowledge arbitrary signals
+        NRFradio.disableCRC();        // accept any signal we find
+        NRFradio.setAddressWidth(2);  // a reverse engineering tactic (not typically recommended)
+        for (uint8_t i = 0; i < 6; ++i) {
+            NRFradio.openReadingPipe(i, noiseAddress[i]);
+        }
+    char dataRate = '1'; // use 2 or 3 for debug
+    if (dataRate == '2') {
+        Serial.println(F("Using 2 Mbps."));
+        NRFradio.setDataRate(RF24_2MBPS);
+    } else if (dataRate == '3') {
+        Serial.println(F("Using 250 kbps."));
+        NRFradio.setDataRate(RF24_250KBPS);
+    } else {  // dataRate == '1' or invalid values
+        Serial.println(F("Using 1 Mbps."));
+        NRFradio.setDataRate(RF24_1MBPS);
+    }
+
+    // Get into standby mode
+    NRFradio.startListening();
+    NRFradio.stopListening();
+    NRFradio.flush_rx();
+    ChannelHistory stored[numChannels]; // need to put it into RAM???? 
+    while(checkSelPress()); // debounce
+
+    while(!checkSelPress()) {
+                // Print out channel measurements, clamped to a single hex digit
+        for (uint8_t channel = 0; channel < numChannels; ++channel) {
+            bool foundSignal = scanChannel(channel);
+            uint8_t cacheSum = stored[channel].push(foundSignal);
+            uint8_t x = (barWidth * channel) + 1 + margin - (barWidth * (bool)channel);
+            // reset bar for current channel to 0
+            tft.fillRect(x, 0, barWidth, chartHeight, BGCOLOR);
+            if (stored[channel].maxPeak > cacheSum * 2) {
+            // draw a peak line only if it is greater than current sum of cached signal counts
+            uint16_t y = chartHeight - (chartHeight * stored[channel].maxPeak / (cacheMax * 2));
+            tft.drawLine(x, y, x + barWidth, y, FGCOLOR);
+        #ifndef HOLD_PEAKS
+            stored[channel].maxPeak -= 1;  // decrement max peak
+        #endif
+            }
+            if (cacheSum) {  // draw the cached signal count
+            uint8_t barHeight = chartHeight * cacheSum / cacheMax;
+            tft.fillRect(x, chartHeight - barHeight, barWidth, barHeight, FGCOLOR);
+            }
+        }
+    }
+
+    }
+    else {
+        Serial.println("Fail Starting radio");
+        displayError("NRF24 not found");
+        delay(500);
+    }
+#endif
+}

--- a/src/modules/NRF24/nrf_spectrum.cpp
+++ b/src/modules/NRF24/nrf_spectrum.cpp
@@ -85,7 +85,7 @@ bool scanChannel(uint8_t channel) {
 }
 
 
-void nrf_spectrum() {
+void nrf_spectrum2() {
 #if defined(HAS_SCREEN)
     if(nrf_start()) {
         const uint8_t noiseAddress[][2] = { { 0x55, 0x55 }, { 0xAA, 0xAA }, { 0xA0, 0xAA }, { 0xAB, 0xAA }, { 0xAC, 0xAA }, { 0xAD, 0xAA } };
@@ -138,6 +138,51 @@ void nrf_spectrum() {
     }
 
     }
+    else {
+        Serial.println("Fail Starting radio");
+        displayError("NRF24 not found");
+        delay(500);
+    }
+#endif
+}
+
+
+void nrf_spectrum() {
+#if defined(HAS_SCREEN)
+    if(nrf_start()) {
+      NRFradio.setAutoAck(false);
+      tft.fillScreen(BGCOLOR);
+      uint8_t bw = WIDTH/120;
+
+      delay(300);
+      uint8_t values[120];
+      tft.setTextSize(FP);
+      while(!checkEscPress()){
+        memset(values,0,120);
+        int i=120;
+        int n=50;
+        while(n--) {
+          i=120;
+          while(i--) {
+            NRFradio.setChannel(i);
+            NRFradio.startListening();
+            delayMicroseconds(128);
+            NRFradio.stopListening();
+            if(NRFradio.testCarrier()) ++values[i];
+          }
+        }
+        i=120;
+        while(i--){
+          tft.fillRect(i*2-bw,0,bw,HEIGHT-10,BGCOLOR);
+          tft.drawWideLine(i*2-bw,HEIGHT-10,i*2-bw,HEIGHT-(10+values[i]*10),bw,FGCOLOR,BGCOLOR);
+        }
+        tft.drawString("ch 0",0,HEIGHT-LH);
+        tft.drawCentreString("60", WIDTH/2,HEIGHT-LH,1);
+        tft.drawRightString("120",WIDTH,HEIGHT-LH,1);
+
+      }
+
+      }
     else {
         Serial.println("Fail Starting radio");
         displayError("NRF24 not found");

--- a/src/modules/NRF24/nrf_spectrum.h
+++ b/src/modules/NRF24/nrf_spectrum.h
@@ -1,3 +1,6 @@
+#pragma once
 #include <RF24.h>
 
-void nrf_spectrum();
+void nrf_spectrum(SPIClass* SSPI);
+
+String scanChannels(SPIClass* SSPI, bool web=false);

--- a/src/modules/NRF24/nrf_spectrum.h
+++ b/src/modules/NRF24/nrf_spectrum.h
@@ -1,0 +1,3 @@
+#include <RF24.h>
+
+void nrf_spectrum();


### PR DESCRIPTION
#### Proposed Changes ####

Separeted Menu for NRF24 module, adding a new 2,4Ghz Spectrum to watch frequency usage from 2.40 until 2.48Ghz (Covers all Wifi Channels)

#### Types of Changes ####

New features.

Excluded NRF24 Jammer from BLE and Wifi, to concentrate on NRF24 menu.


