### PR TITLE
RF Scan/Copy fix

### DIFF
--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -1343,7 +1343,6 @@ RestartScan:
 		}
 	
 		if (checkNextPress()) {
-	:
 			int option = 0;
 	
 			if (RfModule == 1) {

--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -1343,6 +1343,7 @@ RestartScan:
 		}
 	
 		if (checkNextPress()) {
+Menu:
 			int option = 0;
 	
 			if (RfModule == 1) {


### PR DESCRIPTION
After replaying the signal, the scan wasn't working anymore, only after entering back into the RF Copy/Scan menu, and when no cc1101 is detected and the user is pressing the next button, it opens the signal options directly insteand of showing it in loop option and displaying a warning, also added a freq counter