### PR TITLE
Missing if in case of ISO_REPLACEMENT in BLE release method

### DIFF
--- a/lib/Bad_Usb_Lib/BleKeyboard.cpp
+++ b/lib/Bad_Usb_Lib/BleKeyboard.cpp
@@ -312,6 +312,8 @@ size_t BleKeyboard::release(uint8_t k)
 			_keyReport.modifiers &= ~(0x02);	// the left shift modifier
 			k &= 0x7F;
 		}
+		if (k == 0x32) //ISO_REPLACEMENT
+			k = 0x64; //ISO_KEY
 	}
 
 	// Test the key report to see if k is present.  Clear it if it exists.


### PR DESCRIPTION
After testing the bad ble I found that some chars weren't being inserted correctly.
This is just a small fix that I think will fix the issue.

Some examples of incorrect input I've found can be seen in this issue I opened previously https://github.com/pr3y/Bruce/issues/317
