### PR TITLE
fix badusb sub command from webui

### DIFF
--- a/src/modules/others/webInterface.h
+++ b/src/modules/others/webInterface.h
@@ -470,7 +470,7 @@ function runBadusbFile(filePath) {
   var fs = document.getElementById("actualFS").value;
   const ajax5 = new XMLHttpRequest();
   const formdata5 = new FormData();
-  formdata5.append("cmnd", "badusb tx_from_file " + filePath);
+  formdata5.append("cmnd", "badusb run_from_file " + filePath);
   ajax5.open("POST", "/cm", false);
   ajax5.send(formdata5);
   document.getElementById("status").innerHTML = ajax5.responseText;


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Currently, the badusb command from webui is not working. It seems tx_from_file is not supported.
So I changed it to run_from_file as supported sub command.

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

We can confirm that the badusb command from webui is success or not

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

fix #335 

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

