### PR TITLE
customize wifi ap ssid and pwd

### DIFF
--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -100,6 +100,10 @@ extern  String ssid;
 
 extern  String pwd;
 
+extern  String ap_ssid;
+
+extern  String ap_pwd;
+
 extern String fileToCopy;
 
 extern int rotation;

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -18,7 +18,7 @@ void WifiMenu::optionsMenu() {
     if(!wifiConnected) {
         options = {
         {"Connect Wifi", [=]()  { wifiConnectMenu(); }},    //wifi_common.h
-        {"WiFi AP",      [=]()  { wifiConnectMenu(true); displayInfo("pwd: brucenet", true); }},//wifi_common.h
+        {"WiFi AP",      [=]()  { wifiConnectMenu(true); displayInfo("pwd: " + ap_pwd, true); }},//wifi_common.h
         };
     } else {
         options = {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -669,7 +669,7 @@ void getConfigs() {
     if(file) {
       // init with default settings
     #if ROTATION > 1
-      file.print("[{\"rot\":3,\"dimmerSet\":10,\"bright\":100,\"wui_usr\":\"admin\",\"wui_pwd\":\"bruce\",\"Bruce_FGCOLOR\":43023,\"IrTx\":" + String(LED) + ",\"IrRx\":" + String(GROVE_SCL) + ",\"RfTx\":" + String(GROVE_SDA) + ",\"RfRx\":" + String(GROVE_SCL) + ",\"tmz\":3,\"RfModule\":0,\"RfFreq\":433.92,\"RfFxdFreq\":1,\"RfScanRange\":3,\"RfidModule\":" + String(RfidModule) + ",\"wifi\":[{\"ssid\":\"myNetSSID\",\"pwd\":\"myNetPassword\"}],\"wigleBasicToken\":\"\",\"devMode\":0,\"soundEnabled\":1}]");
+      file.print("[{\"rot\":3,\"dimmerSet\":10,\"bright\":100,\"wui_usr\":\"admin\",\"wui_pwd\":\"bruce\",\"Bruce_FGCOLOR\":43023,\"IrTx\":" + String(LED) + ",\"IrRx\":" + String(GROVE_SCL) + ",\"RfTx\":" + String(GROVE_SDA) + ",\"RfRx\":" + String(GROVE_SCL) + ",\"tmz\":3,\"RfModule\":0,\"RfFreq\":433.92,\"RfFxdFreq\":1,\"RfScanRange\":3,\"RfidModule\":" + String(RfidModule) + ",\"wifi\":[{\"ssid\":\"myNetSSID\",\"pwd\":\"myNetPassword\"}],\"wifi_ap\":{\"ssid\":\"BruceNet\",\"pwd\":\"brucenet\"},\"wigleBasicToken\":\"\",\"devMode\":0,\"soundEnabled\":1}]");
       #else
       file.print("[{\"rot\":1,\"dimmerSet\":10,\"bright\":100,\"wui_usr\":\"admin\",\"wui_pwd\":\"bruce\",\"Bruce_FGCOLOR\":43023,\"IrTx\":" + String(LED) + ",\"IrRx\":" + String(GROVE_SCL) + ",\"RfTx\":" + String(GROVE_SDA) + ",\"RfRx\":" + String(GROVE_SCL) + ",\"tmz\":3,\"RfModule\":0,\"RfFreq\":433.92,\"RfFxdFreq\":1,\"RfScanRange\":3,\"RfidModule\":" + String(RfidModule) + ",\"wifi\":[{\"ssid\":\"myNetSSID\",\"pwd\":\"myNetPassword\"}],\"wigleBasicToken\":\"\",\"devMode\":0,\"soundEnabled\":1}]");
     #endif
@@ -710,6 +710,14 @@ void getConfigs() {
     if(setting.containsKey("RfidModule"))  { RfidModule  = setting["RfidModule"].as<int>(); } else { count++; log_i("Fail"); }
 
     if(!setting.containsKey("wifi"))  { count++; log_i("Fail"); }
+
+    if(setting.containsKey("wifi_ap")) {
+      JsonObject wifiAp = setting["wifi_ap"].as<JsonObject>();
+      if (wifiAp.containsKey("ssid")) { ap_ssid = wifiAp["ssid"].as<String>(); } else { count++; log_i("Fail"); }
+      if (wifiAp.containsKey("pwd"))  { ap_pwd  = wifiAp["pwd"].as<String>(); } else { count++; log_i("Fail"); }
+    } else {
+      count++; log_i("Fail");
+    }
 
     if(setting.containsKey("wigleBasicToken"))  { wigleBasicToken  = setting["wigleBasicToken"].as<String>(); } else { count++; log_i("Fail"); }
 
@@ -769,6 +777,11 @@ void saveConfigs() {
       WifiObj["ssid"] = "myNetSSID";
       WifiObj["pwd"] = "myNetPassword";
     }
+  }
+  if(!setting.containsKey("wifi_ap")) {
+    JsonObject WifiAp = setting["wifi_ap"].to<JsonObject>();
+    WifiAp["ssid"] = ap_ssid;
+    WifiAp["pwd"] = ap_pwd;
   }
   setting["wigleBasicToken"] = wigleBasicToken;
   setting["devMode"] = devMode;

--- a/src/core/wifi_common.cpp
+++ b/src/core/wifi_common.cpp
@@ -127,7 +127,8 @@ bool wifiConnect(String ssid, int encryptation, bool isAP) {
     IPAddress AP_GATEWAY(172, 0, 0, 1);
     WiFi.mode(WIFI_AP);
     WiFi.softAPConfig(AP_GATEWAY, AP_GATEWAY, IPAddress(255, 255, 255, 0));
-    WiFi.softAP("BruceNet", "brucenet", 6,0,4,false);  // TODO: customize options via bruce.conf
+    getConfigs();
+    WiFi.softAP(ap_ssid, ap_pwd, 6,0,4,false);
     wifiIP = WiFi.softAPIP().toString(); // update global var
     Serial.print("IP: "); Serial.println(wifiIP);
     wifiConnected=true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,8 @@ String wui_usr="admin";
 String wui_pwd="bruce";
 String ssid;
 String pwd;
+String ap_ssid="BruceNet";
+String ap_pwd="brucenet";
 std::vector<Option> options;
 const int bufSize = 1024;
 uint8_t buff[1024] = {0};


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Allow Wifi AP's ssid and pwd to be set in burce.conf.

```
    "wifi_ap": {
      "ssid": "My Fifi",
      "pwd": "mypwd"
    }
```

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

customize settings

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1. set wifi_ap settings in bruce.conf.

```
    "wifi_ap": {
      "ssid": "My Fifi",
      "pwd": "mypwd"
    }
```

2. enable Wifi AP mode.

3. check if we can connect with the configured SSID and PWD

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

fix #339 

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
user can customize wifi ap ssid and pwd
```

#### Further Comments ####

