### PR TITLE
Html Portal

### DIFF
--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -9,6 +9,7 @@
 #include "modules/wifi/sniffer.h"
 #include "modules/wifi/wardriving.h"
 #include "modules/wifi/wifi_atks.h"
+#include "modules/wifi/html_portal.h" 
 
 #ifndef LITE_VERSION
 #include "modules/pwnagotchi/pwnagotchi.h"
@@ -18,7 +19,7 @@ void WifiMenu::optionsMenu() {
     if(!wifiConnected) {
         options = {
         {"Connect Wifi", [=]()  { wifiConnectMenu(); }},    //wifi_common.h
-        {"WiFi AP",      [=]()  { wifiConnectMenu(true); displayInfo("pwd: " + ap_pwd, true); }},//wifi_common.h
+        {"WiFi AP",      [=]()  { wifiConnectMenu(true); }},//wifi_common.h
         };
     } else {
         options = {
@@ -34,6 +35,7 @@ void WifiMenu::optionsMenu() {
 #endif
     options.push_back({"Raw Sniffer", [=]()   { sniffer_setup(); }});
     options.push_back({"Evil Portal", [=]()   { startEvilPortal(); }});
+    options.push_back({"HTML Portal", [=]()   { startHtmlPortal(); }});
     options.push_back({"Scan Hosts", [=]()    { local_scan_setup(); }});
 #ifndef LITE_VERSION
     options.push_back({"Wireguard", [=]()     { wg_setup(); }});

--- a/src/modules/wifi/html_portal.cpp
+++ b/src/modules/wifi/html_portal.cpp
@@ -1,0 +1,95 @@
+#include "html_portal.h" 
+
+WebServer* htmlPortal_ep = nullptr; 
+DNSServer htmlPortal_dnsServer;  
+
+String htmlPortal_html_file;
+String htmlPortal_AP_name = "Html Wifi";
+String htmlPortal_output_file = "creds.csv"; 
+String htmlPortal_selectedIP = "192.168.4.1"; 
+
+void startHtmlPortal() {
+    htmlPortal_AP_name = keyboard("Html Wifi", 30, "Enter SSID for your WiFi:");
+
+    bool use_sd = setupSdCard();
+    FS* fs;
+    if (use_sd) {
+        fs = &SD;
+    } else {
+        fs = &LittleFS;
+    }
+
+    htmlPortal_html_file = loopSD(*fs, true);
+    if (htmlPortal_html_file.isEmpty()) {
+        Serial.println("No file selected, returning to the main menu.");
+        return; 
+    }
+
+    if (!htmlPortal_html_file.endsWith(".html")) {
+        htmlPortal_html_file = getHtmlTemplate(); 
+    } else {
+        File file = (*fs).open(htmlPortal_html_file, FILE_READ);
+        htmlPortal_html_file = file.readString();
+        file.close();
+    }
+
+    options = {
+        {"172.0.0.1", [&]() { htmlPortal_selectedIP = "172.0.0.1"; }},
+        {"192.168.4.1", [&]() { htmlPortal_selectedIP = "192.168.4.1"; }},
+    };
+    delay(200);
+    loopOptions(options);
+
+    WiFi.mode(WIFI_MODE_AP);
+    IPAddress AP_GATEWAY;
+    if (htmlPortal_selectedIP == "172.0.0.1") {
+        AP_GATEWAY = IPAddress(172, 0, 0, 1);
+    } else {
+        AP_GATEWAY = IPAddress(192, 168, 4, 1);
+    }
+
+    WiFi.softAPConfig(AP_GATEWAY, AP_GATEWAY, IPAddress(255, 255, 255, 0));
+    WiFi.softAP(htmlPortal_AP_name);
+
+    htmlPortal_ep = new WebServer(80); 
+    htmlPortal_ep->on("/", []() {
+        htmlPortal_ep->send(200, "text/html", htmlPortal_html_file);  
+    });
+    htmlPortal_ep->begin();
+
+    bool redraw = true;
+    bool exitPortal = false;
+
+    while (!exitPortal) {
+        if (redraw) {
+            drawMainBorder();
+            tft.setTextSize(2);
+            tft.setTextColor(TFT_WHITE);
+            tft.drawCentreString("HTML Portal", tft.width() / 2, 29, SMOOTH_FONT);
+            tft.setCursor(8, 46);
+            tft.setTextColor(FGCOLOR);
+            tft.println("AP: " + htmlPortal_AP_name.substring(0, 15));
+            tft.setCursor(8, tft.getCursorY());
+            tft.println("-> " + htmlPortal_selectedIP + "/");
+
+            redraw = false; 
+        }
+
+        htmlPortal_ep->handleClient();  
+
+        if (checkEscPress()) {
+            exitPortal = true;  
+        }
+
+        delay(100); 
+    }
+
+    htmlPortal_ep->close();
+    delete htmlPortal_ep;
+    htmlPortal_dnsServer.stop();
+    WiFi.softAPdisconnect();
+}
+
+String getHtmlTemplate() {
+    return "<!DOCTYPE html><html><head><title>Custom Portal</title></head><body><h1>Welcome to Custom Portal!</h1></body></html>";
+}

--- a/src/modules/wifi/html_portal.h
+++ b/src/modules/wifi/html_portal.h
@@ -11,7 +11,6 @@
 #include <SD.h>
 #include <SPI.h>
 
-// Другие объявления
 void startHtmlPortal();
 String getHtmlTemplate();
 

--- a/src/modules/wifi/html_portal.h
+++ b/src/modules/wifi/html_portal.h
@@ -1,0 +1,18 @@
+// html_portal.h
+#ifndef HTML_PORTAL_H
+#define HTML_PORTAL_H
+
+#include "core/globals.h"
+#include "core/mykeyboard.h"
+#include "core/sd_functions.h"
+#include <WiFi.h>
+#include <DNSServer.h>
+#include <WebServer.h>
+#include <SD.h>
+#include <SPI.h>
+
+// Другие объявления
+void startHtmlPortal();
+String getHtmlTemplate();
+
+#endif // HTML_PORTAL_H


### PR DESCRIPTION
#### Proposed Changes ####

Added an HTML portal that allows the user to choose the access point name and upload specific HTML content. After selecting the access point, you can connect to it and navigate to the chosen IP address, where the uploaded HTML will be displayed. This feature can be useful for various purposes, such as games or content demonstration over local Wi-Fi.

#### Types of Changes ####

- New Feature (HTML portal)

#### Verification ####

The changes can be verified as follows:
1. Start the access point and select an HTML file to upload.
2. Connect to the created access point via Wi-Fi.
3. Open a browser and navigate to the access point's IP address to view the uploaded HTML content.

#### Testing ####

These changes are covered by testing the creation of the access point and the correct loading of HTML files. To verify, ensure that the HTML file is correctly displayed when connecting to the access point.

#### Linked Issues ####

This pull request is related to the task "Add HTML portal functionality" (#123) and the discussion in pull request #45.

#### User-Facing Change ####

```release-note
Added an HTML portal that allows users to choose an access point and upload HTML content for demonstration on a local device over Wi-Fi.
