### PR TITLE
fix ntp sync for stick c plus

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -433,7 +433,14 @@ void setClock() {
                 timeClient.begin();
                 timeClient.update();
                 localTime = myTZ.toLocal(timeClient.getEpochTime());
-                #if !defined(HAS_RTC)
+                
+                #if defined(HAS_RTC)
+                  struct tm *timeinfo = localtime(&localTime);
+                  TimeStruct.Hours   = timeinfo->tm_hour;
+                  TimeStruct.Minutes = timeinfo->tm_min;
+                  TimeStruct.Seconds = timeinfo->tm_sec;
+                  _rtc.SetTime(&TimeStruct);
+                #else
                   rtc.setTime(timeClient.getEpochTime());
                 #endif
 


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Currently, NTP synchronization doesn't work on stick c plus。（Probably all devices with RTC）

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Check if NTP synchronization works properly on stick c plus

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

fix #363

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

