### PR TITLE
Json wifi structure update; password is saved on succesfull connection only

### DIFF
--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -79,8 +79,6 @@ extern int prog_handler;    // 0 - Flash, 1 - LittleFS, 2 - Download
 extern bool sdcardMounted;  // inform if SD Cardis active or not
 
 extern bool wifiConnected;  // inform if wifi is active or not
-// TODO: instead of storing it here, retrieve it from the stored config
-extern String wifiPSK;      // esp doesn't allow retreive connected ap pwd
 
 extern String wifiIP;
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -676,9 +676,9 @@ void getConfigs() {
     if(file) {
       // init with default settings
     #if ROTATION > 1
-      file.print("[{\"rot\":3,\"dimmerSet\":10,\"bright\":100,\"wui_usr\":\"admin\",\"wui_pwd\":\"bruce\",\"Bruce_FGCOLOR\":43023,\"IrTx\":" + String(LED) + ",\"IrRx\":" + String(GROVE_SCL) + ",\"RfTx\":" + String(GROVE_SDA) + ",\"RfRx\":" + String(GROVE_SCL) + ",\"tmz\":3,\"RfModule\":0,\"RfFreq\":433.92,\"RfFxdFreq\":1,\"RfScanRange\":3,\"RfidModule\":" + String(RfidModule) + ",\"wifi\":[{\"ssid\":\"myNetSSID\",\"pwd\":\"myNetPassword\"}],\"wifi_ap\":{\"ssid\":\"BruceNet\",\"pwd\":\"brucenet\"},\"wigleBasicToken\":\"\",\"devMode\":0,\"soundEnabled\":1}]");
+      file.print("[{\"rot\":3,\"dimmerSet\":10,\"bright\":100,\"wui_usr\":\"admin\",\"wui_pwd\":\"bruce\",\"Bruce_FGCOLOR\":43023,\"IrTx\":" + String(LED) + ",\"IrRx\":" + String(GROVE_SCL) + ",\"RfTx\":" + String(GROVE_SDA) + ",\"RfRx\":" + String(GROVE_SCL) + ",\"tmz\":3,\"RfModule\":0,\"RfFreq\":433.92,\"RfFxdFreq\":1,\"RfScanRange\":3,\"RfidModule\":" + String(RfidModule) + ",\"wifi\":{},\"wifi_ap\":{\"ssid\":\"BruceNet\",\"pwd\":\"brucenet\"},\"wigleBasicToken\":\"\",\"devMode\":0,\"soundEnabled\":1}]");
       #else
-      file.print("[{\"rot\":1,\"dimmerSet\":10,\"bright\":100,\"wui_usr\":\"admin\",\"wui_pwd\":\"bruce\",\"Bruce_FGCOLOR\":43023,\"IrTx\":" + String(LED) + ",\"IrRx\":" + String(GROVE_SCL) + ",\"RfTx\":" + String(GROVE_SDA) + ",\"RfRx\":" + String(GROVE_SCL) + ",\"tmz\":3,\"RfModule\":0,\"RfFreq\":433.92,\"RfFxdFreq\":1,\"RfScanRange\":3,\"RfidModule\":" + String(RfidModule) + ",\"wifi\":[{\"ssid\":\"myNetSSID\",\"pwd\":\"myNetPassword\"}],\"wigleBasicToken\":\"\",\"devMode\":0,\"soundEnabled\":1}]");
+      file.print("[{\"rot\":1,\"dimmerSet\":10,\"bright\":100,\"wui_usr\":\"admin\",\"wui_pwd\":\"bruce\",\"Bruce_FGCOLOR\":43023,\"IrTx\":" + String(LED) + ",\"IrRx\":" + String(GROVE_SCL) + ",\"RfTx\":" + String(GROVE_SDA) + ",\"RfRx\":" + String(GROVE_SCL) + ",\"tmz\":3,\"RfModule\":0,\"RfFreq\":433.92,\"RfFxdFreq\":1,\"RfScanRange\":3,\"RfidModule\":" + String(RfidModule) + ",\"wifi\":{},\"wigleBasicToken\":\"\",\"devMode\":0,\"soundEnabled\":1}]");
     #endif
     }
     file.close();
@@ -778,12 +778,7 @@ void saveConfigs() {
   setting["RfidModule"] = RfidModule;
   setting["tmz"] = tmz;
   if(!setting.containsKey("wifi")) {
-    JsonArray WifiList = setting["wifi"].to<JsonArray>();
-    if(WifiList.size()<1) {
-      JsonObject WifiObj = WifiList.add<JsonObject>();
-      WifiObj["ssid"] = "myNetSSID";
-      WifiObj["pwd"] = "myNetPassword";
-    }
+    setting["wifi"] = JsonObject();
   }
   if(!setting.containsKey("wifi_ap")) {
     JsonObject WifiAp = setting["wifi_ap"].to<JsonObject>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,9 +37,14 @@ int soundEnabled=1;
 bool interpreter_start = false;
 bool sdcardMounted = false;
 bool gpsConnected = false;
+
+// wifi globals
+// TODO put in a namespace
 bool wifiConnected = false;
 String wifiIP;
-String wifiPSK;
+String ssid;
+String pwd;
+
 bool BLEConnected = false;
 bool returnToMenu;
 bool isSleeping = false;
@@ -59,8 +64,7 @@ JsonDocument settings;
 
 String wui_usr="admin";
 String wui_pwd="bruce";
-String ssid;
-String pwd;
+
 String ap_ssid="BruceNet";
 String ap_pwd="brucenet";
 std::vector<Option> options;

--- a/src/modules/wifi/ap_info.cpp
+++ b/src/modules/wifi/ap_info.cpp
@@ -131,7 +131,7 @@ void fillInfo(ScrollableTextArea& area){
     // in promiscius mode also Rx/Tx can be gathered
     // organized in the most to least usable
     area.addLine("SSID: " + String((char*)ap_info.ssid));
-    area.addLine("PSK: " + wifiPSK);
+    area.addLine("PSK: " + pwd);
     area.addLine("Internet: " + String(internetConnection() ? "avail" : "unavail"));
     area.addLine("Modes: " + phyModes2String(ap_info));
     area.addLine("Signal strength: " + String(ap_info.rssi) + "db");


### PR DESCRIPTION
 #### What ####
 - wifi json field changed from
    wifi:[{s1:p1},{s2:p2}]
   to
    wifi:{s1:p1,s2:p2}
- wifi password is now saved only upon successful connection

So refactoring + bug fixing + improvement

#### Why ####

O(1) instead of O(n) to find a wifi password
Code is cleaner
Bug fixed (:

#### Verification ####

Try to connect to a known wifi with the wrong password
Retry with the correct password
Disconnect from the wifi
Connect to it again. Check that the password type pop-up didn't appear and it used the stored password
(previously the password was saved on the first connection attempt rather than the successful one)

#### User-Facing Change ####

**Users should clean the Wi-Fi section of the config file (or just remake the config file) otherwise the passwords won't be saved**
```release-note
password is stored only upon successful connection
```

#### Further Comments ####

This one is a preparation for a wifi repeater functionality  