### PR TITLE
AP info now gathers public IP

### DIFF
--- a/src/core/net_utils.cpp
+++ b/src/core/net_utils.cpp
@@ -4,6 +4,20 @@
 #include <ESPping.h>
 #include <HTTPClient.h>
 
+String getPublicIP(){
+  if( !internetConnection() ) return "NO INTERNET";
+
+  HTTPClient http;
+  http.begin("https://ipinfo.io/ip");
+  int httpCode = http.GET();
+  if( httpCode != 200 ) return "GET FAILED " + String(httpCode);
+
+  const String ip = http.getString();
+  http.end();
+
+  return ip;
+}
+
 bool internetConnection(){
     return Ping.ping(IPAddress(8,8,8,8));
 }

--- a/src/core/net_utils.h
+++ b/src/core/net_utils.h
@@ -4,6 +4,8 @@
 
 bool internetConnection();
 
+String getPublicIP();
+
 String getManufacturer(const String& mac);
 
 String MAC(uint8_t* data);

--- a/src/modules/wifi/ap_info.cpp
+++ b/src/modules/wifi/ap_info.cpp
@@ -137,6 +137,7 @@ void fillInfo(ScrollableTextArea& area){
     area.addLine("Signal strength: " + String(ap_info.rssi) + "db");
     // AP might not have assigned IP and gateway ip might differ from an ap ip
     area.addLine("Gateway: " + WiFi.gatewayIP().toString());
+    area.addLine("Public IP: " + getPublicIP());
     area.addLine("Channel: " + String(ap_info.primary) + " " + getChannelWidth(ap_info.second));
     area.addLine("BSSID: " +  mac); // sometimes MAC != BSSID (but we ignore that case)
     area.addLine("Manufacturer: " +  getManufacturer(mac));


### PR DESCRIPTION
#### What

Adds getPublicIP() function that gets networks' public IP  

#### Pics
![image](https://github.com/user-attachments/assets/6dc7de29-b521-47d2-a9be-ed745597b849)


#### User-Facing Change ####
NONE
```release-note
AP info also displays network public IP
```

