### PR TITLE
Add PN532 BLE devices support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,6 +55,7 @@ lib_deps =
 	https://github.com/rennancockles/MFRC522-I2C
 	https://github.com/rennancockles/ESP-ChameleonUltra
 	https://github.com/rennancockles/ESP-Amiibolink
+	https://github.com/whywilson/ESP-PN532BLE
 	NTPClient
 	Timezone
 	ESP32Time

--- a/src/core/menu_items/RFIDMenu.cpp
+++ b/src/core/menu_items/RFIDMenu.cpp
@@ -5,6 +5,7 @@
 #include "modules/rfid/rfid125.h"
 #include "modules/rfid/chameleon.h"
 #include "modules/rfid/amiibo.h"
+#include "modules/rfid/pn532ble.h"
 
 void RFIDMenu::optionsMenu() {
     options = {
@@ -16,6 +17,7 @@ void RFIDMenu::optionsMenu() {
         {"Write NDEF",  [=]()  { TagOMatic(TagOMatic::WRITE_NDEF_MODE); }},
         {"Amiibolink",  [=]()  { Amiibo(); }},
         {"Chameleon",   [=]()  { Chameleon(); }},
+        {"PN532 BLE",   [=]()  { Pn532ble(); }},
         {"Config",      [=]()  { configMenu(); }},
         {"Main Menu",   [=]()  { backToMenu(); }},
     };

--- a/src/modules/rfid/pn532ble.cpp
+++ b/src/modules/rfid/pn532ble.cpp
@@ -1,0 +1,190 @@
+
+#include "pn532ble.h"
+#include "core/mykeyboard.h"
+#include "core/display.h"
+
+Pn532ble::Pn532ble()
+{
+    setup();
+}
+
+Pn532ble::~Pn532ble()
+{
+}
+
+void Pn532ble::setup()
+{
+    displayBanner();
+
+    if (!connect())
+        return;
+
+    showDeviceInfo();
+
+    delay(500);
+    return loop();
+}
+
+bool Pn532ble::connect()
+{
+    displayInfo("Turn on PN532 BLE device", true);
+
+    displayBanner();
+    padprintln("");
+    displayInfo("Searching...");
+
+    if (!pn532_ble.searchForDevice())
+    {
+        displayError("Not found");
+        delay(1000);
+        return false;
+    }
+
+    if (!pn532_ble.connectToDevice())
+    {
+        displayError("Connect failed");
+        delay(1000);
+        return false;
+    }
+    std::string deviceName = pn532_ble.getName();
+    displaySuccess("Connected");
+    delay(800);
+
+    return true;
+}
+
+void Pn532ble::loop()
+{
+    while (1)
+    {
+        if (checkEscPress())
+        {
+            returnToMenu = true;
+            break;
+        }
+
+        if (checkSelPress())
+        {
+            selectMode();
+        }
+    }
+}
+
+void Pn532ble::selectMode()
+{
+    options = {
+        {"Tag Scan", [&]()
+         { setMode(HF_SCAN_MODE); }},
+        {"Back", [&]() { setMode(GET_FW_MODE); }},
+    };
+    delay(200);
+    loopOptions(options);
+}
+
+void Pn532ble::setMode(AppMode mode)
+{
+    currentMode = mode;
+
+    displayBanner();
+    switch (mode)
+    {
+    case GET_FW_MODE:
+        showDeviceInfo();
+        break;
+    case HF_SCAN_MODE:
+        pn532_ble.setNormalMode();
+        hf14aScan();
+        break;
+    }
+}
+
+void Pn532ble::displayBanner()
+{
+    drawMainBorderWithTitle("PN532 BLE");
+    padprintln("PN532 HSU with Bluetooth 4.0+");
+    padprintln("------------");
+    delay(300);
+}
+
+void Pn532ble::showDeviceInfo()
+{
+    displayBanner();
+    padprintln("Devices: " + String(pn532_ble.getName().c_str()));
+    pn532_ble.setNormalMode();
+    bool res = pn532_ble.getVersion();
+    if (!res)
+    {
+        displayError("Get version failed");
+        delay(1000);
+        return;
+    }
+    uint8_t *version = pn532_ble.cmdResponse.data;
+    uint8_t dataSize = pn532_ble.cmdResponse.dataSize;
+    String versionStr = "Version: ";
+    for (size_t i = 0; i < dataSize; i++)
+    {
+        versionStr += version[i] < 0x10 ? " 0" : " ";
+        versionStr += String(version[i], HEX);
+    }
+    padprintln(versionStr);
+    padprintln("------------");
+    padprintln("");
+    padprintln("Press OK to select mode.");
+}
+
+void Pn532ble::hf14aScan()
+{
+    displayBanner();
+    padprintln("HF 14a Scan");
+    delay(200);
+    bool res = pn532_ble.hf14aScan();
+    delay(20);
+    if (!res)
+    {
+        displayError("No tag found");
+    }
+    else
+    {
+        u_int8_t *data = pn532_ble.cmdResponse.data;
+        u_int8_t dataSize = pn532_ble.cmdResponse.dataSize;
+        Iso14aTagInfo tagInfo = parseHf14aScan(data, dataSize);
+        padprintln("------------");
+        padprintln("UID:  " + tagInfo.uid_hex);
+        padprintln("ATQA: " + tagInfo.atqa_hex);
+        padprintln("SAK:  " + tagInfo.sak_hex);
+        bool isGen1A = pn532_ble.isGen1A(); 
+        padprintln("Gen1A: " + String(isGen1A ? "Yes" : "No"));
+    }
+}
+
+String bytes2HexString(std::vector<uint8_t> *data, uint8_t dataSize)
+{
+    String hexString = "";
+    for (size_t i = 0; i < dataSize; i++)
+    {
+        hexString += (*data)[i] < 0x10 ? " 0" : " ";
+        hexString += String((*data)[i], HEX);
+    }
+    hexString.toUpperCase();
+    return hexString;
+}
+
+Pn532ble::Iso14aTagInfo Pn532ble::parseHf14aScan(uint8_t *data, uint8_t dataSize)
+{
+    Iso14aTagInfo tagInfo;
+    tagInfo.atqa = {data[2], data[3]};
+    tagInfo.sak = data[4];
+    tagInfo.uidSize = data[5];
+    tagInfo.uid.assign(data + 6, data + 6 + tagInfo.uidSize);
+    tagInfo.uid_hex = "";
+    for (size_t i = 0; i < tagInfo.uid.size(); i++)
+    {
+        tagInfo.uid_hex += tagInfo.uid[i] < 0x10 ? " 0" : " ";
+        tagInfo.uid_hex += String(tagInfo.uid[i], HEX);
+    }
+    tagInfo.uid_hex.toUpperCase();
+    tagInfo.atqa_hex = bytes2HexString(&tagInfo.atqa, 2);
+    std::vector<uint8_t> sakVector = {tagInfo.sak};
+    tagInfo.sak_hex = bytes2HexString(&sakVector, 1);
+    return tagInfo;
+}

--- a/src/modules/rfid/pn532ble.h
+++ b/src/modules/rfid/pn532ble.h
@@ -1,0 +1,51 @@
+#ifndef __PN532BLE_H__
+#define __PN532BLE_H__
+
+#include <set>
+#include "pn532_ble.h"
+#include <vector>
+
+class Pn532ble
+{
+public:
+    Pn532ble();
+    ~Pn532ble();
+
+    void setup();
+    void loop();
+    bool connect();
+    String getDeviceName() { return String(pn532_ble.getName().c_str()); }
+
+    enum AppMode
+    {
+        GET_FW_MODE,
+        HF_SCAN_MODE
+    };
+    typedef struct 
+    {
+        std::vector<uint8_t> atqa;
+        uint8_t sak;
+        uint8_t uidSize;
+        std::vector<uint8_t> uid;
+        String uid_hex;
+        String sak_hex;
+        String atqa_hex;
+    } Iso14aTagInfo;
+
+private:
+    PN532_BLE pn532_ble = PN532_BLE(false);
+    PN532_BLE::HfTag hfTagData;
+
+    std::vector<uint8_t> buffer;
+    void onNotify(uint8_t *data, size_t length);
+    void displayBanner();
+    void showDeviceInfo();
+    void hf14aScan();
+    void selectMode();
+    AppMode currentMode;
+    void setMode(AppMode mode);
+
+    Iso14aTagInfo parseHf14aScan(uint8_t *data, uint8_t dataSize);
+};
+
+#endif


### PR DESCRIPTION
#### Proposed Changes ####

Add PN532 BLE devices support on Burce firmware, tested on CardPuter.

#### Types of Changes ####

Support connect to PN532_BLE devices with Bluetooth and check Gen1A type.