### PR TITLE
fix CYD GPS

### DIFF
--- a/src/modules/wifi/wardriving.cpp
+++ b/src/modules/wifi/wardriving.cpp
@@ -42,7 +42,7 @@ void Wardriving::begin_wifi() {
 }
 
 bool Wardriving::begin_gps() {
-    GPSserial.begin(9600, SERIAL_8N1, SERIAL_RX, SERIAL_TX); // RX, TX
+    GPSserial.begin(9600, SERIAL_8N1, SERIAL_TX, SERIAL_RX);
 
     int count = 0;
     padprintln("Waiting for GPS data");


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Bugfix for GPS on CYD

ref #352

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Verify Wardriving is work on CYD with NEO-6M



#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

I tested it on 2432S028R

![IMG_0131](https://github.com/user-attachments/assets/cd27220a-9443-46db-8f4b-0afe60bc1271)


Since it is indoors, it is displayed as not updated, but when it is outdoors, the location can be obtained successfully.
And the wardriving.csv was created successfully.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

ref #352 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

Modified with reference to the following.

https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/d81d8ffdf207d8549c271f11a99e98dc7727ce67/esp32_marauder/GpsInterface.cpp#L28