### PR TITLE
Added WS2812 RGB Rotary Encoder Led for LilyGO T-embed CC1101

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,19 +19,13 @@ default_envs =
 	m5stack-cores3
 	CYD-2432S028
 	CYD-2USB
-	lilygo-t-embed-cc1101
-	lilygo-t-deck
 ;uncomment to not use global dirs to avoid possible conflicts
 ;platforms_dir = .pio/platforms
 ;packages_dir = .pio/packages
 ;build_cache_dir = .pio/buildcache
 ;cache_dir = .pio/cache
 
-extra_configs =
-  ports/*/platformio.ini
-
-[env]
-monitor_filters = esp32_exception_decoder
+[common]
 build_flags =
 	-DBRUCE_VERSION='"dev"'
 	-DEEPROMSIZE=128
@@ -55,13 +49,14 @@ lib_deps =
 	IRremoteESP8266
 	Time
 	LibSSH-ESP32
-	PCA9554
+	;PCA9554
+	bakadave/PCA9554 @ ^0.3.2
 	https://github.com/bmorcelli/ESPping/
 	https://github.com/rennancockles/PN532
 	https://github.com/rennancockles/MFRC522-I2C
 	https://github.com/rennancockles/ESP-ChameleonUltra
 	https://github.com/rennancockles/ESP-Amiibolink
-	https://github.com/whywilson/ESP-PN532BLE#1262a21
+	https://github.com/whywilson/ESP-PN532BLE
 	NTPClient
 	Timezone
 	ESP32Time
@@ -84,3 +79,1506 @@ lib_deps =
 	;chegewara/EspTinyUSB
 	bitbank2/AnimatedGIF
 
+[env:m5stack-cplus2]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stick-c
+framework = arduino
+board_build.partitions = custom_8Mb.csv
+board_build.f_flash = 40000000L
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+build_flags =
+	${common.build_flags}
+	-DCORE_DEBUG_LEVEL=5
+	;-DBOARD_HAS_PSRAM
+	;-mfix-esp32-psram-cache-issue
+	;-mfix-esp32-psram-cache-strategy=memw
+
+	-DSTICK_C_PLUS2=1
+
+	;Features Enabled
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	-DMIC_SPM1423=1 ;Applicable for SPM1423 device
+	;FM Radio
+	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=0
+    -DPIN_CLK=0
+    -DI2S_SCLK_PIN=0
+    -DI2S_DATA_PIN=34
+    -DPIN_DATA=34
+
+	;Have RTC Chip
+	-DHAS_RTC=1
+
+	;Have buzzer
+	-DBUZZ_PIN=2
+
+	;Can run USB as HID
+	;-DUSB_as_HID=1 ;uncomment to enable
+	;-DBAD_TX=25 ; Using pin header
+	;-DBAD_RX=26 ; Using pin header
+	-DBAD_TX=32  ; Using Grove
+	-DBAD_RX=33	 ; Using Grove
+
+	;Buttons configuration
+	-DHAS_BTN=1
+	-DSEL_BTN=37
+	-DUP_BTN=35
+	-DDW_BTN=39
+	-DBTN_ACT=LOW
+	-DBTN_ALIAS='"M5"'
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{ {"Default", LED}, {"M5 IR Mod", GROVE_SDA}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{ {"M5 IR Mod", GROVE_SCL}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=19
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{ {"M5 RF433T", GROVE_SDA}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{ {"M5 RF433R", GROVE_SCL}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+
+    ; connection pins for CC1101 https://github.com/bmorcelli/io433/blob/master/platformio.ini
+    -DUSE_CC1101_VIA_SPI
+    -DCC1101_GDO0_PIN=25
+		-DCC1101_SS_PIN=SPI_SS_PIN
+		-DCC1101_MOSI_PIN=SPI_MOSI_PIN
+		-DCC1101_SCK_PIN=SPI_SCK_PIN
+		-DCC1101_MISO_PIN=SPI_MISO_PIN
+    ;-DCC1101_GDO2_PIN=-1
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=25
+	-DNRF24_SS_PIN=SPI_SS_PIN
+	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
+	-DNRF24_SCK_PIN=SPI_SCK_PIN
+	-DNRF24_MISO_PIN=SPI_MISO_PIN
+
+	;Battery ADC read pin
+	-DBAT_PIN=38
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=3
+	-DWIDTH=240
+	-DHEIGHT=135
+	-DBACKLIGHT=27
+	-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DST7789_2_DRIVER=1
+	-DTFT_RGB_ORDER=1
+	-DTFT_WIDTH=135
+	-DTFT_HEIGHT=240
+	-DTFT_BACKLIGHT_ON=1
+	-DTFT_CS=5
+	-DTFT_DC=14
+	-DTFT_RST=12
+	-DTOUCH_CS=-1
+	-DTFT_MOSI=15
+	-DTFT_SCLK=13
+	-DTFT_BL=27
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=20000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=14
+	-DSDCARD_SCK=0
+	-DSDCARD_MISO=36
+	-DSDCARD_MOSI=26
+
+	;Default I2C port
+	-DGROVE_SDA=32
+	-DGROVE_SCL=33
+
+	-DSPI_SCK_PIN=0
+	-DSPI_MOSI_PIN=GROVE_SDA
+	-DSPI_MISO_PIN=GROVE_SCL
+	-DSPI_SS_PIN=26
+
+lib_deps =
+	${common.lib_deps}
+
+[env:m5stack-cplus1_1]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stick-c
+framework = arduino
+board_build.partitions = custom_4Mb_full.csv
+build_flags =
+	${common.build_flags}
+	-Os
+	-DSTICK_C_PLUS=1
+
+	;Features Enabled
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;FM Radio
+	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=0
+	;Microphone
+	-DMIC_SPM1423=1 ;Applicable for SPM1423 device
+    -DPIN_CLK=0
+    -DI2S_SCLK_PIN=0
+    -DI2S_DATA_PIN=34
+    -DPIN_DATA=34
+
+	;Have RTC Chip
+	-DHAS_RTC=1
+
+	;Have buzzer
+	-DBUZZ_PIN=2
+
+	;Can run USB as HID
+	;-DUSB_as_HID=1 ;uncomment to enable
+	;-DBAD_TX=25 ; Using pin header
+	;-DBAD_RX=26 ; Using pin header
+	-DBAD_TX=32  ; Using Grove
+	-DBAD_RX=33	 ; Using Grove
+
+	;Buttons Setup
+	-DHAS_BTN=1
+	-DSEL_BTN=37
+	-DUP_BTN=0
+	-DDW_BTN=39
+	-DBTN_ACT=LOW
+	-DBTN_ALIAS='"M5"'
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{ {"Default", LED}, {"M5 IR Mod", GROVE_SDA}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{ {"M5 IR Mod", GROVE_SCL}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=9
+	-DLED_ON=LOW
+	-DLED_OFF=HIGH
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{ {"M5 RF433T", GROVE_SDA}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{ {"M5 RF433R", GROVE_SCL}, {"G26",26}, {"G25",25}, {"G0",0}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+
+    ; connection pins for CC1101 https://github.com/bmorcelli/io433/blob/master/platformio.ini
+    -DUSE_CC1101_VIA_SPI
+    -DCC1101_GDO0_PIN=25
+	-DCC1101_SS_PIN=SPI_SS_PIN
+	-DCC1101_MOSI_PIN=SPI_MOSI_PIN
+	-DCC1101_SCK_PIN=SPI_SCK_PIN
+	-DCC1101_MISO_PIN=SPI_MISO_PIN
+    ;-DCC1101_GDO2_PIN=-1
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=25
+	-DNRF24_SS_PIN=SPI_SS_PIN
+	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
+	-DNRF24_SCK_PIN=SPI_SCK_PIN
+	-DNRF24_MISO_PIN=SPI_MISO_PIN
+
+	;Battery ADC read pin
+	-DBAT_PIN=10
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=3
+	-DWIDTH=240
+	-DHEIGHT=135
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DST7789_2_DRIVER=1
+	-DTFT_RGB_ORDER=1
+	-DTFT_WIDTH=135
+	-DTFT_HEIGHT=240
+	-DTFT_BACKLIGHT_ON=0
+	-DTFT_CS=5
+	-DTFT_DC=23
+	-DTFT_RST=18
+	-DTOUCH_CS=-1
+	-DTFT_MOSI=15
+	-DTFT_SCLK=13
+	-DTFT_BL=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=20000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=14
+	-DSDCARD_SCK=0
+	-DSDCARD_MISO=36
+	-DSDCARD_MOSI=26
+
+	;Default I2C port
+	-DGROVE_SDA=32
+	-DGROVE_SCL=33
+
+	-DSPI_SCK_PIN=0
+	-DSPI_MOSI_PIN=GROVE_SDA
+	-DSPI_MISO_PIN=GROVE_SCL
+	-DSPI_SS_PIN=26
+
+lib_deps =
+	${common.lib_deps}
+
+[env:LAUNCHER_m5stack-cplus1_1]
+extends=env:m5stack-cplus1_1
+board_build.partitions = custom_4Mb.csv
+build_flags =
+	${env:m5stack-cplus1_1.build_flags}
+	-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+
+
+[env:m5stack-cardputer]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stack-stamps3
+framework = arduino
+board_build.partitions = custom_8Mb.csv
+build_flags =
+	${common.build_flags}
+	-DCORE_DEBUG_LEVEL=5
+	-DARDUINO_USB_CDC_ON_BOOT=1
+
+	-DCARDPUTER=1
+
+	;Features Enabled
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;Microphone
+	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+	;FM Radio
+	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=40
+    -DPIN_CLK=43
+    -DI2S_SCLK_PIN=43
+    -DI2S_DATA_PIN=46
+    -DPIN_DATA=46
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	-DHAS_RGB_LED=1
+	-DRGB_LED=21
+
+	;Speaker to run music, compatible with NS4168
+	-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=41
+    -DWCLK=43
+    -DDOUT=42
+
+	;Can run USB as HID
+	-DUSB_as_HID=1
+
+	;Buttons configuration
+	-DHAS_BTN=0
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=0
+	-DBTN_ACT=LOw
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{ {"Default", LED}, {"M5 IR Mod", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{ {"M5 IR Mod", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=44
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{ {"M5 RF433T", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{ {"M5 RF433R", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	; connection pins using microSD sniffer module https://www.sparkfun.com/products/9419 https://docs.m5stack.com/en/core/Cardputer
+	-DUSE_CC1101_VIA_SPI
+	-DCC1101_GDO0_PIN=GROVE_SDA
+	-DCC1101_SS_PIN=SPI_SS_PIN
+	-DCC1101_MOSI_PIN=SPI_MOSI_PIN
+	-DCC1101_SCK_PIN=SPI_SCK_PIN
+	-DCC1101_MISO_PIN=SPI_MISO_PIN
+	;-DCC1101_GDO2_PIN=-1
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=GROVE_SDA
+	-DNRF24_SS_PIN=SPI_SS_PIN
+	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
+	-DNRF24_SCK_PIN=SPI_SCK_PIN
+	-DNRF24_MISO_PIN=SPI_MISO_PIN
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DWIDTH=240
+	-DHEIGHT=135
+	-DBACKLIGHT=38
+	-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DUSE_HSPI_PORT=1
+	-DST7789_2_DRIVER=1
+	-DTFT_RGB_ORDER=1
+	-DTFT_WIDTH=135
+	-DTFT_HEIGHT=240
+	-DTFT_BACKLIGHT_ON=1
+	-DTFT_BL=38
+	-DTFT_RST=33
+	-DTFT_DC=34
+	-DTFT_MOSI=35
+	-DTFT_SCLK=36
+	-DTFT_CS=37
+	-DTOUCH_CS=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=20000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=12
+	-DSDCARD_SCK=40
+	-DSDCARD_MISO=39
+	-DSDCARD_MOSI=14
+
+	;Default I2C port
+	-DGROVE_SDA=2
+	-DGROVE_SCL=1
+
+	;Default SPI port
+	-DSPI_SCK_PIN=40
+	-DSPI_MOSI_PIN=14
+	-DSPI_MISO_PIN=39
+	-DSPI_SS_PIN=GROVE_SCL
+
+lib_deps =
+	${common.lib_deps}
+	xylopyrographer/LiteLED@^1.2.0
+
+[env:m5stack-core2]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stick-c
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = custom_16Mb.csv
+board_build.f_flash = 40000000L
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_upload.maximum_ram_size=532480
+;board_upload.maximum_ram_size=4521984
+build_flags =
+	${common.build_flags}
+	-DCORE_DEBUG_LEVEL=5
+
+	-DM5STACK=1 	;key for new device,
+	-DCORE2=1		;mykeyboard.cpp: need map buttons an/or touchscreen,
+					;display.cpp:    need map battery status value,
+					;settings.cpp:   need map brighness control
+					;main.cpp:		  need set startup
+					;serialcmds.cpp: need set power off command
+
+	;Features Enabled
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=18
+	;Microphone
+	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+    -DPIN_CLK=-1
+    -DI2S_SCLK_PIN=-1
+    -DI2S_DATA_PIN=-1
+    -DPIN_DATA=-1
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=-1
+
+	;Have RTC Chip
+	-DHAS_RTC=1
+
+	;Have buzzer
+	;-DBUZZ_PIN=2
+
+	;Speaker to run music, compatible with NS4168
+	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=12
+    -DWCLK=0
+    -DDOUT=2
+
+	;Can run USB as HID
+	;-DUSB_as_HID=1 ;uncomment to enable
+	-DBAD_TX=32
+	-DBAD_RX=33
+
+	;Battery ADC read pin
+	;-DBAT_PIN=10
+
+	;Buttons configuration
+	;-DHAS_BTN=1
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=-1
+	-DBTN_ACT=LOw
+
+	;Touchscreen Config
+	-DHAS_TOUCH=1
+
+	-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"M5 IR Mod", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{{"M5 IR Mod", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=GROVE_SDA
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"M5 RF433T", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{{"M5 RF433R", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DWIDTH=320
+	-DHEIGHT=220 ;240 - 50 for bottom margin
+	;-DBACKLIGHT=38
+	;-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DILI9341_DRIVER=1
+	-DTFT_INVERSION_ON=1
+	-DM5STACK=1
+	-DTFT_WIDTH=240
+	-DTFT_HEIGHT=320
+	-DTFT_MISO=38
+	-DTFT_MOSI=23
+	-DTFT_SCLK=18
+	-DTFT_CS=5
+	-DTFT_DC=15
+	-DTFT_RST=-1
+	-DTFT_BL=-1
+	-DTOUCH_CS=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=40000000
+	-DSPI_READ_FREQUENCY=16000000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=4
+	-DSDCARD_SCK=18
+	-DSDCARD_MISO=38
+	-DSDCARD_MOSI=23
+
+	;Default I2C port
+	-DGROVE_SDA=32
+	-DGROVE_SCL=33
+
+	-DSPI_SCK_PIN=0
+	-DSPI_MOSI_PIN=GROVE_SDA
+	-DSPI_MISO_PIN=GROVE_SCL
+	-DSPI_SS_PIN=26
+
+lib_deps =
+	${common.lib_deps}
+
+[env:m5stack-core16mb]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stack-core-esp32
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = custom_16Mb.csv
+board_build.f_flash = 40000000L
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_upload.maximum_ram_size=532480
+build_flags =
+	${common.build_flags}
+	-DCORE_DEBUG_LEVEL=5
+
+	-DM5STACK=1 	;key for new device,
+	-DCORE=1		;mykeyboard.cpp: need map buttons an/or touchscreen,
+					;display.cpp:    need map battery status value,
+					;settings.cpp:   need map brighness control
+					;main.cpp:		  need set startup
+					;serialcmds.cpp: need set power off command
+
+	;Features Enabled
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=18
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;Microphone
+	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+    -DPIN_CLK=-1
+    -DI2S_SCLK_PIN=-1
+    -DI2S_DATA_PIN=-1
+    -DPIN_DATA=-1
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=-1
+
+	;Have RTC Chip
+	-DHAS_RTC=1
+
+	;Have buzzer
+	-DBUZZ_PIN=25
+
+	;Speaker to run music, compatible with NS4168
+	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=-1
+    -DWCLK=-1
+    -DDOUT=-1
+
+	;Can run USB as HID
+	;-DUSB_as_HID=1 ;uncomment to enable
+	-DBAD_TX=21
+	-DBAD_RX=22
+
+	;Battery ADC read pin
+	;-DBAT_PIN=10
+
+	;Buttons configuration
+	;-DHAS_BTN=1
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=-1
+	-DBTN_ACT=LOw
+
+	;Touchscreen Config
+	;-DHAS_TOUCH=1
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"M5 IR Mod", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{{"M5 IR Mod", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=GROVE_SDA
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"M5 RF433T", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{{"M5 RF433R", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DWIDTH=320
+	-DHEIGHT=220 ;240 - 50 for bottom margin
+	;-DBACKLIGHT=38
+	;-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DILI9341_DRIVER=1
+	-DTFT_INVERSION_ON=1
+	-DTFT_BACKLIGHT_ON=1
+	-DM5STACK=1
+	-DTFT_WIDTH=240
+	-DTFT_HEIGHT=320
+	-DTFT_MOSI=23
+	-DTFT_SCLK=18
+	-DTFT_CS=14
+	-DTFT_DC=27
+	-DTFT_RST=33
+	-DTFT_BL=32
+	-DTOUCH_CS=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=20000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=4
+	-DSDCARD_SCK=18
+	-DSDCARD_MISO=19
+	-DSDCARD_MOSI=23
+
+	;Default I2C port
+	-DGROVE_SDA=21
+	-DGROVE_SCL=22
+
+	-DSPI_SCK_PIN=0
+	-DSPI_MOSI_PIN=GROVE_SDA
+	-DSPI_MISO_PIN=GROVE_SCL
+	-DSPI_SS_PIN=26
+
+lib_deps =
+	${common.lib_deps}
+
+[env:m5stack-core4mb]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stack-core-esp32
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = custom_4Mb_full.csv
+build_flags =
+	${common.build_flags}
+	-DCORE_DEBUG_LEVEL=5
+
+	-DM5STACK=1 	;key for new device,
+	-DCORE=1		;mykeyboard.cpp: need map buttons an/or touchscreen,
+					;display.cpp:    need map battery status value,
+					;settings.cpp:   need map brighness control
+					;main.cpp:		  need set startup
+					;serialcmds.cpp: need set power off command
+
+	;Features Enabled
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=18
+	-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;Microphone
+	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+    -DPIN_CLK=-1
+    -DI2S_SCLK_PIN=-1
+    -DI2S_DATA_PIN=-1
+    -DPIN_DATA=-1
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=-1
+
+	;Have RTC Chip
+	-DHAS_RTC=1
+
+	;Have buzzer
+	-DBUZZ_PIN=25
+
+	;Speaker to run music, compatible with NS4168
+	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=-1
+    -DWCLK=-1
+    -DDOUT=-1
+
+	;Can run USB as HID
+	;-DUSB_as_HID=1 ;uncomment to enable
+	-DBAD_TX=21
+	-DBAD_RX=22
+
+	;Battery ADC read pin
+	;-DBAT_PIN=10
+
+	;Buttons configuration
+	;-DHAS_BTN=1
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=-1
+	-DBTN_ACT=LOw
+
+	;Touchscreen Config
+	;-DHAS_TOUCH=1
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"M5 IR Mod", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{{"M5 IR Mod", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=GROVE_SDA
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"M5 RF433T", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{{"M5 RF433R", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DWIDTH=320
+	-DHEIGHT=220 ;240 - 50 for bottom margin
+	;-DBACKLIGHT=38
+	;-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DILI9341_DRIVER=1
+	-DTFT_INVERSION_ON=1
+	-DTFT_BACKLIGHT_ON=1
+	-DM5STACK=1
+	-DTFT_WIDTH=240
+	-DTFT_HEIGHT=320
+	-DTFT_MOSI=23
+	-DTFT_SCLK=18
+	-DTFT_CS=14
+	-DTFT_DC=27
+	-DTFT_RST=33
+	-DTFT_BL=32
+	-DTOUCH_CS=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=20000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=4
+	-DSDCARD_SCK=18
+	-DSDCARD_MISO=19
+	-DSDCARD_MOSI=23
+
+	;Default I2C port
+	-DGROVE_SDA=21
+	-DGROVE_SCL=22
+
+	-DSPI_SCK_PIN=0
+	-DSPI_MOSI_PIN=GROVE_SDA
+	-DSPI_MISO_PIN=GROVE_SCL
+	-DSPI_SS_PIN=26
+
+lib_deps =
+	${common.lib_deps}
+
+
+
+[env:esp32-s3-devkitc-1-psram]
+board_build.arduino.memory_type = qio_opi  ; NEEDED FOR 8MB PSRAM (N16R8)
+;board_build.partitions = custom_16Mb.csv
+;board_upload.flash_size = 16MB
+;monitor_speed = 115200
+;board_build.partitions = custom_16Mb.csv
+;board_build.f_flash = 40000000L
+;board_upload.flash_size = 16MB
+;board_upload.maximum_size = 16777216
+;board_build.f_flash = 40000000L
+;board_build.flash_mode = qio
+extends                 = env:esp32-s3-devkitc-1
+
+
+[env:esp32-s3-devkitc-1]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+build_flags =
+	${common.build_flags}
+	-DESP32S3DEVKITC1
+	-DUSB_as_HID=1
+	; needed for serial
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DBOARD_HAS_PSRAM
+
+	; grove pins
+	; defaults from https://github.com/espressif/arduino-esp32/blob/master/variants/esp32s3/pins_arduino.h
+	-DGROVE_SDA=8  ; default RF TX pin
+	-DGROVE_SCL=46  ; default IR/RF RX pin
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	; ir led pin
+	-DIR_TX_PINS='{{"M5 IR Mod", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{{"M5 IR Mod", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=40
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"M5 RF433T", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{{"M5 RF433R", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+
+	; sd card pins
+	; suggested https://github.com/espressif/esp-idf/tree/master/examples/storage/sd_card/sdmmc
+	-DSDCARD_CS=-1
+	-DSDCARD_SCK=-1
+	-DSDCARD_MISO=-1
+	-DSDCARD_MOSI=-1
+
+	; tft vars
+	-DROTATION=1
+	-DBACKLIGHT=-1  ; tft backlight pin
+	-DWIDTH=240
+	-DHEIGHT=135
+	-DMINBRIGHT=160  ; unused?
+	-DSMOOTH_FONT=1
+	-DTFT_DISPON=0x29
+	-DTFT_DISPOFF=0x28
+	-DTFT_CS=-1
+	-DTFT_DC=-1
+	-DTFT_RST=-1
+	-DTOUCH_CS=-1
+	-DTFT_MOSI=-1
+	-DTFT_SCLK=-1
+	-DTFT_BL=-1
+	; text sizes
+	-DFP=1
+	-DFM=2
+	-DFG=3
+	; ui control buttons
+	;-DSEL_BTN=1
+	;-DUP_BTN=2  ; also work as ESC
+	;-DDW_BTN=3  ; also work as NEXT
+	-DBTN_ALIAS='"OK"'
+
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=12
+	;Microphone
+	;-DMIC_SPM1423=1 ; uncomment to enable Applicable for SPM1423 device
+    ;-DPIN_CLK=-1
+    ;-DI2S_SCLK_PIN=-1
+    ;-DI2S_DATA_PIN=-1
+    ;-DPIN_DATA=-1
+
+    ;CC1101 SPI connection pins
+    ; best connection pins for higher speed https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/spi_master.html#gpio-matrix-and-io-mux
+    -DUSE_CC1101_VIA_SPI
+    -DCC1101_GDO0_PIN=9
+    -DCC1101_SS_PIN=10
+    -DCC1101_MOSI_PIN=11
+    -DCC1101_SCK_PIN=12
+    -DCC1101_MISO_PIN=13
+    ;-DCC1101_GDO2_PIN=14  ; optional
+
+	; connections are the same as CC1101
+	;-DUSE_NRF24_VIA_SPI
+	;-DNRF24_CE_PIN=6
+    ;-DNRF24_SS_PIN=7  ; chip select
+    ;-DNRF24_MOSI_PIN=11
+    ;-DNRF24_SCK_PIN=12
+    ;-DNRF24_MISO_PIN=13
+
+	-DSPI_SCK_PIN=12
+	-DSPI_MOSI_PIN=11
+	-DSPI_MISO_PIN=13
+	-DSPI_SS_PIN=10
+
+lib_deps =
+	${common.lib_deps}
+
+[env:m5stack-cores3]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stack-cores3
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = custom_16Mb.csv
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+build_flags =
+	${common.build_flags}
+	-DCORE_DEBUG_LEVEL=5
+	-DARDUINO_USB_CDC_ON_BOOT=1
+
+	-DM5STACK=1 	;key for new device,
+	-DCORES3=1		;mykeyboard.cpp: need map buttons an/or touchscreen,
+					;display.cpp:    need map battery status value,
+					;settings.cpp:   need map brighness control
+					;main.cpp:		  need set startup
+					;serialcmds.cpp: need set power off command
+
+	;Features Enabled
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=18
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+
+	;Microphone
+	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+    -DPIN_CLK=-1
+    -DI2S_SCLK_PIN=-1
+    -DI2S_DATA_PIN=-1
+    -DPIN_DATA=-1
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=-1
+
+	;Have RTC Chip
+	-DHAS_RTC=1
+
+	;Speaker to run music, compatible with NS4168
+	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=-1
+    -DWCLK=-1
+    -DDOUT=-1
+
+	;Can run USB as HID
+	-DUSB_as_HID=1 ;uncomment to enable
+
+	;Battery ADC read pin
+	;-DBAT_PIN=10
+
+	;Buttons configuration
+	;-DHAS_BTN=1
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=-1
+	-DBTN_ACT=LOw
+
+	;Touchscreen Config
+	-DHAS_TOUCH=1
+
+	-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"M5 IR Mod", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DIR_RX_PINS='{{"M5 IR Mod", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DLED=GROVE_SDA
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"M5 RF433T", GROVE_SDA}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+	-DRF_RX_PINS='{{"M5 RF433R", GROVE_SCL}, {"Groove W", GROVE_SCL}, {"GROVE Y", GROVE_SDA}}'
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DWIDTH=320
+	-DHEIGHT=220 ;240 - 50 for bottom margin
+	;-DBACKLIGHT=38
+	;-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DILI9341_DRIVER=1
+	-DTFT_INVERSION_ON=1
+	-DM5STACK=1
+	-DTFT_MOSI=23
+	-DTFT_SCLK=18
+	-DTFT_CS=5
+	-DTFT_DC=15
+	-DTFT_RST=-1
+	-DTFT_BL=-1
+	-DTOUCH_CS=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=20000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=4
+	-DSDCARD_SCK=18
+	-DSDCARD_MISO=38
+	-DSDCARD_MOSI=23
+
+	;Default I2C port
+	-DGROVE_SDA=32
+	-DGROVE_SCL=33
+
+	-DSPI_SCK_PIN=0
+	-DSPI_MOSI_PIN=GROVE_SDA
+	-DSPI_MISO_PIN=GROVE_SCL
+	-DSPI_SS_PIN=26
+
+lib_deps =
+	${common.lib_deps}
+
+
+
+##################################### CYD MODELS ####################################################
+[env:CYD-2432S028]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = esp32dev
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+framework = arduino
+board_build.partitions = custom_4Mb_full.csv
+build_flags =
+	${common.build_flags}
+	-Os
+	-DCORE_DEBUG_LEVEL=5
+	;-DARDUINO_USB_CDC_ON_BOOT=1  ; Used only in ESP32-S3 to make Serial Comands work
+
+	-DCYD=1 	;key for new device,
+					;mykeyboard.cpp: need map buttons an/or touchscreen and battery status value,
+					;settings.cpp:   need map brighness control
+					;main.cpp:		  need set startup
+					;serialcmds.cpp: need set power off command
+
+	;Features Enabled
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=40
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;Microphone
+	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+    -DPIN_CLK=-1
+    -DI2S_SCLK_PIN=-1
+    -DI2S_DATA_PIN=-1
+    -DPIN_DATA=-1
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=-1
+
+	;Have RTC Chip
+	;-DHAS_RTC=1
+
+	;Speaker to run music, compatible with NS4168
+	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=-1
+    -DWCLK=-1
+    -DDOUT=-1
+
+	;Can run USB as HID
+	;-DUSB_as_HID=1 ;uncomment to enable
+	-DBAD_TX=GROVE_SDA
+	-DBAD_RX=GROVE_SCL
+
+	; SERIAL (GPS) dedicated pins
+	-DSERIAL_TX=1
+	-DSERIAL_RX=3
+
+	;Battery ADC read pin
+	;-DBAT_PIN=10
+
+	;Buttons configuration
+	-DHAS_BTN=0
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=0
+	-DBTN_ACT=LOw
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}}'
+	-DIR_RX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}, {"Pin 35", 35}}'
+	-DLED=22		;NEED TO SET SOMETHING HERE, at least -1
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}}'
+	-DRF_RX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}, {"Pin 35", 35}}'
+
+    ;CC1101 SPI connection pins
+    ; best connection pins for higher speed https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/spi_master.html#gpio-matrix-and-io-mux
+    -DUSE_CC1101_VIA_SPI
+	-DCC1101_GDO0_PIN=22
+	-DCC1101_SS_PIN=27
+	-DCC1101_MOSI_PIN=SPI_MOSI_PIN
+	-DCC1101_SCK_PIN=SPI_SCK_PIN
+	-DCC1101_MISO_PIN=SPI_MISO_PIN
+    ;-DCC1101_GDO2_PIN=14  ; optional
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=22
+	-DNRF24_SS_PIN=27  ; chip select
+	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
+	-DNRF24_SCK_PIN=SPI_SCK_PIN
+	-DNRF24_MISO_PIN=SPI_MISO_PIN
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DWIDTH=320
+	-DHEIGHT=220 ;240-20 lower margin
+	-DBACKLIGHT=21
+	-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DILI9341_2_DRIVER=1
+	-DUSE_HSPI_PORT=1
+	-DTFT_MISO=12
+	-DTFT_MOSI=13
+	-DTFT_SCLK=14
+	-DTFT_CS=15
+	-DTFT_DC=2
+	-DTFT_RST=-1
+	-DTFT_BL=21
+	-DTFT_BACKLIGHT_ON=HIGH
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=40000000
+	-DSPI_READ_FREQUENCY=16000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+	-DTOUCH_CS=33
+
+	;SD Card Setup pins
+	-DSDCARD_CS=5
+	-DSDCARD_SCK=18
+	-DSDCARD_MISO=19
+	-DSDCARD_MOSI=23
+
+	;TouchScreen Controller
+	-DHAS_TOUCH=1
+	-DXPT2046_IRQ=36
+	-DXPT2046_MOSI=32
+	-DXPT2046_MISO=39
+	-DXPT2046_CLK=25
+	-DXPT2046_CS=33
+
+	;tft Brighness Control
+	-DTFT_BRIGHT_CHANNEL=0
+	-DTFT_BRIGHT_Bits=8
+	-DTFT_BRIGHT_FREQ=5000
+
+	;Default I2C port
+	-DGROVE_SDA=27
+	-DGROVE_SCL=22
+
+	-DSPI_SCK_PIN=18
+	-DSPI_MOSI_PIN=23
+	-DSPI_MISO_PIN=19
+	-DSPI_SS_PIN=27 ;grove beside SDCard
+
+lib_deps =
+	${common.lib_deps}
+
+##################################### CYD MODELS ####################################################
+
+[env:CYD-2USB]
+extends=env:CYD-2432S028
+build_flags =
+	${env:CYD-2432S028.build_flags}
+	-DTFT_INVERSION_ON
+
+[env:LAUNCHER_CYD-2432S028]
+extends=env:CYD-2432S028
+build_flags =
+	${env:CYD-2432S028.build_flags}
+	-DLITE_VERSION=1
+
+[env:LAUNCHER_CYD-2USB]
+extends=env:CYD-2432S028
+build_flags =
+	${env:CYD-2432S028.build_flags}
+	-DTFT_INVERSION_ON	
+	-DLITE_VERSION=1
+
+################################# END OF CYD MODELS ####################################################
+
+#################################### EStart OF LILYGO MODELS #######################################
+[env:lilygo-t-embed-cc1101]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stack-stamps3
+framework = arduino
+board_build.partitions = custom_8Mb.csv
+build_flags =
+	${common.build_flags}
+	-Os
+	-DCORE_DEBUG_LEVEL=5
+	-DARDUINO_USB_CDC_ON_BOOT=1  ; Used only in ESP32-S3 to make Serial Comands work
+	-DREDRAW_DELAY=0 # Used to improve navigation on menus for this device
+
+	-DT_EMBED=1		;key for new device,
+	-DT_EMBED_1101=1 ;mykeyboard.cpp: need map buttons an/or touchscreen and battery status value,
+					;settings.cpp:   need map brighness control
+					;main.cpp:		  need set startup
+					;serialcmds.cpp: need set power off command
+	-DBOARD_LORA_SW1=47
+	-DBOARD_LORA_SW0=48
+
+	# Config to use IRQ and RST pins of PN532, if needed
+	-DPN532_RF_REST=45
+	-DPN532_IRQ=17
+
+	;Features Enabled
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=40
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;Microphone
+	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+    -DPIN_CLK=39
+    -DI2S_SCLK_PIN=39
+    -DI2S_DATA_PIN=42
+    -DPIN_DATA=42
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=21
+
+	;WS2812 RGB Rotary Encoder Leds
+	-DHAS_WS2812_LED=1 ;uncomment to enable
+	-DWS2812_DATA_PIN=14
+	-DWS2812_NUM_LEDS=8
+	-DWS2812_DEFAULT_LIGHT=5
+
+	;Have RTC Chip
+	;-DHAS_RTC=1
+
+	;Speaker to run music, compatible with NS4168
+	-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=46
+    -DWCLK=40
+    -DDOUT=7
+
+	;Can run USB as HID
+	-DUSB_as_HID=1 ;uncomment to enable
+	;-DBAD_TX=GROVE_SDA
+	;-DBAD_RX=GROVE_SCL
+
+	;Battery ADC read pin
+	;-DBAT_PIN=10
+
+	;Buttons configuration
+	-DHAS_BTN=1
+	-DBTN_ALIAS='"Mid"'
+    -DSEL_BTN=0
+	-DUP_BTN=-1 ;Dont have btns, use a encoder
+	-DDW_BTN=-1 ;Dont have btns, use a encoder
+	-DBK_BTN=6
+	-DBTN_ACT=LOW
+
+	-DENCODER_INA=4
+	-DENCODER_INB=5
+	-DENCODER_KEY=0
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"Default", 2}, {"Pin 43", 43}, {"Pin 44", 44}}'
+	-DIR_RX_PINS='{{"Default", 1}, {"Pin 43", 43}, {"Pin 44", 44}}'
+	-DLED=2		;NEED TO SET SOMETHING HERE, at least -1
+	-DRXLED=1 
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
+	-DRF_RX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
+
+    ;CC1101 SPI connection pins
+    ; best connection pins for higher speed https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/spi_master.html#gpio-matrix-and-io-mux
+    -DUSE_CC1101_VIA_SPI
+	-DCC1101_GDO0_PIN=3 ; or 38, or 47 or 48?
+	-DCC1101_SS_PIN=12
+	-DCC1101_MOSI_PIN=SPI_MOSI_PIN
+	-DCC1101_SCK_PIN=SPI_SCK_PIN
+	-DCC1101_MISO_PIN=SPI_MISO_PIN
+    ;-DCC1101_GDO2_PIN=14  ; optional
+
+	; connections are the same as CC1101
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=43 ; left Grove
+	-DNRF24_SS_PIN=44  ; chip select
+	-DNRF24_MOSI_PIN=SDCARD_MOSI
+	-DNRF24_SCK_PIN=SDCARD_SCK
+	-DNRF24_MISO_PIN=SDCARD_MISO
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=3
+	-DWIDTH=320
+	-DHEIGHT=170
+	-DBACKLIGHT=TFT_BL
+	-DMINBRIGHT=1
+	-DPIN_POWER_ON=15
+
+	;TFT_eSPI display
+	-DUSER_SETUP_LOADED=1
+	-DUSE_HSPI_PORT=1
+	-DST7789_DRIVER=1
+	-DTFT_WIDTH=170
+	-DTFT_HEIGHT=320
+	-DTFT_INVERSION_ON
+	-DTFT_BL=21   
+	-DTFT_MISO=10   
+	-DTFT_MOSI=9
+	-DTFT_SCLK=11
+	-DTFT_CS=41 
+	-DTFT_DC=16
+	-DTFT_RST=-1 
+	-DTOUCH_CS=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=80000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=13
+	-DSDCARD_SCK=11
+	-DSDCARD_MISO=10
+	-DSDCARD_MOSI=9
+
+	;Default I2C port
+	-DGROVE_SDA=8
+	-DGROVE_SCL=18
+
+	-DSPI_SCK_PIN=11
+	-DSPI_MOSI_PIN=9
+	-DSPI_MISO_PIN=10
+	-DSPI_SS_PIN=8
+
+lib_deps =
+	${common.lib_deps}
+	lewisxhe/XPowersLib @ ^0.2.4
+	mathertel/RotaryEncoder @ ^1.5.3
+	fastled/FastLED @ ^3.9.2
+
+
+
+#################################### END OF LILYGO MODELS #######################################
+
+#New device model
+[env:NewDeviceModel]
+platform = https://github.com/bmorcelli/platform-espressif32/releases/download/0.0.4/platform-espressif32.zip
+board = m5stack-stamps3
+framework = arduino
+board_build.partitions = custom_8Mb.csv
+build_flags =
+	${common.build_flags}
+	-Os
+	-DCORE_DEBUG_LEVEL=5
+	;-DARDUINO_USB_CDC_ON_BOOT=1  ; Used only in ESP32-S3 to make Serial Comands work
+
+	-DNEW_DEVICE=1 	;key for new device,
+					;mykeyboard.cpp: need map buttons an/or touchscreen and battery status value,
+					;settings.cpp:   need map brighness control
+					;main.cpp:		  need set startup
+					;serialcmds.cpp: need set power off command
+
+	;Features Enabled
+	# Config to use IRQ and RST pins of PN532, if needed
+	;-DPN532_RF_REST=-1
+	;-DPN532_IRQ=-1
+
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=40
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;Microphone
+	;-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+    -DPIN_CLK=43
+    -DI2S_SCLK_PIN=43
+    -DI2S_DATA_PIN=46
+    -DPIN_DATA=46
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=21
+
+	;Have RTC Chip
+	;-DHAS_RTC=1
+
+	;Speaker to run music, compatible with NS4168
+	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=41
+    -DWCLK=43
+    -DDOUT=42
+
+	;Can run USB as HID
+	;-DUSB_as_HID=1 ;uncomment to enable
+	-DBAD_TX=GROVE_SDA
+	-DBAD_RX=GROVE_SCL
+
+	;Battery ADC read pin
+	;-DBAT_PIN=10
+
+	;Buttons configuration
+	-DHAS_BTN=0
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=0
+	-DBTN_ACT=LOw
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"M5 IR Mod", GROVE_SDA}, {"Pin 1", 1}, {"Pin 2", 2}}'
+	-DIR_RX_PINS='{{"M5 IR Mod", GROVE_SCL}, {"Pin 1", 1}, {"Pin 2", 2}}'
+	-DLED=-1		;NEED TO SET SOMETHING HERE, at least -1
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"M5 RF433T", GROVE_SDA}, {"Pin 1", 1}, {"Pin 2", 2}}'
+	-DRF_RX_PINS='{{"M5 FR433R", GROVE_SCL}, {"Pin 1", 1}, {"Pin 2", 2}}'
+
+    ;CC1101 SPI connection pins
+    ; best connection pins for higher speed https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/spi_master.html#gpio-matrix-and-io-mux
+    ;-DUSE_CC1101_VIA_SPI
+	-DCC1101_GDO0_PIN=9
+	-DCC1101_SS_PIN=10
+	-DCC1101_MOSI_PIN=SPI_MOSI_PIN
+	-DCC1101_SCK_PIN=SPI_SCK_PIN
+	-DCC1101_MISO_PIN=SPI_MISO_PIN
+    ;-DCC1101_GDO2_PIN=14  ; optional
+
+	; connections are the same as CC1101
+	;-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=6
+	-DNRF24_SS_PIN=7  ; chip select
+	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
+	-DNRF24_SCK_PIN=SPI_SCK_PIN
+	-DNRF24_MISO_PIN=SPI_MISO_PIN
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DWIDTH=240
+	-DHEIGHT=135
+	-DBACKLIGHT=38
+	-DMINBRIGHT=160
+
+	;TFT_eSPI Setup
+	-DUSER_SETUP_LOADED=1
+	-DUSE_HSPI_PORT=1
+	-DST7789_2_DRIVER=1
+	-DTFT_RGB_ORDER=1
+	-DTFT_WIDTH=135
+	-DTFT_HEIGHT=240
+	-DTFT_BACKLIGHT_ON=1
+	-DTFT_BL=38
+	-DTFT_RST=33
+	-DTFT_DC=34
+	-DTFT_MOSI=35
+	-DTFT_SCLK=36
+	-DTFT_CS=37
+	-DTOUCH_CS=-1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=20000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=12
+	-DSDCARD_SCK=40
+	-DSDCARD_MISO=39
+	-DSDCARD_MOSI=14
+
+	;Default I2C port
+	-DGROVE_SDA=2
+	-DGROVE_SCL=1
+
+	-DSPI_SCK_PIN=12
+	-DSPI_MOSI_PIN=11
+	-DSPI_MISO_PIN=13
+	-DSPI_SS_PIN=10
+
+lib_deps =
+	${common.lib_deps}
+	xylopyrographer/LiteLED@^1.2.0

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -1,10 +1,13 @@
 #include "config.h"
 #include "sd_functions.h"
 
-
 JsonDocument BruceConfig::toJson() const {
     JsonDocument jsonDoc;
     JsonObject setting = jsonDoc.to<JsonObject>();
+
+    setting["ws2812_red"] = ws2812_r;
+    setting["ws2812_green"] = ws2812_g;
+    setting["ws2812_blue"] = ws2812_b;
 
     setting["priColor"] = String(priColor, HEX);
     setting["secColor"] = String(secColor, HEX);
@@ -72,6 +75,10 @@ void BruceConfig::fromFile() {
 
     JsonObject setting = jsonDoc.as<JsonObject>();
     int count = 0;
+
+    if(!setting["ws2812_red"].isNull()) { ws2812_r = setting["ws2812_red"].as<int>(); } else { count++; log_e("Fail"); }
+    if(!setting["ws2812_green"].isNull()) { ws2812_g = setting["ws2812_green"].as<int>(); } else { count++; log_e("Fail"); }
+    if(!setting["ws2812_blue"].isNull()) { ws2812_b = setting["ws2812_blue"].as<int>(); } else { count++; log_e("Fail"); }
 
     if(!setting["priColor"].isNull())  { priColor  = strtoul(setting["priColor"], nullptr, 16); } else { count++; log_e("Fail"); }
     if(!setting["secColor"].isNull())  { secColor  = strtoul(setting["secColor"], nullptr, 16); } else { count++; log_e("Fail"); }
@@ -187,6 +194,14 @@ void BruceConfig::setRotation(int value) {
 
 void BruceConfig::validateRotationValue() {
     if (rotation!=1 && rotation!=3) rotation = 1;
+}
+
+
+void BruceConfig::set_WS2812_Color(int r, int g, int b) {
+    ws2812_r = r;
+    ws2812_g = g;
+    ws2812_b = b;
+    saveFile();
 }
 
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -33,6 +33,11 @@ public:
 
     const char *filepath = "/bruce.conf";
 
+    // Ws2812 Colors
+    uint8_t ws2812_r;     ///< Red channel value
+    uint8_t ws2812_g;     ///< Green channel value
+    uint8_t ws2812_b;     ///< Blue channel value
+
     // Theme colors in RGB565 format
     uint16_t priColor = DEFAULT_PRICOLOR;
     uint16_t secColor = DEFAULT_PRICOLOR-0x2000;
@@ -83,6 +88,7 @@ public:
 
     void setRotation(int value);
     void validateRotationValue();
+    void set_WS2812_Color(int r, int g, int b);
     void setDimmer(int value);
     void validateDimmerValue();
     void setBright(int value);

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -4,9 +4,20 @@
 #include "core/i2c_finder.h"
 #include "core/wifi_common.h"
 
+#ifdef HAS_WS2812_LED
+#include "core/ws2812.h"
+#endif
+
 void ConfigMenu::optionsMenu() {
     options = {
+        #if defined(CYD) // Brightness control -> Not working yet, don't know why! @Pirata, Delete if from here after you solve this thing
+        {"Brightness",    [=]() { displayWarning("Bright CTRL not working",true);}},
+        #else
         {"Brightness",    [=]() { setBrightnessMenu(); }},
+        #endif
+        #ifdef HAS_WS2812_LED
+        {"WS2812 LED",    [=]() { ws2812_setup(); }},
+        #endif
         {"Dim Time",      [=]() { setDimmerTimeMenu(); }},
         {"Orientation",   [=]() { gsetRotation(true); }},
         {"UI Color",      [=]() { setUIColor(); }},

--- a/src/core/menu_items/OthersMenu.cpp
+++ b/src/core/menu_items/OthersMenu.cpp
@@ -13,6 +13,7 @@
 #include "modules/others/led_control.h"
 #endif
 
+
 void OthersMenu::optionsMenu() {
     options = {
         {"SD Card",      [=]() { loopSD(SD); }},
@@ -24,7 +25,7 @@ void OthersMenu::optionsMenu() {
         {"Mic Spectrum", [=]() { mic_test(); }},
     #endif
         {"BadUSB",       [=]()  { usb_setup(); }},
-        #if defined(HAS_KEYBOARD_HID)
+        #if defined(CARDPUTER)
         {"USB Keyboard", [=]()  { usb_keyboard(); }},
         #endif
     #ifdef HAS_RGB_LED

--- a/src/core/powerSave.cpp
+++ b/src/core/powerSave.cpp
@@ -1,6 +1,10 @@
 #include "powerSave.h"
 #include "settings.h"
 
+#ifdef HAS_WS2812_LED
+#include "ws2812.h"
+#endif
+
 /* Turn off the display */
 void turnOffDisplay() {
   setBrightness(0,false);
@@ -32,6 +36,9 @@ void checkPowerSaveTime(){
       setBrightness(5, false);
     }else if((millis() - previousMillis) >= ((bruceConfig.dimmerSet * 1000) + 5000) && isScreenOff == false && isSleeping == false){
       isScreenOff = true;
+      #ifdef HAS_WS2812_LED
+      ws2812_TurnOff();
+      #endif
       turnOffDisplay();
     }
   }
@@ -40,6 +47,9 @@ void checkPowerSaveTime(){
 /* Put device on sleep mode */
 void sleepModeOn(){
   isSleeping = true;
+  #ifdef HAS_WS2812_LED
+  ws2812_TurnOff();
+  #endif
   setCpuFrequencyMhz(80);
   turnOffDisplay();
   delay(200);
@@ -48,6 +58,9 @@ void sleepModeOn(){
 /* Wake up device */
 void sleepModeOff(){
   isSleeping = false;
+  #ifdef HAS_WS2812_LED
+  ws2812_TurnOn();
+  #endif
   setCpuFrequencyMhz(240);
   getBrightness();
   delay(200);

--- a/src/core/ws2812.cpp
+++ b/src/core/ws2812.cpp
@@ -1,0 +1,85 @@
+#ifdef HAS_WS2812_LED
+
+#include "core/display.h"
+#include "core/globals.h"
+#include <FastLED.h>
+
+CRGB leds[WS2812_NUM_LEDS];
+
+void ws2812_set_color(CRGB c)
+{
+    for(int i = 0; i < WS2812_NUM_LEDS; i++){
+        leds[i] = c;
+    }
+    FastLED.show();
+    bruceConfig.set_WS2812_Color(c.r, c.g, c.b);
+}
+
+void ws2812_set_light(uint8_t light)
+{
+    FastLED.setBrightness(light);
+    FastLED.show();
+}
+
+void ws2812_TurnOff(void)
+{
+    for(int i = 0; i < WS2812_NUM_LEDS; i++){
+        leds[i] = CRGB::Black;
+    }
+    FastLED.show();
+}
+
+void ws2812_TurnOn(void)
+{
+    ws2812_set_color(CRGB(bruceConfig.ws2812_r, bruceConfig.ws2812_g, bruceConfig.ws2812_b));
+}
+
+CRGB hsvToRgb(uint16_t h, uint8_t s, uint8_t v)
+{
+    uint8_t f = (h % 60) * 255 / 60;
+    uint8_t p = (255 - s) * (uint16_t)v / 255;
+    uint8_t q = (255 - f * (uint16_t)s / 255) * (uint16_t)v / 255;
+    uint8_t t = (255 - (255 - f) * (uint16_t)s / 255) * (uint16_t)v / 255;
+    uint8_t r = 0, g = 0, b = 0;
+    switch ((h / 60) % 6) {
+    case 0: r = v; g = t; b = p; break;
+    case 1: r = q; g = v; b = p; break;
+    case 2: r = p; g = v; b = t; break;
+    case 3: r = p; g = q; b = v; break;
+    case 4: r = t; g = p; b = v; break;
+    case 5: r = v; g = p; b = q; break;
+    }
+
+    CRGB c;
+    c.red = r;
+    c.green = g;
+    c.blue = b;
+    return c;
+}
+
+void ws2812_init(void)
+{
+    FastLED.addLeds<WS2812, WS2812_DATA_PIN, GRB>(leds, WS2812_NUM_LEDS);
+    FastLED.setBrightness(WS2812_DEFAULT_LIGHT);   
+}
+
+void ws2812_setup(void)
+{
+    ws2812_init();
+
+    options = {
+        {"OFF", [=]() { ws2812_set_color(CRGB::Black); }},
+        {"PURPLE", [=]() { ws2812_set_color(CRGB::Purple); }},
+        {"WHITE", [=]() { ws2812_set_color(CRGB::White); }},
+        {"RED", [=]() { ws2812_set_color(CRGB::Red); }},
+        {"GREEN", [=]() { ws2812_set_color(CRGB::Green); }},
+        {"BLUE", [=]() { ws2812_set_color(CRGB::Blue); }},
+    };
+    delay(200);
+    loopOptions(options);
+    delay(200);
+}
+
+
+
+#endif

--- a/src/core/ws2812.h
+++ b/src/core/ws2812.h
@@ -1,0 +1,12 @@
+#ifdef HAS_WS2812_LED
+
+#include <FastLED.h>
+
+void ws2812_init(void);
+void ws2812_setup(void);
+void ws2812_set_color(CRGB c);
+void ws2812_set_light(uint8_t light);
+void ws2812_TurnOff(void);
+void ws2812_TurnOn(void);
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,9 @@ BruceConfig bruceConfig;
 
 MainMenu mainMenu;
 SPIClass sdcardSPI;
+#if defined(STICK_C_PLUS) || defined(STICK_C_PLUS2)
 SPIClass CC_NRF_SPI;
-
+#endif
 // Public Globals Variables
 unsigned long previousMillis = millis();
 int prog_handler;    // 0 - Flash, 1 - LittleFS, 3 - Download
@@ -48,15 +49,26 @@ const int bufSize = 1024;
 uint8_t buff[1024] = {0};
 // Protected global variables
 #if defined(HAS_SCREEN)
+  #if defined(M5STACK) && !defined(CORE2) && !defined(CORE)
+  #define tft M5.Lcd
+  M5Canvas sprite(&M5.Lcd);
+  M5Canvas draw(&M5.Lcd);
+  #else
 	TFT_eSPI tft = TFT_eSPI();         // Invoke custom library
 	TFT_eSprite sprite = TFT_eSprite(&tft);
 	TFT_eSprite draw = TFT_eSprite(&tft);
+  #endif
 #else
     SerialDisplayClass tft;
     SerialDisplayClass& sprite = tft;
     SerialDisplayClass& draw = tft;
 #endif
 
+#if defined(CARDPUTER)
+  Keyboard_Class Keyboard = Keyboard_Class();
+#elif defined (STICK_C_PLUS)
+  AXP192 axp192;
+#endif
 
 #include "Wire.h"
 #include "core/display.h"
@@ -68,6 +80,7 @@ uint8_t buff[1024] = {0};
 #include "modules/others/audio.h"  // for playAudioFile
 #include "modules/rf/rf.h"  // for initCC1101once
 #include "modules/bjs_interpreter/interpreter.h" // for JavaScript interpreter
+#include "core/ws2812.h" // for WS2812 Rotary Leds
 
 
 /*********************************************************************
@@ -79,21 +92,122 @@ void begin_storage() {
   setupSdCard();
 }
 
-/*********************************************************************
-**  Function: _setup_gpio()
-**  Sets up a weak (empty) function to be replaced by /ports/* /interface.h
-*********************************************************************/
-void _setup_gpio() __attribute__((weak));
-void _setup_gpio() { }
 
 /*********************************************************************
 **  Function: setup_gpio
 **  Setup GPIO pins
 *********************************************************************/
 void setup_gpio() {
-    //init setup from /ports/*/interface.h
-    _setup_gpio();
+  #if  defined(STICK_C_PLUS2)
+    pinMode(UP_BTN, INPUT);   // Sets the power btn as an INPUT
+    pinMode(SEL_BTN, INPUT);
+    pinMode(DW_BTN, INPUT);
+    pinMode(4, OUTPUT);     // Keeps the Stick alive after take off the USB cable
+    digitalWrite(4,HIGH);   // Keeps the Stick alive after take off the USB cable
+  #elif defined(STICK_C_PLUS)
+    pinMode(SEL_BTN, INPUT);
+    pinMode(DW_BTN, INPUT);
+    axp192.begin();           // Start the energy management of AXP192
+  #elif defined(CARDPUTER)
+    Keyboard.begin();
+    pinMode(0, INPUT);
+    pinMode(10, INPUT);     // Pin that reads the
+  #elif ! defined(HAS_SCREEN)
+    // do nothing
+  #elif defined(M5STACK) // init must be done after tft, to make SDCard work
+    //M5.begin();
+  #elif defined(CYD)
+    pinMode(XPT2046_CS, OUTPUT);
+    //touchSPI.begin(XPT2046_CLK, XPT2046_MISO, XPT2046_MOSI, XPT2046_CS);
+    if(!touch.begin()) {
+        Serial.println("Touch IC not Started");
+        log_i("Touch IC not Started");
+    } else log_i("Touch IC Started");
+    digitalWrite(XPT2046_CS, LOW);
+    // Brightness control -> Not working yet, don't know why! @Pirata
+    pinMode(TFT_BL,OUTPUT);
+    ledcSetup(TFT_BRIGHT_CHANNEL,TFT_BRIGHT_FREQ, TFT_BRIGHT_Bits); //Channel 0, 10khz, 8bits
+    ledcAttachPin(TFT_BL, TFT_BRIGHT_CHANNEL);
+    ledcWrite(TFT_BRIGHT_CHANNEL,255);
 
+  #elif defined(T_EMBED)
+    pinMode(PIN_POWER_ON, OUTPUT);
+    digitalWrite(PIN_POWER_ON, HIGH);
+    #ifdef T_EMBED_1101
+      // T-Embed CC1101 has a antenna circuit optimized to each frequency band, controlled by SW0 and SW1
+      //Set antenna frequency settings
+      pinMode(BOARD_LORA_SW1, OUTPUT);
+      pinMode(BOARD_LORA_SW0, OUTPUT);
+
+      // Chip Select CC1101 to HIGH State
+      pinMode(CC1101_SS_PIN, OUTPUT);
+      digitalWrite(CC1101_SS_PIN,HIGH);
+
+      // Power chip pin
+      pinMode(PIN_POWER_ON, OUTPUT);
+      digitalWrite(PIN_POWER_ON, HIGH);  // Power on CC1101 and LED
+      bool pmu_ret = false;
+      Wire.begin(GROVE_SDA, GROVE_SCL);
+      pmu_ret = PPM.init(Wire, GROVE_SDA, GROVE_SCL, BQ25896_SLAVE_ADDRESS);
+      if(pmu_ret) {
+          PPM.setSysPowerDownVoltage(3300);
+          PPM.setInputCurrentLimit(3250);
+          Serial.printf("getInputCurrentLimit: %d mA\n",PPM.getInputCurrentLimit());
+          PPM.disableCurrentLimitPin();
+          PPM.setChargeTargetVoltage(4208);
+          PPM.setPrechargeCurr(64);
+          PPM.setChargerConstantCurr(832);
+          PPM.getChargerConstantCurr();
+          Serial.printf("getChargerConstantCurr: %d mA\n",PPM.getChargerConstantCurr());
+          PPM.enableADCMeasure();
+          PPM.enableCharge();
+          PPM.enableOTG();
+          PPM.disableOTG();
+      }
+    #else
+      pinMode(BAT_PIN,INPUT); // Battery value
+    #endif
+
+    // Start with default IR, RF and RFID Configs, replace old
+    bruceConfig.rfModule=CC1101_SPI_MODULE;
+    bruceConfig.rfidModule=PN532_I2C_MODULE;
+    bruceConfig.irRx=1;
+    
+    pinMode(BK_BTN, INPUT);
+    pinMode(ENCODER_KEY, INPUT);
+    // use TWO03 mode when PIN_IN1, PIN_IN2 signals are both LOW or HIGH in latch position.
+    encoder = new RotaryEncoder(ENCODER_INA, ENCODER_INB, RotaryEncoder::LatchMode::TWO03);
+
+    // register interrupt routine
+    attachInterrupt(digitalPinToInterrupt(ENCODER_INA), checkPosition, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(ENCODER_INB), checkPosition, CHANGE);
+
+  #elif defined(T_DECK)
+    pinMode(PIN_POWER_ON, OUTPUT);
+    digitalWrite(PIN_POWER_ON, HIGH);
+    pinMode(SEL_BTN, INPUT);
+
+    // Setup for Trackball
+    pinMode(UP_BTN, INPUT_PULLUP);
+    attachInterrupt(UP_BTN, ISR_up, FALLING);
+    pinMode(DW_BTN, INPUT_PULLUP);
+    attachInterrupt(DW_BTN, ISR_down, FALLING);
+    pinMode(L_BTN, INPUT_PULLUP);
+    attachInterrupt(L_BTN, ISR_left, FALLING);
+    pinMode(R_BTN, INPUT_PULLUP);
+    attachInterrupt(R_BTN, ISR_right, FALLING);
+    //pinMode(BACKLIGHT, OUTPUT);
+    //digitalWrite(BACKLIGHT,HIGH);
+
+      // PWM backlight setup
+    // ledcSetup(TFT_BRIGHT_CHANNEL,TFT_BRIGHT_FREQ, TFT_BRIGHT_Bits); //Channel 0, 10khz, 8bits
+    // ledcAttachPin(TFT_BL, TFT_BRIGHT_CHANNEL);
+    // ledcWrite(TFT_BRIGHT_CHANNEL,125);    
+  #else
+    pinMode(UP_BTN, INPUT);   // Sets the power btn as an INPUT
+    pinMode(SEL_BTN, INPUT);
+    pinMode(DW_BTN, INPUT);
+  #endif
 
   #if defined(BACKLIGHT)
   pinMode(BACKLIGHT, OUTPUT);
@@ -111,13 +225,23 @@ void setup_gpio() {
 
 }
 
+
 /*********************************************************************
 **  Function: begin_tft
 **  Config tft
 *********************************************************************/
 void begin_tft(){
-#if defined(HAS_SCREEN)// && !defined(CORE) //Need to test if it will work on Core Fire etc..
+#if defined(HAS_SCREEN) && !defined(M5STACK)
   tft.init();
+#elif defined(CORE2)
+  M5.begin();
+  tft.init();
+#elif defined(CORE)
+  tft.init();
+  M5.begin();
+#elif defined(M5STACK)
+  M5.begin();
+
 #endif
   tft.fillScreen(TFT_BLACK);
   tft.setRotation(bruceConfig.rotation);
@@ -151,22 +275,26 @@ void boot_screen() {
   // Start image loop
   while(millis()<i+7000) { // boot image lasts for 5 secs
   #if !defined(LITE_VERSION)
-    bool drawn=false;
     if((millis()-i>2000) && (millis()-i)<2200){
       tft.fillRect(0,45,WIDTH,HEIGHT-45,bruceConfig.bgColor);
-      if(boot_img && !drawn) {
-        if(showJpeg(SD,"/boot.jpg") && (millis()-i>2000) && (millis()-i<2200)) { boot_img=true; Serial.println("Image from SD"); }
-        else if (showJpeg(LittleFS,"/boot.jpg") && (millis()-i>2000) && (millis()-i<2100)) { boot_img=true; Serial.println("Image from LittleFS"); }
-        else if (showGIF(SD,"/boot.gif") && (millis()-i>2000) && (millis()-i<2200)) { boot_img=true; Serial.println("Image from SD"); }
-        else if (showGIF(LittleFS,"/boot.gif") && (millis()-i>2000) && (millis()-i<2100)) { boot_img=true; Serial.println("Image from LittleFS"); }
-        drawn=true;
-      }
+      if(showJpeg(SD,"/boot.jpg") && (millis()-i>2000) && (millis()-i<2200)) { boot_img=true; Serial.println("Image from SD"); }
+      else if (showJpeg(LittleFS,"/boot.jpg") && (millis()-i>2000) && (millis()-i<2100)) { boot_img=true; Serial.println("Image from LittleFS"); }
+      else if (showGIF(SD,"/boot.gif") && (millis()-i>2000) && (millis()-i<2200)) { boot_img=true; Serial.println("Image from SD"); }
+      else if (showGIF(LittleFS,"/boot.gif") && (millis()-i>2000) && (millis()-i<2100)) { boot_img=true; Serial.println("Image from LittleFS"); }
     }
     if(!boot_img && (millis()-i>2200) && (millis()-i)<2700) tft.drawRect(2*WIDTH/3,HEIGHT/2,2,2,bruceConfig.priColor);
     if(!boot_img && (millis()-i>2700) && (millis()-i)<2900) tft.fillRect(0,45,WIDTH,HEIGHT-45,bruceConfig.bgColor);
-    if(!boot_img && (millis()-i>2900) && (millis()-i)<3400) tft.drawXBitmap(2*WIDTH/3 - 30 ,5+HEIGHT/2,bruce_small_bits, bruce_small_width, bruce_small_height,TFT_BLACK,bruceConfig.priColor);
-    if(!boot_img && (millis()-i>3400) && (millis()-i)<3600) tft.fillRect(0,0,WIDTH,HEIGHT,bruceConfig.bgColor);
-    if(!boot_img && (millis()-i>3600)) tft.drawXBitmap((WIDTH-238)/2,(HEIGHT-133)/2,bits, bits_width, bits_height,TFT_BLACK,bruceConfig.priColor);
+    #if defined(M5STACK)
+      char16_t bgcolor = bruceConfig.bgColor;  // Conversion tor M5GFX variable
+      char16_t priColor = bruceConfig.priColor;// Conversion tor M5GFX variable
+      if(!boot_img && (millis()-i>2900) && (millis()-i)<3400) tft.drawXBitmap(2*WIDTH/3 - 30 ,5+HEIGHT/2,bruce_small_bits, bruce_small_width, bruce_small_height,bgcolor,priColor);
+      if(!boot_img && (millis()-i>3400) && (millis()-i)<3600) tft.fillRect(0,0,WIDTH,HEIGHT,bruceConfig.bgColor);
+      if(!boot_img && (millis()-i>3600)) tft.drawXBitmap((WIDTH-238)/2,(HEIGHT-133)/2,bits, bits_width, bits_height,bgcolor,priColor);
+    #else
+      if(!boot_img && (millis()-i>2900) && (millis()-i)<3400) tft.drawXBitmap(2*WIDTH/3 - 30 ,5+HEIGHT/2,bruce_small_bits, bruce_small_width, bruce_small_height,TFT_BLACK,bruceConfig.priColor);
+      if(!boot_img && (millis()-i>3400) && (millis()-i)<3600) tft.fillRect(0,0,WIDTH,HEIGHT,bruceConfig.bgColor);
+      if(!boot_img && (millis()-i>3600)) tft.drawXBitmap((WIDTH-238)/2,(HEIGHT-133)/2,bits, bits_width, bits_height,TFT_BLACK,bruceConfig.priColor);
+    #endif
   #endif
     if(checkAnyKeyPress())  // If any key or M5 key is pressed, it'll jump the boot screen
     {
@@ -184,7 +312,6 @@ void boot_screen() {
   tft.fillScreen(TFT_BLACK);
 }
 
-
 /*********************************************************************
 **  Function: init_clock
 **  Clock initialisation for propper display in menu
@@ -198,7 +325,6 @@ void init_clock() {
     _rtc.GetTime(&_time);
   #endif
 }
-
 
 /*********************************************************************
 **  Function: startup_sound
@@ -220,7 +346,6 @@ void startup_sound() {
   #endif
 #endif
 }
-
 
 /*********************************************************************
 **  Function: setup
@@ -245,7 +370,7 @@ void setup() {
   BLEConnected=false;
 
   setup_gpio();
-
+  
   #if TFT_MOSI==SDCARD_MOSI // If TFT and SD_Card shares the same SPI Bus, TFT must be initialized before.
     bruceConfig.bright=100; // theres is no value yet
     begin_tft();
@@ -260,6 +385,11 @@ void setup() {
   init_clock();
 
   boot_screen();
+
+  #ifdef HAS_WS2812_LED
+  ws2812_init();
+  ws2812_TurnOn();
+  #endif
 
   startup_sound();
 
@@ -323,7 +453,7 @@ void loop() {
     }
 
     handleSerialCommands();
-#ifdef HAS_KEYBOARD
+#ifdef CARDPUTER
     checkShortcutPress();  // shortctus to quickly start apps without navigating the menus
 #endif
 


### PR DESCRIPTION
**Proposed Changes**
The LEDs on the rotary encoder specific to the Lilygo T-Embed CC1101 can now be configured through the settings menu.

**Types of Changes**
Added functionality for WS2812 LEDs.

**Verification**
Added a couple of files to the core directory and made minor edits to other files. Efforts were made to maintain a clean and consistent structure.

**Testing**
Tested on my personal device, and it works as intended. Further code enhancements are possible, and dimming functionality for the LEDs is not yet implemented.

**Linked Issues**
None.

**User-Facing Change**
None.

**Further Comments**
Error: Cannot compute -> Eaten by shark!!!