### PR TITLE
I improved the build script by adding an option to select the board for compilation.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,13 +1,37 @@
-esptool --chip esp32s3 merge_bin --output Bruce3_Cardputer.bin 0x0 .pio\build\m5stack-cardputer\bootloader.bin 0x8000 .pio\build\m5stack-cardputer\partitions.bin 0x10000 .pio\build\m5stack-cardputer\firmware.bin
+@echo off
+echo ======================================
+echo Select your device to compile:
+echo ======================================
+echo 1. m5stack-cardputer (ESP32-S3)
+echo 2. m5stack-cplus2 (ESP32)
+echo 3. m5stack-cplus1_1 (ESP32)
+echo 4. m5stack-core2 (ESP32)
+echo 5. m5stack-core (ESP32)
+echo 6. m5stack-core4mb (ESP32)
+echo 7. lilygo-t-embed-cc1101 (ESP32-S3)
+echo ======================================
+set /p choice=Enter the number corresponding to your device: 
 
-esptool --chip esp32 merge_bin --output Bruce3_cplus2.bin 0x1000 .pio\build\m5stack-cplus2\bootloader.bin 0x8000 .pio\build\m5stack-cplus2\partitions.bin 0x10000 .pio\build\m5stack-cplus2\firmware.bin
+if "%choice%"=="1" (
+    esptool --chip esp32s3 merge_bin --output Bruce3_Cardputer.bin 0x0 .pio\build\m5stack-cardputer\bootloader.bin 0x8000 .pio\build\m5stack-cardputer\partitions.bin 0x10000 .pio\build\m5stack-cardputer\firmware.bin
+) else if "%choice%"=="2" (
+    esptool --chip esp32 merge_bin --output Bruce3_cplus2.bin 0x1000 .pio\build\m5stack-cplus2\bootloader.bin 0x8000 .pio\build\m5stack-cplus2\partitions.bin 0x10000 .pio\build\m5stack-cplus2\firmware.bin
+) else if "%choice%"=="3" (
+    esptool --chip esp32 merge_bin --output Bruce3_cplus1_1.bin 0x1000 .pio\build\m5stack-cplus1_1\bootloader.bin 0x8000 .pio\build\m5stack-cplus1_1\partitions.bin 0x10000 .pio\build\m5stack-cplus1_1\firmware.bin
+) else if "%choice%"=="4" (
+    esptool --chip esp32 merge_bin --output Bruce3_core2.bin 0x1000 .pio/build/m5stack-core2/bootloader.bin 0x8000 .pio/build/m5stack-core2/partitions.bin 0x10000 .pio/build/m5stack-core2/firmware.bin
+) else if "%choice%"=="5" (
+    esptool --chip esp32 merge_bin --output Bruce3_core.bin 0x1000 .pio/build/m5stack-core/bootloader.bin 0x8000 .pio/build/m5stack-core/partitions.bin 0x10000 .pio/build/m5stack-core/firmware.bin
+) else if "%choice%"=="6" (
+    esptool --chip esp32 merge_bin --output Bruce3_core4mb.bin 0x1000 .pio/build/m5stack-core4mb/bootloader.bin 0x8000 .pio/build/m5stack-core4mb/partitions.bin 0x10000 .pio/build/m5stack-core4mb/firmware.bin
+) else if "%choice%"=="7" (
+    esptool --chip esp32s3 merge_bin --output Bruce3_T-Embed_CC1101.bin 0x0 .pio\build\lilygo-t-embed-cc1101\bootloader.bin 0x8000 .pio\build\lilygo-t-embed-cc1101\partitions.bin 0x10000 .pio\build\lilygo-t-embed-cc1101\firmware.bin
+) else (
+    echo Invalid choice. Please run the script again and choose a valid option.
+    exit /b
+)
 
-esptool --chip esp32 merge_bin --output Bruce3_cplus1_1.bin 0x1000 .pio\build\m5stack-cplus1_1\bootloader.bin 0x8000 .pio\build\m5stack-cplus1_1\partitions.bin 0x10000 .pio\build\m5stack-cplus1_1\firmware.bin
-
-esptool --chip esp32 merge_bin --output Bruce3_core2.bin 0x1000 .pio/build/m5stack-core2/bootloader.bin 0x8000 .pio/build/m5stack-core2/partitions.bin 0x10000 .pio/build/m5stack-core2/firmware.bin
-
-esptool --chip esp32 merge_bin --output Bruce3_core.bin 0x1000 .pio/build/m5stack-core/bootloader.bin 0x8000 .pio/build/m5stack-core/partitions.bin 0x10000 .pio/build/m5stack-core/firmware.bin
-
-esptool --chip esp32 merge_bin --output Bruce3_core4mb.bin 0x1000 .pio/build/m5stack-core4mb/bootloader.bin 0x8000 .pio/build/m5stack-core4mb/partitions.bin 0x10000 .pio/build/m5stack-core4mb/firmware.bin
-
-esptool --chip esp32s3 merge_bin --output Bruce3_T-Embed_CC1101.bin 0x0 .pio\build\lilygo-t-embed-cc1101\bootloader.bin 0x8000 .pio\build\lilygo-t-embed-cc1101\partitions.bin 0x10000 .pio\build\lilygo-t-embed-cc1101\firmware.bin
+echo ======================================
+echo Build complete for selected device.
+echo ======================================
+pause


### PR DESCRIPTION
#### Proposed Changes

This pull request introduces an interactive menu for the `build.bat` script, allowing users to select the target device for compilation. This improvement simplifies the process of building binaries for specific devices by reducing manual editing of the script and minimizing errors.

#### Types of Changes

- **New Feature**: Added an interactive menu for device selection in `build.bat`.
- **Usability Improvement**: Streamlined the compilation workflow for easier use.

#### Verification

The changes can be verified by:
1. Running the updated `build.bat` script.
2. Selecting a device from the displayed menu.
3. Ensuring the correct binary is compiled for the selected device.

#### Testing

This change has been manually tested by:
1. Running the script for all available device options.
2. Confirming that the correct binaries are generated in each case.

Automated testing is not implemented, but manual verification steps are provided.

#### Linked Issues

No specific issue is linked to this pull request. However, this addresses general usability improvements for the build process.

#### User-Facing Change

```release-note
The `build.bat` script now features an interactive menu, allowing users to select the target device for compilation without modifying the script directly.
```

#### Further Comments
"""
This enhancement improves user experience and reduces potential errors during the build process. Future updates could include additional devices or automated testing for further reliability.
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

