### PR TITLE
fix IO6 Button func on t-embed-cc1101

### DIFF
--- a/ports/lilygo-t-embed-cc1101/interface.cpp
+++ b/ports/lilygo-t-embed-cc1101/interface.cpp
@@ -455,12 +455,7 @@ String keyboard(String mytext, int maxSize, String msg) {
     /* Down Btn to move in X axis (to the right) */
     if(checkNextPress())
     {
-      // To handle Encoder devices such as T-EMBED
-      #ifdef T_EMBED_1101
-      if(digitalRead(BK_BTN) == BTN_ACT) { y++; }
-      #else
       if(x==11) { y++; x++; }
-      #endif
       else x++;
 
       if(y>3) { y=-1; }
@@ -473,12 +468,7 @@ String keyboard(String mytext, int maxSize, String msg) {
     }
     /* UP Btn to move in Y axis (Downwards) */
     if(checkPrevPress()) {
-      // To handle Encoder devices such as T-EMBED
-      #ifdef T_EMBED_1101
-      if(digitalRead(BK_BTN) == BTN_ACT) { y--; }
-      #else
       if(x==0) { y--; x--; }
-      #endif
       else x--;
 
       if(y<0 && x<0) x=3;
@@ -490,7 +480,17 @@ String keyboard(String mytext, int maxSize, String msg) {
       else if(y<-1) y=3;
       redraw = true;
     }
-
+    #ifdef T_EMBED_1101
+    /* UP Btn to move in Y axis (Downwards) */
+    if(digitalRead(BK_BTN) == BTN_ACT) {
+      delay(200);
+      if(digitalRead(BK_BTN) == BTN_ACT) { y--; delay(250);  }// Long press
+      else y++; // short press
+      if(y>3) { y=-1; }
+      else if(y<-1) y=3;
+      redraw = true;
+    }
+    #endif
   }
 
   //Resets screen when finished writing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,6 +332,11 @@ void loop() {
     checkShortcutPress();  // shortctus to quickly start apps without navigating the menus
 #endif
 
+#ifdef T_EMBED_1101
+    if (checkEscPress()) {
+      checkReboot();
+    }
+#endif
     if (checkPrevPress()) {
       checkReboot();
       mainMenu.previous();


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Currently, the following functions for IO6Button（top right button） do not seem to be working.

- Power Off
- Move in the y direction on the Keyboard screen (ex, input wifi password)

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Verify below
- if the power is turned off when we press the IO6 button for a long time.
- When we press the IO6 button briefly on the keyboard screen, it moves in the +y direction, and when we press it long, it moves in the -y direction.

#### Testing ####

I tested it on t-embed-cc1101

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

NONE

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

