### PR TITLE
small improvement for loop options

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -244,6 +244,7 @@ void padprintln(double n, int digits, int16_t padx) {
 **  Where you choose among the options in menu
 **********************************************************************/
 int loopOptions(std::vector<Option>& options, bool bright, bool submenu, String subText,int index){
+  delay(200);
   bool redraw = true;
   int menuSize = options.size();
   if(options.size()>MAX_MENU_SIZE) {


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

When loop options are nested, they are not processed correctly on LILYGO t-embed (SEL is automatically pressed on sub options)
ex. WiFi -> Scan hosts -> host -> sub options for host

![IMG_0138](https://github.com/user-attachments/assets/13834bbc-2c15-4435-b988-6d132bb2442b)


#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->


Verify if the scan host sub options is displayed correctly on t-embed 

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

