### PR TITLE
added setting to hide menu items, moved file manager to top-level

### DIFF
--- a/sd_files/interpreter/ir2keys.js
+++ b/sd_files/interpreter/ir2keys.js
@@ -7,42 +7,55 @@
 var running=true;
 badusbSetup();
 
-while(running) {    
+while(true) {    
+    fillScreen(0);
+    drawString("waiting for IR signals...", 3 , 0);
     print("waiting for IR signals...", 0 , 0);
+    drawString(curr_val, 3 , 16);
+    drawString("hold any key to stop", 3 , 32);
+    
+    if(getAnyPress()) break;
+    var cmd = serialReadln(1);
+    if(cmd.trim()!="") break;
+    
     var curr_ir_signal = irRead(1); // 1s timeout
     
     print("received:");
     print(curr_ir_signal);
     
     if(curr_ir_signal) {
+
+        // example full cmd: IRSend {"Protocol":"NEC","Bits":32,"Data":"0x20DF10EF"}
+        serialCmd("IRSend {\"Protocol\":\"" + protocol + "\",\"Bits\":32,\"Data\":\"0x" + curr_val + "\"}");
+            
+        delay(delay_ms);
+        fillScreen(0);
+        
         // switch on curr_ir_signal
         //  https://github.com/espressif/arduino-esp32/blob/master/libraries/USB/src/USBHIDConsumerControl.h
-        if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: B0 00 00 00")) {
+        if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: B0 00 00 00")) {  // CUSTOMIZE FOR YOUR REMOTE
             print("pressed play");
             //badusbPress(0x20);  // KEY_SPACE
             badusbPress(0x2c);  // KEY_SPACE
             //badusbPressSpecial(0x00CD);  // HID_USAGE_CONSUMER_PLAY_PAUSE
         }
-        else if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: 8E 00 00 00")) {
+        else if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: 8E 00 00 00")) {  // CUSTOMIZE FOR YOUR REMOTE
             print("pressed next");
             badusbPrint("n");  // vlc next shortcut
             badusbPressRaw(0x11);  // HID_KEY_N
             //badusbPressSpecial(0x00B5); // HID_USAGE_CONSUMER_SCAN_NEXT
         }
-        else if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: 8F 00 00 00")) {
+        else if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: 8F 00 00 00")) {  // CUSTOMIZE FOR YOUR REMOTE
             print("pressed prev");
             badusbPrint("p");  // vlc next shortcut
             badusbPressRaw(0x13);  // HID_KEY_P
             //badusbPressSpecial(0x00B6);  // HID_USAGE_CONSUMER_SCAN_PREVIOUS
         }
-        else if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: 8F 00 00 00")) {
+        else if(curr_ir_signal.includes("address: 04 00 00 00\ncommand: 8F 00 00 00")) {  // CUSTOMIZE FOR YOUR REMOTE
             print("pressed stop");
             //badusbPressSpecial(0x00B7);  // HID_USAGE_CONSUMER_STOP
         }
         else
             print("unknown button pressed");
     }
-    
-    var cmd = serialReadln(10);
-    if(cmd.trim()=="q") running=false;
 }

--- a/sd_files/interpreter/wifi_brute.js
+++ b/sd_files/interpreter/wifi_brute.js
@@ -23,7 +23,7 @@ while(true)
   var passwords_to_try_arr = [];
   
   var choice = dialogChoice([
-    "Scan Networks", "scan",
+    "Select AP", "scan",
     "Load dict", "load",
     "Start attack", "attack",
     ]

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -29,7 +29,7 @@ JsonDocument BruceConfig::toJson() const {
     for (const auto& pair : wifi) {
         _wifi[pair.first] = pair.second;
     }
-
+    
     setting["irTx"] = irTx;
     setting["irRx"] = irRx;
 
@@ -45,6 +45,11 @@ JsonDocument BruceConfig::toJson() const {
     setting["startupApp"] = startupApp;
     setting["wigleBasicToken"] = wigleBasicToken;
     setting["devMode"] = devMode;
+    
+    JsonArray dm = setting.createNestedArray("disabledMenus");
+    for(int i=0; i < disabledMenus.size(); i++){
+        dm.add(disabledMenus[i]);
+    }
 
     return jsonDoc;
 }
@@ -119,6 +124,14 @@ void BruceConfig::fromFile() {
     if(!setting["wigleBasicToken"].isNull()) { wigleBasicToken  = setting["wigleBasicToken"].as<String>(); } else { count++; log_e("Fail"); }
     if(!setting["devMode"].isNull())         { devMode  = setting["devMode"].as<int>(); } else { count++; log_e("Fail"); }
 
+    if(!setting["disabledMenus"].isNull()) {
+        disabledMenus.clear();
+        JsonArray dm = setting["disabledMenus"].as<JsonArray>();
+        for (JsonVariant e : dm) {
+            disabledMenus.push_back(e.as<String>());
+        }
+    } else { count++; log_e("Fail"); }
+        
     validateConfig();
     if (count>0) saveFile();
 
@@ -383,4 +396,11 @@ void BruceConfig::setDevMode(int value) {
 
 void BruceConfig::validateDevModeValue() {
     if (devMode > 1) devMode = 1;
+}
+
+
+void BruceConfig::addDisabledMenu(String value) {
+    // TODO: check if duplicate
+    disabledMenus.push_back(value);
+    saveFile();
 }

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -5,6 +5,7 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <map>
+#include <vector>
 
 #define DEFAULT_PRICOLOR 0xA80F
 
@@ -64,6 +65,8 @@ public:
     String startupApp = "";
     String wigleBasicToken = "";
     int devMode = 0;
+    
+    std::vector<String> disabledMenus = {};
 
     /////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -119,7 +122,8 @@ public:
     void setWigleBasicToken(String value);
     void setDevMode(int value);
     void validateDevModeValue();
-
+    void addDisabledMenu(String value);
+    // TODO: removeDisabledMenu(String value);
 };
 
 #endif

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -1017,6 +1017,8 @@ bool showGIF(FS fs, String filename, int x, int y) {
     return true;
   }
   displayError("error opening GIF");
+#else
+  displayError("GIF unsupported on this device");
 #endif
   return false;
 }

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -816,12 +816,13 @@ bool showJpeg(FS fs, String filename, int x, int y) {
 #include <AnimatedGIF.h>
 
 #define NORMAL_SPEED
+#define GIF_BUFFER_SIZE 100
 //#define USE_DMA
 
 #ifdef USE_DMA
-  uint16_t usTemp[2][SAFE_STACK_BUFFER_SIZE]; // Global to support DMA use
+  uint16_t usTemp[2][GIF_BUFFER_SIZE]; // Global to support DMA use
 #else
-  uint16_t usTemp[1][SAFE_STACK_BUFFER_SIZE];    // Global to support DMA use
+  uint16_t usTemp[1][GIF_BUFFER_SIZE];    // Global to support DMA use
 #endif
 bool     dmaBuf = 0;
 
@@ -864,7 +865,7 @@ void GIFDraw(GIFDRAW *pDraw)
     {
       c = ucTransparent - 1;
       d = &usTemp[0][0];
-      while (c != ucTransparent && s < pEnd && iCount < SAFE_STACK_BUFFER_SIZE )
+      while (c != ucTransparent && s < pEnd && iCount < GIF_BUFFER_SIZE )
       {
         c = *s++;
         if (c == ucTransparent) // done, stop
@@ -904,10 +905,10 @@ void GIFDraw(GIFDRAW *pDraw)
 
     // Unroll the first pass to boost DMA performance
     // Translate the 8-bit pixels through the RGB565 palette (already byte reversed)
-    if (iWidth <= SAFE_STACK_BUFFER_SIZE)
+    if (iWidth <= GIF_BUFFER_SIZE)
       for (iCount = 0; iCount < iWidth; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
     else
-      for (iCount = 0; iCount < SAFE_STACK_BUFFER_SIZE; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
+      for (iCount = 0; iCount < GIF_BUFFER_SIZE; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
 
 #ifdef USE_DMA // 71.6 fps (ST7796 84.5 fps)
     tft.dmaWait();
@@ -924,10 +925,10 @@ void GIFDraw(GIFDRAW *pDraw)
     while (iWidth > 0)
     {
       // Translate the 8-bit pixels through the RGB565 palette (already byte reversed)
-      if (iWidth <= SAFE_STACK_BUFFER_SIZE)
+      if (iWidth <= GIF_BUFFER_SIZE)
         for (iCount = 0; iCount < iWidth; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
       else
-        for (iCount = 0; iCount < SAFE_STACK_BUFFER_SIZE; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
+        for (iCount = 0; iCount < GIF_BUFFER_SIZE; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
 
 #ifdef USE_DMA
       tft.dmaWait();
@@ -945,7 +946,7 @@ void * GIFOpenFile(const char *fname, int32_t *pSize)
 {
   static File FSGifFile;  // MEMO: declared static to survive return
   if(SD.exists(fname)) FSGifFile = SD.open(fname);
-  if(LittleFS.exists(fname)) FSGifFile = LittleFS.open(fname);
+  else if(LittleFS.exists(fname)) FSGifFile = LittleFS.open(fname);
   if (FSGifFile) {
     *pSize = FSGifFile.size();
     return (void *)&FSGifFile;
@@ -994,7 +995,8 @@ int32_t GIFSeekFile(GIFFILE *pFile, int32_t iPosition)
 }
 
 bool showGIF(FS fs, String filename, int x, int y) {
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
+//#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CARDPUTER)
   if(!fs.exists(filename))
     return false;
   static AnimatedGIF gif;  // MEMO: triggers stack canary if not static

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -5,6 +5,7 @@
 
 MainMenu::MainMenu() {
     _menuItems = {
+        &fileMenu,
         &wifiMenu,
         &bleMenu,
         &rfMenu,
@@ -37,6 +38,7 @@ MainMenu::~MainMenu() {}
 void MainMenu::previous(){
     _currentIndex--;
     if (_currentIndex < 0) _currentIndex = _totalItems - 1;
+    _checkDisabledMenus(false);
 }
 
 /***************************************************************************************
@@ -46,6 +48,7 @@ void MainMenu::previous(){
 void MainMenu::next(){
     _currentIndex++;
     if (_currentIndex >= _totalItems) _currentIndex = 0;
+    _checkDisabledMenus(true);
 }
 
 
@@ -56,7 +59,6 @@ void MainMenu::next(){
 void MainMenu::openMenuOptions(){
     _menuItems[_currentIndex]->optionsMenu();
 }
-
 
 /***************************************************************************************
 ** Function name: draw
@@ -82,4 +84,19 @@ void MainMenu::draw() {
     #if defined(HAS_TOUCH)
     TouchFooter();
     #endif
+}
+
+
+void MainMenu::_checkDisabledMenus(bool next_button) {
+    MenuItemInterface* current_menu = _menuItems[_currentIndex];
+    std::vector<String> l = bruceConfig.disabledMenus;
+
+    String currName = current_menu->getName();
+    if( find(l.begin(), l.end(), currName)!=l.end() ) {
+        // menu disabled, skip to the next/prev one and re-check
+        if(next_button)
+            next();
+        else
+            previous();
+    }
 }

--- a/src/core/main_menu.h
+++ b/src/core/main_menu.h
@@ -3,6 +3,7 @@
 
 #include "menu_items/MenuItemInterface.h"
 
+#include "menu_items/FileMenu.h"
 #include "menu_items/BleMenu.h"
 #include "menu_items/ClockMenu.h"
 #include "menu_items/ConfigMenu.h"
@@ -19,6 +20,7 @@
 
 class MainMenu {
 public:
+    FileMenu fileMenu;
     BleMenu bleMenu;
     ClockMenu clockMenu;
     ConnectMenu connectMenu;
@@ -46,6 +48,7 @@ private:
     int _currentIndex = 0;
     int _totalItems = 0;
     std::vector<MenuItemInterface*> _menuItems;
+    void _checkDisabledMenus(bool next_button);
 };
 
 #endif

--- a/src/core/menu_items/FileMenu.cpp
+++ b/src/core/menu_items/FileMenu.cpp
@@ -1,0 +1,26 @@
+#include "FileMenu.h"
+#include "core/display.h"
+#include "core/sd_functions.h"
+
+void FileMenu::optionsMenu() {
+    options = {
+        {"SD Card",      [=]() { loopSD(SD); }},
+        {"LittleFS",     [=]() { loopSD(LittleFS); }},
+        {"Main Menu",    [=]() { backToMenu(); }},
+    };
+
+    delay(200);
+    loopOptions(options,false,true,"Files");
+}
+
+String FileMenu::getName() {
+    return _name;
+}
+
+void FileMenu::draw() {
+    tft.fillRect(iconX,iconY,80,80,bruceConfig.bgColor);
+
+    tft.drawRect(15+iconX, 5+iconY, 50, 70, bruceConfig.priColor);
+    tft.fillRect(50+iconX, 5+iconY, 15, 15, bruceConfig.bgColor);
+    tft.drawTriangle(50+iconX, 5+iconY, 50+iconX, 19+iconY, 64+iconX, 19+iconY, bruceConfig.priColor);
+}

--- a/src/core/menu_items/FileMenu.cpp
+++ b/src/core/menu_items/FileMenu.cpp
@@ -1,11 +1,13 @@
 #include "FileMenu.h"
 #include "core/display.h"
 #include "core/sd_functions.h"
+#include "modules/others/webInterface.h"
 
 void FileMenu::optionsMenu() {
     options = {
         {"SD Card",      [=]() { loopSD(SD); }},
         {"LittleFS",     [=]() { loopSD(LittleFS); }},
+        {"WebUI",        [=]() { loopOptionsWebUi(); }},
         {"Main Menu",    [=]() { backToMenu(); }},
     };
 

--- a/src/core/menu_items/FileMenu.h
+++ b/src/core/menu_items/FileMenu.h
@@ -1,0 +1,17 @@
+#ifndef __FILE_MENU_H__
+#define __FILE_MENU_H__
+
+#include "MenuItemInterface.h"
+
+
+class FileMenu : public MenuItemInterface {
+public:
+    void optionsMenu(void);
+    void draw(void);
+    String getName(void);
+
+private:
+    String _name = "Files";
+};
+
+#endif

--- a/src/core/menu_items/OthersMenu.cpp
+++ b/src/core/menu_items/OthersMenu.cpp
@@ -16,8 +16,8 @@
 
 void OthersMenu::optionsMenu() {
     options = {
-        {"SD Card",      [=]() { loopSD(SD); }},
-        {"LittleFS",     [=]() { loopSD(LittleFS); }},
+        //{"SD Card",      [=]() { loopSD(SD); }},
+        //{"LittleFS",     [=]() { loopSD(LittleFS); }},
         {"WebUI",        [=]() { loopOptionsWebUi(); }},
         {"QRCodes",      [=]() { qrcode_menu(); }},
         {"GPS Tracker",  [=]() { GPSTracker(); }},

--- a/src/core/menu_items/OthersMenu.cpp
+++ b/src/core/menu_items/OthersMenu.cpp
@@ -16,8 +16,8 @@
 
 void OthersMenu::optionsMenu() {
     options = {
-        //{"SD Card",      [=]() { loopSD(SD); }},
-        //{"LittleFS",     [=]() { loopSD(LittleFS); }},
+        {"SD Card",      [=]() { loopSD(SD); }},
+        {"LittleFS",     [=]() { loopSD(LittleFS); }},
         {"WebUI",        [=]() { loopOptionsWebUi(); }},
         {"QRCodes",      [=]() { qrcode_menu(); }},
         {"GPS Tracker",  [=]() { GPSTracker(); }},

--- a/src/core/serialcmds.cpp
+++ b/src/core/serialcmds.cpp
@@ -796,6 +796,7 @@ bool processSerialCommand(String cmd_str) {
     if(setting_name=="rfidModule") bruceConfig.setRfidModule(static_cast<RFIDModules>(setting_value.toInt()));
     if(setting_name=="wigleBasicToken") bruceConfig.setWigleBasicToken(setting_value);
     if(setting_name=="devMode") bruceConfig.setDevMode(setting_value.toInt());
+    if(setting_name=="disabledMenus") bruceConfig.addDisabledMenu(setting_value);
     return true;
   }
 

--- a/src/core/serialcmds.cpp
+++ b/src/core/serialcmds.cpp
@@ -482,7 +482,7 @@ bool processSerialCommand(String cmd_str) {
       if(!filepath.startsWith("/")) filepath = "/" + filepath;  // add "/" if missing
       FS* fs = NULL;
       if(SD.exists(filepath)) fs = &SD;
-      if(LittleFS.exists(filepath)) fs = &LittleFS;
+      else if(LittleFS.exists(filepath)) fs = &LittleFS;
       if(!fs) return false;  // file not found
       Kb.begin();
       USB.begin();
@@ -890,7 +890,7 @@ bool processSerialCommand(String cmd_str) {
     if(!filepath.startsWith("/")) filepath = "/" + filepath;  // add "/" if missing
     FS* fs = NULL;
     if(SD.exists(filepath)) fs = &SD;
-    if(LittleFS.exists(filepath)) fs = &LittleFS;
+    else if(LittleFS.exists(filepath)) fs = &LittleFS;
     if(!fs) return false;
     // else
     if(cmd_str.startsWith("storage read ")) {
@@ -915,7 +915,7 @@ bool processSerialCommand(String cmd_str) {
     if(!filepath.startsWith("/")) filepath = "/" + filepath;  // add "/" if missing
     FS* fs = NULL;
     if(SD.exists(filepath)) fs = &SD;
-    if(LittleFS.exists(filepath)) fs = &LittleFS;
+    else if(LittleFS.exists(filepath)) fs = &LittleFS;
     if(!fs) return false;  // file not found
     File file = fs->open(filepath, FILE_READ);
     if (!file) return false;
@@ -969,7 +969,7 @@ bool processSerialCommand(String cmd_str) {
     if(!filepath.startsWith("/")) filepath = "/" + filepath;  // add "/" if missing
     FS* fs = NULL;
     if(SD.exists(filepath)) fs = &SD;
-    if(LittleFS.exists(filepath)) fs = &LittleFS;
+    else if(LittleFS.exists(filepath)) fs = &LittleFS;
     if(!fs) return false;  // dir not found
     File root = fs->open(filepath);
     if (!root || !root.isDirectory()) return false; // not a dir
@@ -1005,8 +1005,8 @@ bool processSerialCommand(String cmd_str) {
     filepath.trim();
     if(filepath.length()==0) return false;  // missing arg
     if(!filepath.startsWith("/")) filepath = "/" + filepath;  // add "/" if missing
-    if(!SD.exists(filepath)) return SD.mkdir(filepath);
-    if(!LittleFS.exists(filepath)) return LittleFS.mkdir(filepath);
+    if(sdcardMounted && !SD.exists(filepath)) return SD.mkdir(filepath);
+    else if(!LittleFS.exists(filepath)) return LittleFS.mkdir(filepath);
     // else
     return false;
   }
@@ -1016,9 +1016,7 @@ bool processSerialCommand(String cmd_str) {
     if(filepath.length()==0) return false;  // missing arg
     if(!filepath.startsWith("/")) filepath = "/" + filepath;  // add "/" if missing
     FS* fs = &LittleFS; // default fallback
-    if(SD.exists(filepath)) fs = &SD;
-    if(LittleFS.exists(filepath)) fs = &LittleFS;
-    if(!fs && sdcardMounted) fs = &SD;
+    if(sdcardMounted) fs = &SD;
     String txt = readSmallFileFromSerial();
     if(txt.length()==0) return false;
     File f = fs->open(filepath, FILE_APPEND, true);  // create if it does not exist, append otherwise
@@ -1090,7 +1088,7 @@ bool processSerialCommand(String cmd_str) {
     //if(!filepath.startsWith("/")) filepath = "/" + filepath;  // add "/" if missing
     FS* fs = NULL;
     if(SD.exists(filepath)) fs = &SD;
-    if(LittleFS.exists(filepath)) fs = &LittleFS;
+    else if(LittleFS.exists(filepath)) fs = &LittleFS;
     if(!fs) {   // dir not found
       // assume filepath is an inline script
       Serial.println(filepath);
@@ -1128,7 +1126,7 @@ bool processSerialCommand(String cmd_str) {
     if(cmd_str.startsWith("crypto decrypt_from_file") || cmd_str.startsWith("crypto type_from_file")) {
       FS* fs = NULL;
       if(SD.exists(filepath)) fs = &SD;
-      if(LittleFS.exists(filepath)) fs = &LittleFS;
+      else if(LittleFS.exists(filepath)) fs = &LittleFS;
       if(!fs) return false;  // file not found
       String plaintext = readDecryptedFile(*fs, filepath);
       if(plaintext=="") return false;
@@ -1146,7 +1144,7 @@ bool processSerialCommand(String cmd_str) {
       String txt = readSmallFileFromSerial();
       if(txt.length()==0) return false;
       FS* fs = &SD;
-      if(LittleFS.exists(filepath)) fs = &LittleFS;
+      if(!sdcardMounted) fs = &LittleFS;
       File f = fs->open(filepath, FILE_WRITE);
       if(!f) return false;
       String cyphertxt = encryptString(txt, cachedPassword);

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -131,7 +131,8 @@ void IrRead::read_signal() {
 
     // switch to raw mode if decoding failed
     if(results.decode_type == decode_type_t::UNKNOWN ) {
-        displayWarning("signal decoding failed, switching to RAW mode", true);
+        Serial.println("signal decoding failed, switching to RAW mode");
+        //displayWarning("signal decoding failed, switching to RAW mode", true);
         raw = true;
         // TODO: show a dialog
         // raw = yesNoDialog("decoding failed, save as RAW?");

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -131,8 +131,7 @@ void IrRead::read_signal() {
 
     // switch to raw mode if decoding failed
     if(results.decode_type == decode_type_t::UNKNOWN ) {
-        //displayWarning("signal decoding failed, switching to RAW mode", true);
-        Serial.println("signal decoding failed, switching to RAW mode");
+        displayWarning("signal decoding failed, switching to RAW mode", true);
         raw = true;
         // TODO: show a dialog
         // raw = yesNoDialog("decoding failed, save as RAW?");

--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -756,7 +756,8 @@ RestartRec:
             #ifndef HAS_SCREEN
                 // switch to raw mode if decoding failed
                 if(received.preset == 0) {
-                    displayWarning("signal decoding failed, switching to RAW mode", true);
+                    Serial.println("signal decoding failed, switching to RAW mode");
+                    //displayWarning("signal decoding failed, switching to RAW mode", true);
                     raw = true;
                     // TODO: show a dialog/warning?
                     // raw = yesNoDialog("decoding failed, save as RAW?");


### PR DESCRIPTION
Added:
-  setting to disable menu items, moved file manager to top-level https://github.com/pr3y/Bruce/issues/326

Currently this setting is unexposed in the "Config" menu, it can be used by editing `bruce.conf` manually or via serial cmds:

````
set disabledMenus Connect
set disabledMenus FM
set disabledMenus NRF24
````

Will add this setting array:
````
{
....
  "disabledMenus": [
    "Connect",
    "FM",
    "NRF24"
  ]
}
````

Fixes:

 - prioritize SD over LittleFS in some serialcmds
 - disabled GIF support on non-Cardputer devices (not working/freezing)