### PR TITLE
Refactor BLE Menu Options and Reposition "Press to Act" Display in WiFi Information

### DIFF
--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -7,34 +7,39 @@
 
 void BleMenu::optionsMenu() {
     options.clear();
-   if(BLEConnected) options.push_back({"Disconnect",     [=]() {
-        BLEDevice::deinit();
-        BLEConnected=false;
-        if(Ask_for_restart==1) Ask_for_restart=2; // Sets the variable to ask for restart;
-    }});
 
-        options.push_back({"Media Cmds",     [=]() { ble_MediaCommands(); }});
+    if (BLEConnected) {
+        options.push_back({"Disconnect", [=]() {
+            BLEDevice::deinit();
+            BLEConnected = false;
+            if (Ask_for_restart == 1) Ask_for_restart = 2;
+        }});
+    }
+
+    options.push_back({"Media Cmds", [=]() { ble_MediaCommands(); }});
+
     #if !defined(LITE_VERSION)
-        // options.push_back({"BLE Beacon",   [=]() { ble_test(); }});
-        options.push_back({"BLE Scan",     [=]() { ble_scan(); }});
-        options.push_back({"Bad BLE",      [=]() { ble_setup(); }});
+        options.push_back({"BLE Scan", [=]() { ble_scan(); }});
+        options.push_back({"Bad BLE", [=]() { ble_setup(); }});
     #endif
+
     #if defined(HAS_KEYBOARD_HID)
         options.push_back({"BLE Keyboard", [=]() { ble_keyboard(); }});
     #endif
-    options.push_back({"iOS Spam",     [=]() { aj_adv(0); }});
-    options.push_back({"Windows Spam", [=]() { aj_adv(1); }});
-    options.push_back({"Samsung Spam", [=]() { aj_adv(2); }});
-    options.push_back({"Android Spam", [=]() { aj_adv(3); }});
-    options.push_back({"Spam All",     [=]() { aj_adv(4); }});
-    options.push_back({"Main Menu",    [=]() { backToMenu(); }});
+
+    const char* spamLabels[] = {"iOS Spam", "Windows Spam", "Samsung Spam", "Android Spam", "Spam All"};
+    for (int i = 0; i < 5; i++) options.push_back({spamLabels[i], [=]() { aj_adv(i); }});
+
+    options.push_back({"Main Menu", [=]() { backToMenu(); }});
+
     delay(200);
-    loopOptions(options,false,true,"Bluetooth");
+    loopOptions(options, false, true, "Bluetooth");
 }
 
 String BleMenu::getName() {
     return _name;
 }
+
 
 void BleMenu::draw() {
     tft.fillRect(iconX,iconY,80,80,bruceConfig.bgColor);

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -82,7 +82,7 @@ void wifi_atk_info(String tssid, String mac, uint8_t channel)
   tft.drawString("AP: " + tssid, 10, 48);
   tft.drawString("Channel: " + String(channel), 10, 66);
   tft.drawString(mac, 10, 84);
-  tft.drawString("Press " + String(BTN_ALIAS) + " to act", 10, tft.height() - 20);
+  tft.drawString("Press " + String(BTN_ALIAS) + " to act", 10, 102);
 
   delay(300);
   while (!checkSelPress())

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -82,7 +82,9 @@ void wifi_atk_info(String tssid, String mac, uint8_t channel)
   tft.drawString("AP: " + tssid, 10, 48);
   tft.drawString("Channel: " + String(channel), 10, 66);
   tft.drawString(mac, 10, 84);
-  tft.drawString("Press " + String(BTN_ALIAS) + " to act", 10, 102);
+  #if !defined(HAS_TOUCH)
+    tft.drawString("Press " + String(BTN_ALIAS) + " to act", 10, 102);
+  #endif
 
   delay(300);
   while (!checkSelPress())

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -83,7 +83,7 @@ void wifi_atk_info(String tssid, String mac, uint8_t channel)
   tft.drawString("Channel: " + String(channel), 10, 66);
   tft.drawString(mac, 10, 84);
   #if !defined(HAS_TOUCH)
-    tft.drawString("Press " + String(BTN_ALIAS) + " to act", 10, 102);
+    tft.drawString("Press " + String(BTN_ALIAS) + " to act", 10, tft.height() - 20);
   #endif
 
   delay(300);


### PR DESCRIPTION
#### Proposed Changes ####
Streamlined the BLE menu options for better usability and adjusted the "Press to Act" display position to improve UI clarity and alignment.

#### Types of Changes ####
- Refactor
- UI/UX Enhancement

#### Verification ####
The changes can be verified by:
1. Navigating to the BLE menu.
2. Ensuring the options are streamlined and no longer redundant. (in code)
3. Checking that the "Press to Act" text is correctly positioned as intended.

#### Testing ####
Manual testing was conducted to verify:
- The BLE menu displays the updated options without like before and works.
- The "Press to Act" text is in its new position across only on CYD.

#### Linked Issues ####
NONE

#### User-Facing Change ####
```release-note
The BLE menu options are now more streamlined, and the "Press to Act" text has been repositioned for better readability (was bugged out for CYD).
```

#### Further Comments ####
Small refactor nothing big 😄 