### PR TITLE
Bug Fixes: NEC Extended Encoding Issue (custom_ir.cpp) and Last Captured Signal appearing after the Device Save (ir_read.cpp)

### DIFF
--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -329,8 +329,8 @@ void otherIRcodes() {
     else if(codes[i].protocol.startsWith("RC6"))    options.push_back({ codes[i].name.c_str(), [=](){ sendRC6Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol.startsWith("Samsung")) options.push_back({ codes[i].name.c_str(), [=](){ sendSamsungCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="SIRC")   options.push_back({ codes[i].name.c_str(), [=](){ sendSonyCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
-    else if(codes[i].protocol!="" && codes[i].data!="")   options.push_back({ codes[i].name.c_str(), [=](){ sendDecodedCommand(codes[i].protocol, codes[i].data); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="Panasonic")   options.push_back({ codes[i].name.c_str(), [=](){ sendPanasonicCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol!="" && codes[i].data!="")   options.push_back({ codes[i].name.c_str(), [=](){ sendDecodedCommand(codes[i].protocol, codes[i].data); addToRecentCodes(codes[i]); }});
   }
   options.push_back({ "Main Menu" , [&](){ exit=true; }});
   databaseFile.close();
@@ -355,6 +355,10 @@ void sendNECCommand(String address, String command) {
   if(first_zero_byte_pos!=-1) address = address.substring(0, first_zero_byte_pos);
   first_zero_byte_pos = command.indexOf("00", 2);
   if(first_zero_byte_pos!=-1) command = command.substring(0, first_zero_byte_pos);
+
+  address.replace(" ", "");
+  command.replace(" ", "");
+
   uint16_t addressValue = strtoul(address.c_str(), nullptr, 16);
   uint16_t commandValue = strtoul(command.c_str(), nullptr, 16);
   uint64_t data = irsend.encodeNEC(addressValue, commandValue);
@@ -362,7 +366,6 @@ void sendNECCommand(String address, String command) {
   Serial.println("Sent NEC Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }
-
 
 void sendRC5Command(String address, String command) {
   IRsend irsend(bruceConfig.irTx,true);  // Set the GPIO to be used to sending the message.
@@ -447,8 +450,8 @@ void sendPanasonicCommand(String address, String command) {
 
 bool sendDecodedCommand(String protocol, String value, String bits) {
   // https://github.com/crankyoldgit/IRremoteESP8266/blob/master/examples/SmartIRRepeater/SmartIRRepeater.ino
-
-  decode_type_t type = strToDecodeType(protocol.c_str());
+  
+    decode_type_t type = strToDecodeType(protocol.c_str());
   if(type == decode_type_t::UNKNOWN) return false;
   uint16_t nbit_int = bits.toInt();
 
@@ -472,7 +475,6 @@ bool sendDecodedCommand(String protocol, String value, String bits) {
     success = irsend.send(type, state, state_pos);  // safer
 
   } else {
-
     value.replace(" ", "");
     uint64_t value_int = strtoull(value.c_str(), nullptr, 16);
 

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -203,7 +203,6 @@ String IrRead::parse_raw_signal() {
     return signal_code;
 }
 
-
 void IrRead::append_to_file_str(String btn_name) {
     strDeviceContent += "name: " + btn_name + "\n";
 
@@ -312,34 +311,32 @@ void IrRead::save_device() {
 
     FS* fs = nullptr;
 
-    bool sdCardAvaible = setupSdCard();
-    bool littleFsAvaible = checkLittleFsSize();
+    bool sdCardAvailable = setupSdCard();
+    bool littleFsAvailable = checkLittleFsSize();
 
-    if (sdCardAvaible && littleFsAvaible) {
+    if (sdCardAvailable && littleFsAvailable) {
         // ask to choose one
         options = {
-            {"SD Card", [&]()    { fs=&SD; }},
+            {"SD Card",  [&]()   {  fs=&SD; }},
             {"LittleFS", [&]()   {  fs=&LittleFS; }},
         };
         delay(200);
         loopOptions(options);
-    } else if (sdCardAvaible) {
+    } else if (sdCardAvailable) {
         fs=&SD;
-    } else if (littleFsAvaible) {
+    } else if (littleFsAvailable) {
         fs=&LittleFS;
     };
 
-    if (fs != nullptr && write_file(filename, fs)) {
+    if (fs && write_file(filename, fs)) {
         displaySuccess("File saved to " + String((fs == &SD) ? "SD Card" : "LittleFS") + ".", true);
         signals_read = 0;
         strDeviceContent = "";
-    } else {
-        if (fs == nullptr) {
-            displayError("No storage available.", true);
-        } else displayError("Error writing file.", true);
-    }
+    } else displayError(fs ? "Error writing file." : "No storage available.", true);
 
     delay(1000);
+
+    irrecv.resume();
     begin();
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

https://github.com/pr3y/Bruce/commit/9e5a367cdf0b8629cbb9ca1863b4a72373692826 :
Fixed Bug: After saving the device (with captured signals), instead of showing "Waiting for signal..." it was showing the last captured IR signal.

I added `irrecv.resume()` to resume received IR data to fix the bug.

https://github.com/pr3y/Bruce/commit/f86890865628dbf7e78bf53887430a1e25cb9160 :
Fixed Bug: NEC extended won't work correctly.

```cpp
// Demonstration of the problematic code

// Exemple (NEC extended) with removed trailing "00" bytes
String address = "83 55";
String command = "90 6F";

// When converting to a 16-bit integer, it would only convert the first byte "83" (0x83) and not the full "8355" (0x8355) due to the spaces...
uint16_t addressValue = strtoul(address.c_str(), nullptr, 16);
// Output: 131 (0x83)
uint16_t commandValue = strtoul(command.c_str(), nullptr, 16);
// Output: 144 (0x90)
```

I removed spaces in the address and the command, so it's converted properly (_should (not sure)_ fix the bug where NEC Extended won't work correctly)

```cpp
// Exemple (NEC extended) with removed trailing "00" bytes
String address = "83 55";
String command = "90 6F";

address.replace(" ", "");
// address = "8355";
command.replace(" ", "");
// command = "906F";

uint16_t addressValue = strtoul(address.c_str(), nullptr, 16);
// Output: 33621 (0x8355)
uint16_t commandValue = strtoul(command.c_str(), nullptr, 16);
// Output: 36975 (0x906F)
```

From what I saw [`IRsend::encodeNEC`](https://github.com/crankyoldgit/IRremoteESP8266/blob/9bdf8abcb465268c5409db99dc83a26df64c7445/src/ir_NEC.cpp#L48) should supports Extended NEC so I think it would work.

I wasn't able to test as I don't have any devices using NEC extended at the moment, if anyone can review this change it would be great.
