### PR TITLE
Fix SIRC (Sony) protocol

### DIFF
--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -410,11 +410,20 @@ void sendSonyCommand(String address, String command) {
   uint16_t commandValue = strtoul(command.substring(0,2).c_str(), nullptr, 16);
   uint16_t addressValue = strtoul(address.substring(0,2).c_str(), nullptr, 16);
   uint16_t addressValue2 = strtoul(address.substring(3,6).c_str(), nullptr, 16);
-  uint16_t nbits = 12;
-  if(addressValue2>0) nbits = 20;
-  else if(addressValue>=0x80) nbits = 15;
-  uint32_t data = irsend.encodeSony(nbits,commandValue,addressValue);
-  irsend.sendSony(data,20,10);
+
+  uint16_t nbits = 12; // 12 bits (SIRC)
+  if(addressValue2>0) nbits = 20; // 20 bits (SIRC20)
+  else if(addressValue>0x1F) nbits = 15; // 15 bits (SIRC15)
+
+  uint32_t data;
+  if (nbits == 20) {
+    data = irsend.encodeSony(nbits, commandValue, addressValue, addressValue2);
+  } else {
+    data = irsend.encodeSony(nbits, commandValue, addressValue);
+  }
+
+  // 1 initial + 2 repeat
+  irsend.sendSony(data, nbits, 2);
   Serial.println("Sent Sony Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }


### PR DESCRIPTION
#### Proposed Changes ####
- Updated the bit determination logic for SIRC15 (15 bits):
  - Replaced `if (addressValue >= 0x80)` with `if (addressValue > 0x1F)` ([see here](https://github.com/jamisonderek/flipper-zero-tutorials/wiki/Infrared))
- Modified the arguments passed to `sendSony`:
  - Replaced `20` to `nbits` for compatibility with all SIRC protocols (before this fix, none of SIRC protocols would work).
  - Adjusted the repeat count to `2`.

Tested on my Sony TV using SIRC (12 bits).

See https://github.com/pr3y/Bruce/issues/597#issuecomment-2560092472