### PR TITLE
fix ir_read.cpp

### DIFF
--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -129,16 +129,16 @@ void IrRead::read_signal() {
 
     _read_signal = true;
 
-    // Passaggio ai dati RAW sempre, indipendentemente dal risultato della decodifica
+    // Always switches to RAW data, regardless of the decoding result
     raw = true;
 
     display_banner();
 
-    // Dump dei dettagli del segnale
+    // Dump of signal details
     padprint("RAW Data Captured:");
     String raw_signal = parse_raw_signal();
-    tft.println(raw_signal);  // Mostra il segnale RAW sul display
-    Serial.println(raw_signal);  // Stampa il segnale RAW nella console seriale
+    tft.println(raw_signal);  // Shows the RAW signal on the display
+    Serial.println(raw_signal);  // Print RAW signal to serial monitor
 
     display_btn_options();
     delay(500);

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -129,26 +129,18 @@ void IrRead::read_signal() {
 
     _read_signal = true;
 
-    // switch to raw mode if decoding failed
-    if(results.decode_type == decode_type_t::UNKNOWN ) {
-        Serial.println("signal decoding failed, switching to RAW mode");
-        //displayWarning("signal decoding failed, switching to RAW mode", true);
-        raw = true;
-        // TODO: show a dialog
-        // raw = yesNoDialog("decoding failed, save as RAW?");
-    }
+    // Passaggio ai dati RAW sempre, indipendentemente dal risultato della decodifica
+    raw = true;
 
     display_banner();
 
-    // dump signal details
-    if(raw) {
-        padprint("HEX: RAW data");
-    } else {
-        padprint("HEX: 0x");
-        tft.println(results.value, HEX);
-    }
-    display_btn_options();
+    // Dump dei dettagli del segnale
+    padprint("RAW Data Captured:");
+    String raw_signal = parse_raw_signal();
+    tft.println(raw_signal);  // Mostra il segnale RAW sul display
+    Serial.println(raw_signal);  // Stampa il segnale RAW nella console seriale
 
+    display_btn_options();
     delay(500);
 }
 
@@ -186,7 +178,7 @@ String IrRead::parse_state_signal() {
 }
 
 String IrRead::parse_raw_signal() {
-    // https://github.com/crankyoldgit/IRremoteESP8266/blob/master/examples/SmartIRRepeater/SmartIRRepeater.ino
+    // Cattura i dati RAW come array e li restituisce come stringa
     rawcode = resultToRawArray(&results);
     raw_data_len = getCorrectedRawLength(&results);
 

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -178,7 +178,7 @@ String IrRead::parse_state_signal() {
 }
 
 String IrRead::parse_raw_signal() {
-    // Cattura i dati RAW come array e li restituisce come stringa
+
     rawcode = resultToRawArray(&results);
     raw_data_len = getCorrectedRawLength(&results);
 


### PR DESCRIPTION
ir reader fix, now raw is forced and sending works without problems.

#### Proposed Changes ####

I created a new branch and modified the read_signal() function to force RAW mode, in order to avoid errors in reading the signal. I also made some small adjustments as you can see. Now it works without problems, I tested it on two remote controls that until this afternoon did not work with the beta version. I hope to help you in this amazing project.