### PR TITLE
NECext Support, Fix Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Also, [read our FAQ](https://github.com/pr3y/Bruce/wiki/FAQ)
     
 - [x] TV-B-Gone
 - [x] IR Receiver
-- [x] [Custom IR (NEC, NEC42, NECExt, SIRC, SIRC15, SIRC20, Samsung32, RC5, RC5X, RC6)](https://github.com/pr3y/Bruce/wiki/IR#replay-payloads-like-flipper)
+- [x] [Custom IR (NEC, NECext, SIRC, SIRC15, SIRC20, Samsung32, RC5, RC5X, RC6)](https://github.com/pr3y/Bruce/wiki/IR#replay-payloads-like-flipper)
 - [x] Config
     - [X] Ir TX Pin
     - [X] Ir RX Pin

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -387,11 +387,11 @@ void sendNECextCommand(String address, String command) {
   uint16_t newAddress = (addressValue >> 8) | (addressValue << 8);
   uint16_t newCommand = (commandValue >> 8) | (commandValue << 8);
 
-  // MSB First
-  uint16_t msbAddress = reverseBits(newAddress, 16);
-  uint16_t msbCommand = reverseBits(newCommand, 16);
+  // LSB First
+  uint16_t lsbAddress = reverseBits(newAddress, 16);
+  uint16_t lsbCommand = reverseBits(newCommand, 16);
   
-  uint32_t data = ((uint32_t)msbAddress << 16) | msbCommand;
+  uint32_t data = ((uint32_t)lsbAddress << 16) | lsbCommand;
   irsend.sendNEC(data, 32);
   Serial.println("Sent NECext Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -168,17 +168,18 @@ bool txIrFile(FS *fs, String filepath) {
             bits.trim();
             Serial.println("bits: "+bits);
           } else if (line.indexOf("#") != -1) {  // TODO: also detect EOF
-            if (protocol.startsWith("NEC")) {
+            // https://developer.flipper.net/flipperzero/doxygen/infrared_file_format.html
+            if (protocol=="NEC") {
               sendNECCommand(address, command);
-            } else if (protocol.startsWith("RC5")) {
+            } else if (protocol=="RC5") {
               sendRC5Command(address, command);
-            } else if (protocol.startsWith("RC6")) {
+            } else if (protocol=="RC6") {
               sendRC6Command(address, command);
-            } else if (protocol.startsWith("Samsung")) {
+            } else if (protocol=="Samsung32") {
               sendSamsungCommand(address, command);
             } else if (protocol.startsWith("SIRC")) {
               sendSonyCommand(address, command);
-            } else if (protocol.startsWith("Panasonic")) {
+            } else if (protocol=="Kaseikyo"||protocol=="Panasonic") {
               sendPanasonicCommand(address, command);
             } else if (protocol!="" && value!="") {
               sendDecodedCommand(protocol, value, bits);
@@ -247,12 +248,14 @@ void otherIRcodes() {
 
   if(fs == NULL) {  // recent menu was selected
     if(selected_code.filepath!="") { // a code was selected, switch on code type
+      // https://developer.flipper.net/flipperzero/doxygen/infrared_file_format.html
       if(selected_code.type=="raw")  sendRawCommand(selected_code.frequency, selected_code.data);
-      else if(selected_code.protocol.startsWith("NEC")) sendNECCommand(selected_code.address, selected_code.command);
+      else if(selected_code.protocol=="NEC") sendNECCommand(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="RC5") sendRC5Command(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="RC6") sendRC6Command(selected_code.address, selected_code.command);
-      else if(selected_code.protocol.startsWith("Samsung")) sendSamsungCommand(selected_code.address, selected_code.command);
+      else if(selected_code.protocol=="Samsung32") sendSamsungCommand(selected_code.address, selected_code.command);
       else if(selected_code.protocol.startsWith("SIRC")) sendSonyCommand(selected_code.address, selected_code.command);
+      else if(selected_code.protocol=="Kaseikyo"||selected_code.protocol=="Panasonic") sendPanasonicCommand(selected_code.address, selected_code.command);
       else if(selected_code.protocol!="") sendDecodedCommand(selected_code.protocol, selected_code.data);
     }
     return;
@@ -323,13 +326,14 @@ void otherIRcodes() {
   options = { };
   bool exit = false;
   for(int i=0; i<=total_codes; i++) {
+    // https://developer.flipper.net/flipperzero/doxygen/infrared_file_format.html
     if(codes[i].type=="raw")        options.push_back({ codes[i].name.c_str(), [=](){ sendRawCommand(codes[i].frequency, codes[i].data); addToRecentCodes(codes[i]); }});
-    else if(codes[i].protocol.startsWith("NEC"))    options.push_back({ codes[i].name.c_str(), [=](){ sendNECCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
-    else if(codes[i].protocol.startsWith("RC5"))    options.push_back({ codes[i].name.c_str(), [=](){ sendRC5Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
-    else if(codes[i].protocol.startsWith("RC6"))    options.push_back({ codes[i].name.c_str(), [=](){ sendRC6Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
-    else if(codes[i].protocol.startsWith("Samsung")) options.push_back({ codes[i].name.c_str(), [=](){ sendSamsungCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol=="NEC")    options.push_back({ codes[i].name.c_str(), [=](){ sendNECCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol=="RC5")    options.push_back({ codes[i].name.c_str(), [=](){ sendRC5Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol=="RC6")    options.push_back({ codes[i].name.c_str(), [=](){ sendRC6Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol=="Samsung32") options.push_back({ codes[i].name.c_str(), [=](){ sendSamsungCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol.startsWith("SIRC"))   options.push_back({ codes[i].name.c_str(), [=](){ sendSonyCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
-    else if(codes[i].protocol=="Panasonic")   options.push_back({ codes[i].name.c_str(), [=](){ sendPanasonicCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol=="Kaseikyo"||codes[i].protocol=="Panasonic")   options.push_back({ codes[i].name.c_str(), [=](){ sendPanasonicCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol!="" && codes[i].data!="")   options.push_back({ codes[i].name.c_str(), [=](){ sendDecodedCommand(codes[i].protocol, codes[i].data); addToRecentCodes(codes[i]); }});
   }
   options.push_back({ "Main Menu" , [&](){ exit=true; }});
@@ -351,18 +355,10 @@ void sendNECCommand(String address, String command) {
   IRsend irsend(bruceConfig.irTx);  // Set the GPIO to be used to sending the message.
   irsend.begin();
   displaySomething("Sending..");
-  uint8_t first_zero_byte_pos = address.indexOf("00", 2);
-  if(first_zero_byte_pos!=-1) address = address.substring(0, first_zero_byte_pos);
-  first_zero_byte_pos = command.indexOf("00", 2);
-  if(first_zero_byte_pos!=-1) command = command.substring(0, first_zero_byte_pos);
-
-  address.replace(" ", "");
-  command.replace(" ", "");
-
-  uint16_t addressValue = strtoul(address.c_str(), nullptr, 16);
-  uint16_t commandValue = strtoul(command.c_str(), nullptr, 16);
+  uint16_t addressValue = strtoul(address.substring(0,2).c_str(), nullptr, 16);
+  uint16_t commandValue = strtoul(command.substring(0,2).c_str(), nullptr, 16);
   uint64_t data = irsend.encodeNEC(addressValue, commandValue);
-  irsend.sendNEC(data, 32, 10);
+  irsend.sendNEC(data, 32);
   Serial.println("Sent NEC Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }
@@ -374,7 +370,7 @@ void sendRC5Command(String address, String command) {
   uint8_t addressValue = strtoul(address.substring(0,2).c_str(), nullptr, 16);
   uint8_t commandValue = strtoul(command.substring(0,2).c_str(), nullptr, 16);
   uint16_t data = irsend.encodeRC5(addressValue, commandValue);
-  irsend.sendRC5(data, 13, 10);
+  irsend.sendRC5(data, 13);
   Serial.println("Sent RC5 command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }
@@ -385,10 +381,10 @@ void sendRC6Command(String address, String command) {
   displaySomething("Sending..");
   address.replace(" ", "");
   command.replace(" ", "");
-  uint32_t addressValue = strtoul(address.c_str(), nullptr, 16);
-  uint32_t commandValue = strtoul(command.c_str(), nullptr, 16);
+  uint32_t addressValue = strtoul(address.substring(0,2).c_str(), nullptr, 16);
+  uint32_t commandValue = strtoul(command.substring(0,2).c_str(), nullptr, 16);
   uint64_t data = irsend.encodeRC6(addressValue, commandValue);
-  irsend.sendRC6(data,20, 10);
+  irsend.sendRC6(data, 20);
   Serial.println("Sent RC5 command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -392,7 +392,6 @@ void sendNECextCommand(String address, String command) {
   uint16_t lsbCommand = reverseBits(newCommand, 16);
   
   uint32_t data = ((uint32_t)lsbAddress << 16) | lsbCommand;
-  Serial.println("Data: 0x" + String(data, HEX));
   irsend.sendNEC(data, 32); // Sends MSB first
   Serial.println("Sent NECext Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -171,6 +171,8 @@ bool txIrFile(FS *fs, String filepath) {
             // https://developer.flipper.net/flipperzero/doxygen/infrared_file_format.html
             if (protocol=="NEC") {
               sendNECCommand(address, command);
+            } else if (protocol=="NECext") {
+              sendNECextCommand(address, command);
             } else if (protocol=="RC5") {
               sendRC5Command(address, command);
             } else if (protocol=="RC6") {
@@ -251,6 +253,7 @@ void otherIRcodes() {
       // https://developer.flipper.net/flipperzero/doxygen/infrared_file_format.html
       if(selected_code.type=="raw")  sendRawCommand(selected_code.frequency, selected_code.data);
       else if(selected_code.protocol=="NEC") sendNECCommand(selected_code.address, selected_code.command);
+      else if(selected_code.protocol=="NECext") sendNECextCommand(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="RC5") sendRC5Command(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="RC6") sendRC6Command(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="Samsung32") sendSamsungCommand(selected_code.address, selected_code.command);
@@ -329,6 +332,7 @@ void otherIRcodes() {
     // https://developer.flipper.net/flipperzero/doxygen/infrared_file_format.html
     if(codes[i].type=="raw")        options.push_back({ codes[i].name.c_str(), [=](){ sendRawCommand(codes[i].frequency, codes[i].data); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="NEC")    options.push_back({ codes[i].name.c_str(), [=](){ sendNECCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol=="NECext")    options.push_back({ codes[i].name.c_str(), [=](){ sendNECextCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="RC5")    options.push_back({ codes[i].name.c_str(), [=](){ sendRC5Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="RC6")    options.push_back({ codes[i].name.c_str(), [=](){ sendRC6Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="Samsung32") options.push_back({ codes[i].name.c_str(), [=](){ sendSamsungCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
@@ -350,7 +354,7 @@ void otherIRcodes() {
 }  // end of otherIRcodes
 
 
-//IR commands
+// IR commands
 void sendNECCommand(String address, String command) {
   IRsend irsend(bruceConfig.irTx);  // Set the GPIO to be used to sending the message.
   irsend.begin();
@@ -360,6 +364,36 @@ void sendNECCommand(String address, String command) {
   uint64_t data = irsend.encodeNEC(addressValue, commandValue);
   irsend.sendNEC(data, 32);
   Serial.println("Sent NEC Command");
+  digitalWrite(bruceConfig.irTx, LED_OFF);
+}
+
+void sendNECextCommand(String address, String command) {
+  IRsend irsend(bruceConfig.irTx);  // Set the GPIO to be used to sending the message.
+  irsend.begin();
+  displaySomething("Sending..");
+  
+  uint8_t first_zero_byte_pos = address.indexOf("00", 2);
+  if(first_zero_byte_pos!=-1) address = address.substring(0, first_zero_byte_pos);
+  first_zero_byte_pos = command.indexOf("00", 2);
+  if(first_zero_byte_pos!=-1) command = command.substring(0, first_zero_byte_pos);
+  
+  address.replace(" ", "");
+  command.replace(" ", "");
+
+  uint16_t addressValue = strtoul(address.c_str(), nullptr, 16);
+  uint16_t commandValue = strtoul(command.c_str(), nullptr, 16);
+
+  // Invert Endianness
+  uint16_t newAddress = (addressValue >> 8) | (addressValue << 8);
+  uint16_t newCommand = (commandValue >> 8) | (commandValue << 8);
+
+  // MSB First
+  uint16_t msbAddress = reverseBits(newAddress, 16);
+  uint16_t msbCommand = reverseBits(newCommand, 16);
+  
+  uint32_t data = ((uint32_t)msbAddress << 16) | msbCommand;
+  irsend.sendNEC(data, 32);
+  Serial.println("Sent NECext Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -173,7 +173,7 @@ bool txIrFile(FS *fs, String filepath) {
               sendNECCommand(address, command);
             } else if (protocol=="NECext") {
               sendNECextCommand(address, command);
-            } else if (protocol=="RC5") {
+            } else if (protocol=="RC5"||protocol=="RC5X") {
               sendRC5Command(address, command);
             } else if (protocol=="RC6") {
               sendRC6Command(address, command);
@@ -254,7 +254,7 @@ void otherIRcodes() {
       if(selected_code.type=="raw")  sendRawCommand(selected_code.frequency, selected_code.data);
       else if(selected_code.protocol=="NEC") sendNECCommand(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="NECext") sendNECextCommand(selected_code.address, selected_code.command);
-      else if(selected_code.protocol=="RC5") sendRC5Command(selected_code.address, selected_code.command);
+      else if(selected_code.protocol=="RC5"||selected_code.protocol=="RC5X") sendRC5Command(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="RC6") sendRC6Command(selected_code.address, selected_code.command);
       else if(selected_code.protocol=="Samsung32") sendSamsungCommand(selected_code.address, selected_code.command);
       else if(selected_code.protocol.startsWith("SIRC")) sendSonyCommand(selected_code.address, selected_code.command);
@@ -333,7 +333,7 @@ void otherIRcodes() {
     if(codes[i].type=="raw")        options.push_back({ codes[i].name.c_str(), [=](){ sendRawCommand(codes[i].frequency, codes[i].data); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="NEC")    options.push_back({ codes[i].name.c_str(), [=](){ sendNECCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="NECext")    options.push_back({ codes[i].name.c_str(), [=](){ sendNECextCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
-    else if(codes[i].protocol=="RC5")    options.push_back({ codes[i].name.c_str(), [=](){ sendRC5Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
+    else if(codes[i].protocol=="RC5"||codes[i].protocol=="RC5X")    options.push_back({ codes[i].name.c_str(), [=](){ sendRC5Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="RC6")    options.push_back({ codes[i].name.c_str(), [=](){ sendRC6Command(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol=="Samsung32") options.push_back({ codes[i].name.c_str(), [=](){ sendSamsungCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
     else if(codes[i].protocol.startsWith("SIRC"))   options.push_back({ codes[i].name.c_str(), [=](){ sendSonyCommand(codes[i].address, codes[i].command); addToRecentCodes(codes[i]); }});
@@ -387,12 +387,13 @@ void sendNECextCommand(String address, String command) {
   uint16_t newAddress = (addressValue >> 8) | (addressValue << 8);
   uint16_t newCommand = (commandValue >> 8) | (commandValue << 8);
 
-  // LSB First
+  // NEC protocol bit order is LSB first
   uint16_t lsbAddress = reverseBits(newAddress, 16);
   uint16_t lsbCommand = reverseBits(newCommand, 16);
   
   uint32_t data = ((uint32_t)lsbAddress << 16) | lsbCommand;
-  irsend.sendNEC(data, 32);
+  Serial.println("Data: 0x" + String(data, HEX));
+  irsend.sendNEC(data, 32); // Sends MSB first
   Serial.println("Sent NECext Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -397,15 +397,11 @@ void sendSamsungCommand(String address, String command) {
   IRsend irsend(bruceConfig.irTx);  // Set the GPIO to be used to sending the message.
   irsend.begin();
   displaySomething("Sending..");
-  //uint64_t data = ((uint64_t)strtoul(address.c_str(), nullptr, 16) << 32) | strtoul(command.c_str(), nullptr, 16);
-  address.replace(" ", "");
-  command.replace(" ", "");
-  uint32_t addressValue = strtoul(address.c_str(), nullptr, 16);
-  uint32_t commandValue = strtoul(command.c_str(), nullptr, 16);
+  uint8_t addressValue = strtoul(address.substring(0,2).c_str(), nullptr, 16);
+  uint8_t commandValue = strtoul(command.substring(0,2).c_str(), nullptr, 16);
   uint64_t data = irsend.encodeSAMSUNG(addressValue, commandValue);
-  irsend.sendSAMSUNG(data, 32, 10);
-  //delay(20);
-  //irsend.sendSamsung36(data, 36, 10);
+
+  irsend.sendSAMSUNG(data, 32);
   Serial.println("Sent Samsung Command");
   digitalWrite(bruceConfig.irTx, LED_OFF);
 }

--- a/src/modules/ir/custom_ir.h
+++ b/src/modules/ir/custom_ir.h
@@ -11,6 +11,7 @@
 // custom Ir
 void sendRawCommand(uint16_t frequency, String rawData);
 void sendNECCommand(String address, String command);
+void sendNECextCommand(String address, String command);
 void sendRC5Command(String address, String command);
 void sendRC6Command(String address, String command);
 void sendSamsungCommand(String address, String command);


### PR DESCRIPTION
#### Proposed Changes ####
- Added support for `NECext` protocol.
- Fix `Samsung32`, `RC6` protocol.
- Fix incorrect `repeats` number (This resolves the issue where the command was being sent multiple times unnecessarily).
- Removed `NEC42` from the README, because it is not supported.

Fix #597 