### PR TITLE
Add  lilyGo T-Display S3 board

### DIFF
--- a/boards/lilygo-t-display-s3.ini
+++ b/boards/lilygo-t-display-s3.ini
@@ -1,0 +1,26 @@
+[env:lilygo-t-display-s3]
+board = lilygo-t-display-s3
+board_build.partitions = custom_16Mb.csv
+build_src_filter =${env.build_src_filter} +<../boards/lilygo-t-display-s3>
+build_flags =
+	${env.build_flags}
+	-Iboards/lilygo-t-display-s3
+	-Os
+	-DCORE_DEBUG_LEVEL=5
+	-DREDRAW_DELAY=1 # Used to improve navigation on menus for this device
+	-DMIC_SPM1423
+
+	-UARDUINO_USB_CDC_ON_BOOT #Turn off CDC on boot https://github.com/Xinyuan-LilyGO/T-Display-S3
+	-DDISABLE_ALL_LIBRARY_WARNINGS
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
+	-DIR_RX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
+	-DRF_RX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
+
+lib_deps =
+	${env.lib_deps}
+	fastled/FastLED @3.9.4

--- a/boards/lilygo-t-display-s3.json
+++ b/boards/lilygo-t-display-s3.json
@@ -1,0 +1,61 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DT_DISPLAY_S3",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DARDUINO_USB_MODE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x239A",
+        "0x811B"
+      ],
+      [
+        "0x239A",
+        "0x011B"
+      ],
+      [
+        "0x239A",
+        "0x811C"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "pinouts"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "LilyGo T-Display S3",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.lilygo.cc",
+  "vendor": "LilyGo"
+}

--- a/boards/lilygo-t-display-s3/interface.cpp
+++ b/boards/lilygo-t-display-s3/interface.cpp
@@ -1,0 +1,163 @@
+#include "core/powerSave.h"
+#include "interface.h"
+#include <globals.h>
+
+#if defined(T_DISPLAY_S3)
+#include <esp_adc_cal.h>
+#endif
+
+/***************************************************************************************
+** Function name: _setup_gpio()
+** Description:   initial setup for the device
+***************************************************************************************/
+void _setup_gpio()
+{
+  // setup buttons
+  pinMode(DW_BTN, INPUT_PULLUP);
+  pinMode(UP_BTN, INPUT_PULLUP);
+  pinMode(SEL_BTN, INPUT_PULLUP);
+
+  pinMode(PIN_POWER_ON, OUTPUT);
+  digitalWrite(PIN_POWER_ON, HIGH);
+
+  pinMode(BAT_PIN, INPUT);
+
+  // Start with default IR, RF and RFID Configs, replace old
+  bruceConfig.rfModule = CC1101_SPI_MODULE;
+  bruceConfig.rfidModule = PN532_I2C_MODULE;
+  bruceConfig.irRx = 1;
+}
+
+/***************************************************************************************
+** Function name: getBattery()
+** Description:   Delivers the battery value from 1-100
+***************************************************************************************/
+int getBattery()
+{
+  int percent = 0;
+  esp_adc_cal_characteristics_t adc_chars;
+  esp_adc_cal_value_t val_type = esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12, 1100, &adc_chars);
+  uint32_t raw = analogRead(BAT_PIN);
+  uint32_t v1 = esp_adc_cal_raw_to_voltage(raw, &adc_chars) * 2;
+
+  if (v1 > 4150)
+  {
+    percent = 0;
+  }
+  else
+  {
+    percent = map(v1, 3200, 4150, 0, 100);
+  }
+
+  return (percent < 0)      ? 0
+         : (percent >= 100) ? 100
+                            : percent;
+}
+
+/*********************************************************************
+**  Function: setBrightness
+**  set brightness value
+**********************************************************************/
+void _setBrightness(uint8_t brightval)
+{
+  if (brightval == 0)
+  {
+    analogWrite(TFT_BL, brightval);
+  }
+  else
+  {
+    int bl = MINBRIGHT + round(((255 - MINBRIGHT) * brightval / 100));
+    analogWrite(TFT_BL, bl);
+  }
+}
+
+/*********************************************************************
+** Function: InputHandler
+** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
+**********************************************************************/
+void InputHandler(void)
+{
+  checkPowerSaveTime();
+  PrevPress = false;
+  NextPress = false;
+  SelPress = false;
+  AnyKeyPress = false;
+  EscPress = false;
+  UpPress = false;
+  DownPress = false;
+
+  if (digitalRead(SEL_BTN) == BTN_ACT || digitalRead(UP_BTN) == BTN_ACT || digitalRead(DW_BTN) == BTN_ACT)
+  {
+    if (!wakeUpScreen())
+      AnyKeyPress = true;
+    else
+      goto END;
+  }
+
+  if (digitalRead(UP_BTN) == BTN_ACT)
+  {
+    PrevPress = true;
+  }
+
+  if (digitalRead(DW_BTN) == BTN_ACT)
+  {
+    NextPress = true;
+  }
+
+  if (digitalRead(SEL_BTN) == BTN_ACT)
+  {
+    SelPress = true;
+  }
+
+END:
+  if (AnyKeyPress)
+  {
+    long tmp = millis();
+    while ((millis() - tmp) < 200 && (digitalRead(SEL_BTN) == BTN_ACT || digitalRead(UP_BTN) == BTN_ACT || digitalRead(DW_BTN) == BTN_ACT))
+      ;
+  }
+}
+
+void powerOff()
+{
+  #ifdef T_DISPLAY_S3
+    esp_sleep_enable_ext0_wakeup((gpio_num_t)SEL_BTN,BTN_ACT); 
+    esp_deep_sleep_start();
+  #endif
+}
+
+void checkReboot()
+{
+#ifdef T_DISPLAY_S3
+  int countDown;
+  /* Long press power off */
+  if (digitalRead(UP_BTN) == BTN_ACT && digitalRead(DW_BTN) == BTN_ACT)
+  {
+    uint32_t time_count = millis();
+    while (digitalRead(UP_BTN) == BTN_ACT && digitalRead(DW_BTN) == BTN_ACT)
+    {
+      // Display poweroff bar only if holding button
+      if (millis() - time_count > 500)
+      {
+        tft.setTextSize(1);
+        tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+        countDown = (millis() - time_count) / 1000 + 1;
+        if (countDown < 4)
+          tft.drawCentreString("PWR OFF IN " + String(countDown) + "/3", tftWidth / 2, 12, 1);
+        else
+        {
+          tft.fillScreen(bruceConfig.bgColor);
+          while (digitalRead(UP_BTN) == BTN_ACT || digitalRead(DW_BTN) == BTN_ACT);
+          delay(200);
+          powerOff();
+        }
+        delay(10);
+      }
+    }
+
+    // Clear text after releasing the button
+    delay(30);
+    tft.fillRect(60, 12, tftWidth - 60, tft.fontHeight(1), bruceConfig.bgColor);
+  }
+#endif
+}

--- a/boards/pinouts/lilygo-t-display-s3.h
+++ b/boards/pinouts/lilygo-t-display-s3.h
@@ -1,0 +1,104 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// Lite Version
+// #define LITE_VERSION 1
+
+// Main I2C Bus
+#define SPI_SS_PIN      10
+#define SPI_MOSI_PIN    11
+#define SPI_MISO_PIN    13
+#define SPI_SCK_PIN     12
+static const uint8_t SS    = SPI_SS_PIN;
+static const uint8_t MOSI  = SPI_MOSI_PIN;
+static const uint8_t SCK   = SPI_MISO_PIN;
+static const uint8_t MISO  = SPI_SCK_PIN;
+
+// Set Main I2C Bus
+#define GROVE_SDA 44
+#define GROVE_SCL 43
+static const uint8_t SDA = GROVE_SDA;
+static const uint8_t SCL = GROVE_SCL;
+
+// TFT_eSPI display
+#define USER_SETUP_LOADED
+#define ST7789_DRIVER   1
+#define TFT_BACKLIGHT_ON 1
+#define INIT_SEQUENCE_3
+#define CGRAM_OFFSET
+#define TFT_RGB_ORDER TFT_RGB
+#define TFT_INVERSION_ON
+#define TFT_PARALLEL_8_BIT
+#define SMOOTH_FONT     1
+#define TFT_WIDTH       170
+#define TFT_HEIGHT      320
+#define TFT_BL          38
+#define TFT_MISO        -1   
+#define TFT_MOSI        11
+#define TFT_SCLK        12
+#define TFT_CS          6 
+#define TFT_DC          7
+#define TFT_RST         5
+#define TFT_D0          39
+#define TFT_D1          40
+#define TFT_D2          41
+#define TFT_D3          42
+#define TFT_D4          45
+#define TFT_D5          46
+#define TFT_D6          47
+#define TFT_D7          48
+#define TFT_WR          8
+#define TFT_RD          9
+#define LOAD_GLCD
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_FONT6
+#define LOAD_FONT7
+#define LOAD_FONT8
+#define LOAD_GFXFF
+#define SPI_FREQUENCY   40000000
+#define SPI_READ_FREQUENCY 20000000
+
+// Display Setup#
+#define HAS_SCREEN
+#define ROTATION        3
+#define MINBRIGHT       (uint8_t) 1
+
+// Font Sizes#
+#define FP  1
+#define FM  2
+#define FG  3
+
+// Serial
+#define SERIAL_TX   43
+#define SERIAL_RX   44
+
+// Battery PIN
+#define PIN_POWER_ON    15
+#define BAT_PIN         4
+
+// Mic
+#define PIN_CLK         39
+#define PIN_DATA        42
+
+#define BTN_ALIAS	'"OK"'
+#define HAS_3_BUTTONS
+#define SEL_BTN     1
+#define UP_BTN      0
+#define DW_BTN      14 
+#define BK_BTN	    3
+#define BTN_ACT     LOW
+
+// IR
+#define LED	        44
+#define RXLED	    43
+#define LED_ON	    HIGH
+#define LED_OFF	    LOW
+
+// BadUSB 
+#define USB_as_HID 1
+
+#endif /* Pins_Arduino_h */

--- a/boards/pinouts/pins_arduino.h
+++ b/boards/pinouts/pins_arduino.h
@@ -1,4 +1,6 @@
-#ifdef T_EMBED_1101
+#ifdef T_DISPLAY_S3
+#include "lilygo-t-display-s3.h"
+#elif T_EMBED_1101
 #include "lilygo-t-embed-cc1101.h"
 #elif T_EMBED
 #include "lilygo-t-embed.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ default_envs =
 	CYD-2USB
 	lilygo-t-embed-cc1101
 	lilygo-t-deck
+	lilygo-t-display-s3
 ;uncomment to not use global dirs to avoid possible conflicts
 ;platforms_dir = .pio/platforms
 ;packages_dir = .pio/packages
@@ -72,8 +73,8 @@ lib_deps =
 	https://github.com/rennancockles/MFRC522-I2C
 	https://github.com/rennancockles/ESP-ChameleonUltra
 	https://github.com/rennancockles/ESP-Amiibolink
-	https://github.com/whywilson/ESP-PN532BLE
-  https://github.com/T-vK/ESP32-BLE-Mouse
+	https://github.com/epiHATR/ESP-PN532BLE
+  	https://github.com/T-vK/ESP32-BLE-Mouse
 	NTPClient
 	Timezone
 	ESP32Time


### PR DESCRIPTION
#### Proposed Changes ####

In this PR, I have made some changes:
- Add lilyGo T-Display S3 board configuration and logic handler
- Change the source of ESP-PN532BLE to my folk repo since it's unable to compile using current code

#### Types of Changes ####

Add new board

#### Verification ####
Tested on LilyGo T-Display S3 with 2 default buttons and one additional button as bellow:
- BOOT button: act as Previous
- KEY button: act as Next button
- Custom button at GPIO1 : Select button, startup button
- Hold Boot & Key buttons for power off the board

![IMG_6260](https://github.com/user-attachments/assets/40eccd0b-4e78-448e-94e9-640b306dd5f7)


#### Testing ####

Tested in default board T-Display S3 by lilyGo


