### PR TITLE
Rf Save File fix interaction with filesystem

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -73,6 +73,7 @@ lib_deps =
 	https://github.com/rennancockles/MFRC522-I2C
 	https://github.com/rennancockles/ESP-ChameleonUltra
 	https://github.com/rennancockles/ESP-Amiibolink
+	;https://github.com/epiHATR/ESP-PN532BLE
 	https://github.com/whywilson/ESP-PN532BLE
 	NTPClient
 	Timezone

--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -830,6 +830,14 @@ RestartRec:
 
 bool RCSwitch_SaveSignal(float frequency, RfCodes codes, bool raw, char* key)
 {
+    FS *fs;
+    String filename = "";
+
+    if(!getFsStorage(fs)) {
+        displayError("No space left on device", true);
+        return false;
+    }
+    
     if (!codes.key && codes.data=="") {
         Serial.println("Empty signal, it was not saved.");
         return false;
@@ -843,6 +851,7 @@ bool RCSwitch_SaveSignal(float frequency, RfCodes codes, bool raw, char* key)
         subfile_out += "Bit: " + String(codes.Bit) + "\n";
         subfile_out += "Key: " + String(key) + "\n";
         subfile_out += "TE: " + String(codes.te) + "\n";
+        filename = "rcs_";
         //subfile_out += "RAW_Data: " + codes.data;
     } else {
         // save as raw
@@ -856,45 +865,21 @@ bool RCSwitch_SaveSignal(float frequency, RfCodes codes, bool raw, char* key)
         subfile_out += "Preset: " + String(codes.preset) + "\n";
         subfile_out += "Protocol: RAW\n";
         subfile_out += "RAW_Data: " + codes.data;
+        filename = "raw_";
     }
 
     int i = 0;
     File file;
-    String FS = "";
 
-    if (SD.begin()) {
-        if (!SD.exists("/BruceRF")) {
-            SD.mkdir("/BruceRF");
-        }
-
-        while (SD.exists("/BruceRF/bruce_" + String(i) + ".sub")) {
-            i++;
-        }
-
-        file = SD.open("/BruceRF/bruce_"+ String(i) +".sub", FILE_WRITE);
-        FS="SD";
-    } else if (LittleFS.begin()) {
-        sdcardMounted=false;
-        if (!checkLittleFsSize()) {
-            return false;
-        }
-        if (!LittleFS.exists("/BruceRF")) {
-            LittleFS.mkdir("/BruceRF");
-        }
-
-        while(LittleFS.exists("/BruceRF/bruce_" + String(i) + ".sub")) {
-            i++;
-        }
-
-        file = LittleFS.open("/BruceRF/bruce_" + String(i) +".sub", FILE_WRITE);
-        FS = "LittleFS";
-    }
+    if (!(*fs).exists("/BruceRF")) (*fs).mkdir("/BruceRF");
+    while((*fs).exists("/BruceRF/" + filename + String(i) + ".sub")) i++;
+    
+    file = (*fs).open("/BruceRF/" + filename + String(i) + ".sub", FILE_WRITE);
 
     if (file) {
         file.println(subfile_out);
-        displaySuccess(FS + "/bruce_" + String(i) + ".sub");
+        displaySuccess("/BruceRF/" + filename + String(i) + ".sub");
     } else {
-        Serial.println("Fail saving data to LittleFS");
         displayError("Error saving file", true);
     }
 
@@ -1652,7 +1637,7 @@ RestartScan:
                 goto RestartScan;
             }
 
-			if (option == 1) { // Range 
+			if (option == 1) { // Range submenu
                 option=0;
 				options = {
 					{ String("Fxd [" + String(bruceConfig.rfFreq) + "]").c_str(), [=]()  { bruceConfig.setRfScanRange(bruceConfig.rfScanRange, 1); } },
@@ -1665,7 +1650,7 @@ RestartScan:
 
 				loopOptions(options);
 
-                if(option == 1) {
+                if(option == 1) { // Range
                     options = {};
                     int ind=0;
                     int arraySize = sizeof(subghz_frequency_list) / sizeof(subghz_frequency_list[0]);
@@ -1689,7 +1674,7 @@ RestartScan:
                 decimalToHexString(received.key,hexString);
                 RCSwitch_SaveSignal(found_freq, received, received.protocol=="RAW"? true:false, hexString);
                 deinitRfModule();
-                delay(200);
+                delay(1500);
                 goto RestartScan;
             }
             else if (option == 3) { // Set Default


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Use the new method for interacting with the filesystem, because the one used was not working on T-Embed C1101 and the display was freezing.
I decided to use "FS" class to fix this issue.
Also, change to the names of the signals on the filesystem. RAW type will be called raw_ and RcSwitch will be called rcs_.
#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->
Bugfix
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
"Save Signal" in RF Scan/Copy menu is now working on C1101
#### Testing ####
Yes
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

