### PR TITLE
Fix signal count not being reset on reset signal

### DIFF
--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -1698,6 +1698,7 @@ RestartScan:
                 received.key=0;
                 received.preset="";
                 received.protocol="";
+                signals=0;
                 deinitRfModule();
                 delay(1500);
                 goto RestartScan;


### PR DESCRIPTION
When a signal is scanned and you hit "Reset Signal" from menu, "Total signals found" counter was not being reset.
