### PR TITLE
Fix keep WiFi connection after closing WebUi if it was established beforehand

### DIFF
--- a/src/core/serialcmds.cpp
+++ b/src/core/serialcmds.cpp
@@ -617,10 +617,6 @@ bool processSerialCommand(String cmd_str) {
 
   if(cmd_str == "webui" ) {
     // start the webui
-    if(!wifiConnected) {
-      Serial.println("wifiConnect");
-      wifiConnectMenu(WIFI_AP);  // TODO: read mode from config file
-    }
     Serial.println("startWebUi");
     startWebUi(true);  // MEMO: will quit when check(EscPress)
     return true;

--- a/src/modules/others/webInterface.cpp
+++ b/src/modules/others/webInterface.cpp
@@ -20,33 +20,13 @@ WebServer* server=nullptr;               // initialise webserver
 const char* host = "bruce";
 String uploadFolder="";
 
-
-
-/**********************************************************************
-**  Function: webUIMyNet
-**  Display options to launch the WebUI
-**********************************************************************/
-void webUIMyNet() {
-  if (WiFi.status() != WL_CONNECTED) {
-    if(wifiConnectMenu()) startWebUi(false);
-    else {
-      displayError("Wifi Offline");
-    }
-  } else {
-    //If it is already connected, just start the network
-    startWebUi(false);
-  }
-  // On fail installing will run the following line
-}
-
-
 /**********************************************************************
 **  Function: loopOptionsWebUi
 **  Display options to launch the WebUI
 **********************************************************************/
 void loopOptionsWebUi() {
   options = {
-      {"my Network", [=]() { webUIMyNet(); }},
+      {"my Network", [=]() { startWebUi(false); }},
       {"AP mode", [=]()    { startWebUi(true); }},
   };
 

--- a/src/modules/others/webInterface.cpp
+++ b/src/modules/others/webInterface.cpp
@@ -45,7 +45,6 @@ void webUIMyNet() {
 **  Display options to launch the WebUI
 **********************************************************************/
 void loopOptionsWebUi() {
-  // Definição da matriz "Options"
   options = {
       {"my Network", [=]() { webUIMyNet(); }},
       {"AP mode", [=]()    { startWebUi(true); }},
@@ -493,11 +492,14 @@ server->on("/script.js", HTTP_GET, []() {
 void startWebUi(bool mode_ap) {
   setupSdCard();
 
+  bool keepWifiConnected = false;
   if (WiFi.status() != WL_CONNECTED) {
     if( mode_ap )
       wifiConnectMenu(WIFI_AP);
     else
       wifiConnectMenu(WIFI_STA);
+  } else {
+    keepWifiConnected = true;
   }
 
   // configure web server
@@ -526,7 +528,7 @@ void startWebUi(bool mode_ap) {
   MDNS.end();
 
   delay(100);
-  wifiDisconnect();
+  if(!keepWifiConnected) wifiDisconnect();
   enableCore0WDT();
   enableCore1WDT();
   enableLoopWDT();


### PR DESCRIPTION
I am switching beetwen the `Files/WebUI` and the `JS interpreter`.
Every time even if the connection was established before entering the `Files/WebUI` it disconnects after I exit the WebUI.
This PR fixes this, of course if the wifi connection is created during the WebUI initiation, it will still disconnect after closing the WebUI, as expected.

#### Proposed Changes ####

- fixed keep WiFi connection after closing WebUi if it was established beforehand
- removed unnesesary wifi connections functions before calling `startWebUi()` as they duplicated the code already present in the `startWebUi()` function

#### Types of Changes ####

Bugfix

#### Verification ####

You can start the WebUI with a connected WiFi, and the connection will remain active.
If you start the WebUI with no WiFi connection, it will disconnect from WiFi after closing the WebUI.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix to keep WiFi connection after closing WebUi if it was established beforehand
```
