### PR TITLE
Keyboard: Fix a glitch with SPACE btn and navigation

### DIFF
--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -504,11 +504,16 @@ String keyboard(String mytext, int maxSize, String msg) {
         else x++;
 
         if (y > 3) y = -1;
+        if (y==-1 && x>3) x = 0;
+        
         redraw = true;
       }
       /* UP Btn to move in Y axis (Downwards) */
       if(check(PrevPress)) {
-        if(check(EscPress)) { y--; }
+        if(check(EscPress)) { 
+          y--;
+          if(y==-1 && x>3) x=3;
+        }
         else if(x==0) { y--; x--; }
         else x--;
 


### PR DESCRIPTION
When using keyboard with encoder (Lilygo T-Embed), there is a glitch.
If you are on a letter greater than the 3rd one in a row and press the PrevBtn and EscBtn at the same time, you can reproduce it.
Marker goes to the first row and selects SPACE, after that you need to rotate the encoder more than one time to go to DEL.
Similar bug occurs with NextBtn and EscBtn.

Now fixed.

