### PR TITLE
Fix SDcard mount error

### DIFF
--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -457,7 +457,6 @@ String loopSD(FS &fs, bool filePicker, String allowed_ext, String rootPath) {
   tft.fillScreen(bruceConfig.bgColor);
   tft.drawRoundRect(5,5,tftWidth-10,tftHeight-10,5,bruceConfig.priColor);
   if(&fs==&SD) {
-    closeSdCard();
     if(!setupSdCard()){
       displayError("Fail Mounting SD", true);
       return "";


### PR DESCRIPTION
#### Proposed Changes ####
Fix SD card mount error on CYD.

#### Types of Changes ####
Bugfix

#### Verification ####
removing the `closeSdCard();` on line 461 at `sd_functions.cpp` fixes the "Fail Mounting SD" bug even the SDCard was successfully mounted on boot this was probably caused by unmounting the SDcard without remounting it?

#### Testing ####
Tested on my 2USB-CYD

#### Linked Issues ####
Fixes #704 #696

```release-note
Fixes SD card mount error.
```

#### Further Comments ####

I'm not good at cpp if you guys can implement better fix that would be nice