### PR TITLE
Add t-display s3 power off menu item

### DIFF
--- a/boards/pinouts/lilygo-t-display-s3.h
+++ b/boards/pinouts/lilygo-t-display-s3.h
@@ -87,7 +87,7 @@ static const uint8_t SCL = GROVE_SCL;
 // Buttons & Navigation
 #define BTN_ALIAS	'"OK"'
 #define HAS_3_BUTTONS
-#define SEL_BTN     1
+#define SEL_BTN     16
 #define UP_BTN      0
 #define DW_BTN      14 
 #define BK_BTN	    3

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -28,6 +28,15 @@ void ConfigMenu::optionsMenu() {
 
 #if defined(T_EMBED_1101)
     options.emplace_back("Turn-off", [=]() { digitalWrite(PIN_POWER_ON,LOW); esp_sleep_enable_ext0_wakeup(GPIO_NUM_6,LOW); esp_deep_sleep_start(); });
+#elif defined(T_DISPLAY_S3)
+    options.emplace_back("Turn-off", [=]()
+    {
+        tft.fillScreen(TFT_BLACK);
+        digitalWrite(PIN_POWER_ON, LOW);
+        digitalWrite(TFT_BL, LOW);
+        tft.writecommand(0x10);
+        esp_deep_sleep_start(); 
+    });
 #endif
     if (bruceConfig.devMode) options.emplace_back("Dev Mode", [=]() { devMenu(); });
 


### PR DESCRIPTION
#### Proposed Changes ####
Add Power-Off menu item in Settings
Change Select button PIN to 16 for easier usage.

#### Types of Changes ####
Add new functions

#### Testing ####
Tested on stock lilyGO T-Display S3

Users are now having 2 ways to power-off the board:
- Hold both of BOOT & RST button for 3  seconds
- Settings > Power-Off
