### PR TITLE
Fix raw sniffer not writing to SDCard CYD

### DIFF
--- a/src/modules/wifi/sniffer.cpp
+++ b/src/modules/wifi/sniffer.cpp
@@ -329,7 +329,7 @@ void sniffer_setup() {
   long deauth_tmp=0;
   drawMainBorderWithTitle("RAW SNIFFER");
 
-  closeSdCard();
+  //closeSdCard();
   
   _only_HS=true; // default mode to start if it doesn't have SD Cadr
   if(setupSdCard()) {


### PR DESCRIPTION
#### Proposed Changes ####
removing the closeSdCard(); will fix the issue that the raw sniffer writes into LittleFS even the SDCard is present.

#### Types of Changes ####

removed **closeSdCard();** sdcard doesn't get remounted after closed..

#### Testing ####

Tested on CYD2USB