### PR TITLE
Implement error handling / quitting of "Listen TCP"

### DIFF
--- a/src/modules/wifi/tcp_utils.cpp
+++ b/src/modules/wifi/tcp_utils.cpp
@@ -41,7 +41,13 @@ void listenTcpPort() {
 
             while (client.connected()) {
                 if (inputMode) {
-                    String keyString = keyboard("", 16, "send input data");
+                    String keyString = keyboard("", 16, "send input data, q=quit");
+                    if (keyString == "q") {
+                        displayError("Exiting Listener");
+                        client.stop();
+                        server.stop();
+                        return;
+                    }
                     delay(300);
                     inputMode = false;
                     tft.fillScreen(TFT_BLACK);

--- a/src/modules/wifi/tcp_utils.cpp
+++ b/src/modules/wifi/tcp_utils.cpp
@@ -14,7 +14,15 @@ void listenTcpPort() {
     tft.setTextColor(TFT_WHITE, TFT_BLACK);
 
     String portNumber = keyboard("", 5, "TCP port to listen");
+    if (portNumber.length() == 0) {
+        displayError("No port number given, exiting");
+        return;
+    }
     int portNumberInt = atoi(portNumber.c_str());
+    if (portNumberInt == 0) {
+        displayError("Invalid port number, exiting");
+        return;
+    }
 
     WiFiServer server(portNumberInt);
     server.begin();


### PR DESCRIPTION
#### Proposed Changes ####

Implement functions to be able to leave TCP Listen properly.

#### Types of Changes ####

Improvement in TCP Listen usage

#### Verification ####

* Enter "Listen TCP" and press "OK" with an empty string for the port.
  Should show "No port number given, exiting" and end up in the main menu
* Enter "Listen TCP", enter a text e.g. "NOPORT" and press "OK".
  Should show "Invalid port number, exiting" and end up in the main menu
* Enter "Listen TCP", enter a valid port (e.g. 80) connect with a device, press Select to go into input mode
   input "q" only. 
   Should show "Exiting Listener" and end up in the main menu.

#### Testing ####

I couldn't find a mock for menu/behavioral testing.
Just tested myself on a Lilygo T-Embed CC1101

#### Linked Issues ####

none

#### User-Facing Change ####

```release-note
 - possibility to leave "TCP Listen" loop by sending the letter "q"
```

