### PR TITLE
Add BLE Name & WiFi AP Credentials Settings

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -28,6 +28,8 @@ JsonDocument BruceConfig::toJson() const {
     _wifiAp["ssid"] = wifiAp.ssid;
     _wifiAp["pwd"] = wifiAp.pwd;
 
+    setting["bleName"] = bleName;
+
     JsonObject _wifi = setting.createNestedObject("wifi");
     for (const auto& pair : wifi) {
         _wifi[pair.first] = pair.second;
@@ -125,6 +127,8 @@ void BruceConfig::fromFile() {
         for (JsonPair kv : setting["wifi"].as<JsonObject>())
             wifi[kv.key().c_str()] = kv.value().as<String>();
     } else { count++; log_e("Fail"); }
+
+    if(!setting["bleName"].isNull())  { bleName  = setting["bleName"].as<String>(); } else { count++; log_e("Fail"); }
 
     if(!setting["irTx"].isNull())        { irTx        = setting["irTx"].as<int>(); } else { count++; log_e("Fail"); }
     if(!setting["irRx"].isNull())        { irRx        = setting["irRx"].as<int>(); } else { count++; log_e("Fail"); }
@@ -356,6 +360,12 @@ String BruceConfig::getWifiPassword(const String& ssid) const {
     auto it = wifi.find(ssid);
     if (it != wifi.end()) return it->second;
     return "";
+}
+
+
+void BruceConfig::setBleName(String value) {
+    bleName = value;
+    saveFile();
 }
 
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -60,6 +60,9 @@ public:
     Credential webUI = {"admin", "bruce"};
     WiFiCredential wifiAp = {"BruceNet", "brucenet"};
     std::map<String, String> wifi = {};
+    
+    // BLE 
+    String bleName = String("Keyboard_" + String((uint8_t)(ESP.getEfuseMac() >> 32), HEX));
 
     // IR
     int irTx = LED;
@@ -139,6 +142,9 @@ public:
     void addQrCodeEntry(const String& menuName, const String& content);
     void removeQrCodeEntry(const String& menuName);
     String getWifiPassword(const String& ssid) const;
+
+    // BLE
+    void setBleName(const String name);
 
     // IR
     void setIrTxPin(int value);

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -21,6 +21,7 @@ void ConfigMenu::optionsMenu() {
         {"Sound On/Off",  [=]() { setSoundConfig(); }},
         {"Startup WiFi",  [=]() { setWifiStartupConfig(); }},
         {"Startup App",   [=]() { setStartupApp(); }},
+        {"Network Creds", [=]() { setNetworkCredsMenu(); }},
         {"Clock",         [=]() { setClock(); }},
         {"Sleep",         [=]() { setSleepMode(); }},
         {"Restart",       [=]() { ESP.restart(); }},

--- a/src/core/serialcmds.cpp
+++ b/src/core/serialcmds.cpp
@@ -800,6 +800,7 @@ bool processSerialCommand(String cmd_str) {
         setting_value.substring(setting_value.indexOf(",")+1)
       );
     }
+    if(setting_name=="bleName") bruceConfig.setBleName(setting_value);
     if(setting_name=="irTx") bruceConfig.setIrTxPin(setting_value.toInt());
     if(setting_name=="irRx") bruceConfig.setIrRxPin(setting_value.toInt());
     if(setting_name=="rfTx") bruceConfig.setRfTxPin(setting_value.toInt());

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -644,7 +644,7 @@ void setBleNameMenu() {
   options = {
     {"Default",   [=]() { bruceConfig.setBleName(defaultBleName); }, isDefault},
     {"Custom",    [=]() {
-      String newBleName = keyboard(isDefault ? "" : bruceConfig.bleName, 30, "BLE Device Name:");
+      String newBleName = keyboard(bruceConfig.bleName, 30, "BLE Device Name:");
       if (!newBleName.isEmpty()) bruceConfig.setBleName(newBleName);
       else displayError("BLE Name cannot be empty", true);
     }, !isDefault},

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -631,3 +631,93 @@ void setGpsBaudrateMenu() {
   loopOptions(options, bruceConfig.gpsBaudrate);
 
 }
+
+/*********************************************************************
+**  Function: setBleNameMenu
+**  Handles Menu to set BLE Gap Name
+**********************************************************************/
+void setBleNameMenu() {
+  const String defaultBleName = "Keyboard_" + String((uint8_t)(ESP.getEfuseMac() >> 32), HEX);
+
+  const bool isDefault = bruceConfig.bleName == defaultBleName;
+
+  options = {
+    {"Default",   [=]() { bruceConfig.setBleName(defaultBleName); }, isDefault},
+    {"Custom",    [=]() {
+      String newBleName = keyboard(isDefault ? "" : bruceConfig.bleName, 30, "BLE Device Name:");
+      if (!newBleName.isEmpty()) bruceConfig.setBleName(newBleName);
+      else displayError("BLE Name cannot be empty", true);
+    }, !isDefault},
+    {"Main Menu", [=]() { backToMenu(); }},
+  };
+
+  loopOptions(options, isDefault ? 0 : 1);
+}
+
+/*********************************************************************
+**  Function: setWifiApSsidMenu
+**  Handles Menu to set the WiFi AP SSID
+**********************************************************************/
+void setWifiApSsidMenu() {
+  const bool isDefault = bruceConfig.wifiAp.ssid == "BruceNet";
+
+  options = {
+    {"Default (BruceNet)", [=]() { bruceConfig.setWifiApCreds("BruceNet", bruceConfig.wifiAp.pwd); }, isDefault},
+    {"Custom",             [=]() {
+      String newSsid = keyboard(bruceConfig.wifiAp.ssid, 32, "WiFi AP SSID:");
+      if (!newSsid.isEmpty()) bruceConfig.setWifiApCreds(newSsid, bruceConfig.wifiAp.pwd);
+      else displayError("SSID cannot be empty", true);
+    }, !isDefault},
+    {"Main Menu",          [=]() { backToMenu(); }},
+  };
+
+  loopOptions(options, isDefault ? 0 : 1);
+}
+
+/*********************************************************************
+**  Function: setWifiApPasswordMenu
+**  Handles Menu to set the WiFi AP Password
+**********************************************************************/
+void setWifiApPasswordMenu() {
+  const bool isDefault = bruceConfig.wifiAp.pwd == "brucenet";
+
+  options = {
+    {"Default (brucenet)", [=]() { bruceConfig.setWifiApCreds(bruceConfig.wifiAp.ssid, "brucenet"); }, isDefault},
+    {"Custom",             [=]() {
+      String newPassword = keyboard(bruceConfig.wifiAp.pwd, 32, "WiFi AP Password:");
+      if (!newPassword.isEmpty()) bruceConfig.setWifiApCreds(bruceConfig.wifiAp.ssid, newPassword);
+      else displayError("Password cannot be empty", true);
+    }, !isDefault},
+    {"Main Menu",          [=]() { backToMenu(); }},
+  };
+
+  loopOptions(options, isDefault ? 0 : 1);
+}
+
+/*********************************************************************
+**  Function: setWifiApCredsMenu
+**  Handles Menu to configure WiFi AP Credentials
+**********************************************************************/
+void setWifiApCredsMenu() {
+  options = {
+    {"SSID",      [=]() { setWifiApSsidMenu(); }},
+    {"Password",  [=]() { setWifiApPasswordMenu(); }},
+    {"Main Menu", [=]() { backToMenu(); }},
+  };
+
+  loopOptions(options);
+}
+
+/*********************************************************************
+**  Function: setNetworkCredsMenu
+**  Main Menu for setting Network credentials (BLE & WiFi)
+**********************************************************************/
+void setNetworkCredsMenu() {
+  options = {
+    {"WiFi AP Creds", [=]() { setWifiApCredsMenu(); }},
+    {"BLE Name",      [=]() { setBleNameMenu(); }},
+    {"Main Menu",     [=]() { backToMenu(); }},
+  };
+
+  loopOptions(options);
+}

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -49,4 +49,6 @@ void setStartupApp();
 
 void setGpsBaudrateMenu();
 
+void setNetworkCredsMenu();
+
 #endif

--- a/src/modules/ble/bad_ble.cpp
+++ b/src/modules/ble/bad_ble.cpp
@@ -6,7 +6,10 @@
 #include "bad_ble.h"
 
 #define DEF_DELAY 100
-BleKeyboard Kble(String("Keyboard_" + String((uint8_t)(ESP.getEfuseMac() >> 32), HEX)).c_str(), "BruceNet", 98);
+
+bool KbleInitialized = false;
+BleKeyboard Kble;
+
 uint8_t Ask_for_restart=0;
 /* Example of payload file
 
@@ -31,6 +34,12 @@ STRINGLN encho Is this funny??
 REPEAT 20
 
 */
+
+void initBleKeyboard() {
+  if (KbleInitialized) return;
+  Kble = BleKeyboard(bruceConfig.bleName.c_str(), "BruceNet", 98);
+  KbleInitialized = true;
+}
 
 void key_input_ble(FS fs, String bad_script) {
   if (fs.exists(bad_script) && bad_script!="") {
@@ -235,6 +244,9 @@ bool ask_restart() {
 
 void ble_setup() {
   if(ask_restart()) return;
+
+  initBleKeyboard();
+
   FS *fs;
   Serial.println("BadBLE begin");
   bool first_time=true;
@@ -300,7 +312,6 @@ NewScript:
     else displayWarning("Canceled", true);
   }
 End:
-
   returnToMenu=true;
 }
 
@@ -309,6 +320,8 @@ End:
 void ble_MediaCommands() {
   if(ask_restart()) return;
   Ask_for_restart=1; // arm the flag
+  
+  initBleKeyboard();
 
   if(!Kble.isConnected()) Kble.begin();
 
@@ -338,7 +351,6 @@ void ble_MediaCommands() {
     if(!returnToMenu) goto reMenu;
   }
   returnToMenu=true;
-
 }
 
 #if defined(HAS_KEYBOARD)
@@ -346,6 +358,8 @@ void ble_MediaCommands() {
 
 void ble_keyboard() {
   if(ask_restart()) return;
+
+  initBleKeyboard();
 
   drawMainBorder();
   options = {

--- a/src/modules/ble/bad_ble.cpp
+++ b/src/modules/ble/bad_ble.cpp
@@ -35,7 +35,7 @@ REPEAT 20
 
 */
 
-void initBleKeyboard() {
+void initKBle() {
   if (KbleInitialized) return;
   Kble = BleKeyboard(bruceConfig.bleName.c_str(), "BruceNet", 98);
   KbleInitialized = true;
@@ -245,7 +245,7 @@ bool ask_restart() {
 void ble_setup() {
   if(ask_restart()) return;
 
-  initBleKeyboard();
+  initKBle();
 
   FS *fs;
   Serial.println("BadBLE begin");
@@ -321,7 +321,7 @@ void ble_MediaCommands() {
   if(ask_restart()) return;
   Ask_for_restart=1; // arm the flag
   
-  initBleKeyboard();
+  initKBle();
 
   if(!Kble.isConnected()) Kble.begin();
 
@@ -359,7 +359,7 @@ void ble_MediaCommands() {
 void ble_keyboard() {
   if(ask_restart()) return;
 
-  initBleKeyboard();
+  initKBle();
 
   drawMainBorder();
   options = {

--- a/src/modules/ble/bad_ble.cpp
+++ b/src/modules/ble/bad_ble.cpp
@@ -8,7 +8,7 @@
 #define DEF_DELAY 100
 
 bool KbleInitialized = false;
-BleKeyboard Kble;
+BleKeyboard Kble = BleKeyboard("BruceNet", "BruceNet", 98); // deviceName will be changed using setName()
 
 uint8_t Ask_for_restart=0;
 /* Example of payload file
@@ -34,12 +34,6 @@ STRINGLN encho Is this funny??
 REPEAT 20
 
 */
-
-void initKBle() {
-  if (KbleInitialized) return;
-  Kble = BleKeyboard(bruceConfig.bleName.c_str(), "BruceNet", 98);
-  KbleInitialized = true;
-}
 
 void key_input_ble(FS fs, String bad_script) {
   if (fs.exists(bad_script) && bad_script!="") {
@@ -245,7 +239,7 @@ bool ask_restart() {
 void ble_setup() {
   if(ask_restart()) return;
 
-  initKBle();
+  Kble.setName(bruceConfig.bleName.c_str());
 
   FS *fs;
   Serial.println("BadBLE begin");
@@ -321,7 +315,7 @@ void ble_MediaCommands() {
   if(ask_restart()) return;
   Ask_for_restart=1; // arm the flag
   
-  initKBle();
+  Kble.setName(bruceConfig.bleName.c_str());
 
   if(!Kble.isConnected()) Kble.begin();
 
@@ -359,7 +353,7 @@ void ble_MediaCommands() {
 void ble_keyboard() {
   if(ask_restart()) return;
 
-  initKBle();
+  Kble.setName(bruceConfig.bleName.c_str());
 
   drawMainBorder();
   options = {

--- a/src/modules/ble/bad_ble.cpp
+++ b/src/modules/ble/bad_ble.cpp
@@ -7,7 +7,6 @@
 
 #define DEF_DELAY 100
 
-bool KbleInitialized = false;
 BleKeyboard Kble = BleKeyboard("BruceNet", "BruceNet", 98); // deviceName will be changed using setName()
 
 uint8_t Ask_for_restart=0;


### PR DESCRIPTION
#### Proposed Changes ####
- Added "Network Credentials" setting:
  - Customize BLE Device Name (BadBLE).
  - Configure WiFi AP SSID and Password (WebUI AP).
  
#### User-Facing Change ####
You can now customize the BLE name and WiFi AP credentials through the Settings.

Resolves #725 