### PR TITLE
Update net_utils.cpp

### DIFF
--- a/src/core/net_utils.cpp
+++ b/src/core/net_utils.cpp
@@ -15,7 +15,7 @@ String getManufacturer(const String& mac){
   // but it is around 700kb and i don't know a way to get specific part
   // without downloading the whole txt
   HTTPClient http;
-  http.begin("https://api.maclookup.app/v2/macs/" + mac); 
+  http.begin("http://api.maclookup.app/v2/macs/" + mac); 
   int httpCode = http.GET();  // Send the request
   if( httpCode != 200 ){ http.end(); return "GET failed"; } 
 


### PR DESCRIPTION
Disable SSL Verification that causes memory errors.

#### Proposed Changes ####

use http instead of https when fetching the mac informations because it cause memory allocation errors when it tries to verify the SSL

#### Types of Changes ####

minor fix

#### Verification ####

Connect to wifi then AP info

#### Testing ####

Tested on CYD-2USB

#### Linked Issues ####
None

