### PR TITLE
Allow WebUI as a startup app

### DIFF
--- a/src/core/startup_app.cpp
+++ b/src/core/startup_app.cpp
@@ -12,11 +12,13 @@
 #include "modules/gps/gps_tracker.h"
 #include "modules/gps/wardriving.h"
 #include "modules/rfid/pn532ble.h"
+#include "modules/others/webInterface.h"
 
 StartupApp::StartupApp() {
     _startupApps["GPS Tracker"] = []() { GPSTracker(); };
     _startupApps["PN532 BLE"]  = []() { Pn532ble(); };
     _startupApps["Wardriving"]  = []() { Wardriving(); };
+    _startupApps["WebUI"]  = []() { startWebUi(); };
 }
 
 bool StartupApp::startApp(const String& appName) const {


### PR DESCRIPTION
#### Proposed Changes ####

This adds the WebUI to the list of possible startup apps

#### Types of Changes ####

New feature

#### Verification ####

1. Navigate to the "Config" menu
2. Choose "Startup App"
3. Verify that "WebUI" appears in the list
4. Choose "WebUI" from the list
5. Restart the device
6. Verify that the device boots into the WebUI

#### Testing ####

I'm not sure if it needs to be; I'm happy to take advice on how to write a test if it is. I built it using GitHub Actions on my fork and flashed it to my Lilygo T-Embed CC1101 and it worked the way I wanted it to.

#### User-Facing Change ####

```release-note
The WebUI can now be selected as a startup app.
```

#### Further Comments ####

My use case is that I have a ceiling fan that we currently control with a Flipper Zero, because the remote is long-lost. I thought maybe I could have another Flipper permanently connected to Home Assistant to control the fan, but they're $140 :) I found the T-Embed CC1101 and Bruce and and this is the only change I'll need to make it all work.