### PR TITLE
Add read cooldown to allow card removal in Chameleon module

### DIFF
--- a/src/modules/rfid/chameleon.cpp
+++ b/src/modules/rfid/chameleon.cpp
@@ -394,8 +394,6 @@ void Chameleon::factoryReset() {
 // LF Methods
 
 void Chameleon::readLFTag() {
-    if (millis() - _lastReadTime < 2000) return;
-
     if (!chmUltra.cmdLFRead()) return;
 
     formatLFUID();
@@ -405,7 +403,6 @@ void Chameleon::readLFTag() {
     padprintln("UID: " + printableLFUID);
 
     _lf_read_uid = true;
-    _lastReadTime = millis();
     delay(500);
 }
 
@@ -618,8 +615,6 @@ void Chameleon::parseLFUID() {
 // HF Methods
 
 void Chameleon::readHFTag() {
-    if (millis() - _lastReadTime < 2000) return;
-
     if (!chmUltra.cmd14aScan()) return;
 
     displayInfo("Reading data blocks...");
@@ -634,7 +629,6 @@ void Chameleon::readHFTag() {
     dumpHFCardDetails();
 
     _hf_read_uid = true;
-    _lastReadTime = millis();
     delay(500);
 }
 

--- a/src/modules/rfid/chameleon.cpp
+++ b/src/modules/rfid/chameleon.cpp
@@ -394,6 +394,8 @@ void Chameleon::factoryReset() {
 // LF Methods
 
 void Chameleon::readLFTag() {
+    if (millis() - _lastReadTime < 2000) return;
+
     if (!chmUltra.cmdLFRead()) return;
 
     formatLFUID();
@@ -403,6 +405,7 @@ void Chameleon::readLFTag() {
     padprintln("UID: " + printableLFUID);
 
     _lf_read_uid = true;
+    _lastReadTime = millis();
     delay(500);
 }
 
@@ -615,6 +618,8 @@ void Chameleon::parseLFUID() {
 // HF Methods
 
 void Chameleon::readHFTag() {
+    if (millis() - _lastReadTime < 2000) return;
+
     if (!chmUltra.cmd14aScan()) return;
 
     displayInfo("Reading data blocks...");
@@ -629,6 +634,7 @@ void Chameleon::readHFTag() {
     dumpHFCardDetails();
 
     _hf_read_uid = true;
+    _lastReadTime = millis();
     delay(500);
 }
 

--- a/src/modules/rfid/chameleon.h
+++ b/src/modules/rfid/chameleon.h
@@ -83,6 +83,7 @@ private:
     bool _hf_read_uid = false;
     bool _battery_set = false;
     bool pageReadSuccess = false;
+    uint32_t _lastReadTime = 0;
     String strAllPages = "";
     int totalPages = 0;
     int dataPages = 0;

--- a/src/modules/rfid/chameleon.h
+++ b/src/modules/rfid/chameleon.h
@@ -71,6 +71,7 @@ public:
     bool connect();
 
 private:
+    uint32_t _lastReadTime = 0;
     ChameleonUltra chmUltra = ChameleonUltra(true);
     ChameleonUltra::LfTag lfTagData;
     ChameleonUltra::HfTag hfTagData;

--- a/src/modules/rfid/chameleon.h
+++ b/src/modules/rfid/chameleon.h
@@ -71,7 +71,6 @@ public:
     bool connect();
 
 private:
-    uint32_t _lastReadTime = 0;
     ChameleonUltra chmUltra = ChameleonUltra(true);
     ChameleonUltra::LfTag lfTagData;
     ChameleonUltra::HfTag hfTagData;

--- a/src/modules/rfid/tag_o_matic.cpp
+++ b/src/modules/rfid/tag_o_matic.cpp
@@ -239,12 +239,15 @@ void TagOMatic::dump_scan_results() {
 }
 
 void TagOMatic::read_card() {
+    if (millis() - _lastReadTime < 2000) return;
+    
     if (_rfid->read() != RFIDInterface::SUCCESS) return;
 
     display_banner();
     dump_card_details();
 
     _read_uid = true;
+    _lastReadTime = millis();
     delay(500);
 }
 

--- a/src/modules/rfid/tag_o_matic.h
+++ b/src/modules/rfid/tag_o_matic.h
@@ -47,6 +47,7 @@ private:
     RFID_State _initial_state;
     bool _read_uid = false;
     bool _ndef_created = false;
+    uint32_t _lastReadTime = 0;
     RFID_State current_state;
     std::set<String> _scanned_set;
     std::vector<String> _scanned_tags;


### PR DESCRIPTION
#### Proposed Changes ####

Added a 2-second cooldown period after successful card reads in Chameleon module to prevent immediate re-reading. This gives users time to remove the card from the Chameleon Ultra device before subsequent read attempts.

#### Types of Changes ####
- Bugfix (addresses unintended immediate re-read behavior)
- Hardware interaction improvement

#### Linked Issues ####
Fixes #739 
