### PR TITLE
A better way to save IR devices

### DIFF
--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -372,12 +372,51 @@ bool IrRead::write_file(String filename, FS* fs) {
     if (fs == nullptr) return false;
 
     if (!(*fs).exists("/BruceIR")) (*fs).mkdir("/BruceIR");
+        
+    while ((*fs).exists("/BruceIR/" + filename + ".ir")) {
+        int ch = 1;
+        int i = 1;
+
+        displayWarning("File \"" + String(filename) + "\" already exist", true);
+        display_banner();
+
+        // ask to choose one
+        options = {
+            {"Add num index",  [&]()   {  ch=1; }},
+            {"Overwrite ",     [&]()   {  ch=2; }},
+            {"Change name",    [&]()   {  ch=3; }},
+        };
+        
+        loopOptions(options);
+
+        switch(ch)
+        {
+            case 1:
+                filename += "_";
+                while((*fs).exists("/BruceIR/" + filename + String(i) + ".ir")) i++;
+                filename += String(i);
+                break;
+            case 2:
+                (*fs).remove("/BruceIR/" + filename + ".ir");
+                break;
+            case 3:
+                filename = keyboard(filename, 30, "File name:");
+                display_banner();
+                break;
+        }
+    }
+
+    /*
+    /Old "Add num index" solution 
+
     if ((*fs).exists("/BruceIR/" + filename + ".ir")) {
         int i = 1;
         filename += "_";
         while((*fs).exists("/BruceIR/" + filename + String(i) + ".ir")) i++;
         filename += String(i);
     }
+    */
+
     File file = (*fs).open("/BruceIR/"+ filename + ".ir", FILE_WRITE);
 
     if(!file) {

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -377,12 +377,12 @@ bool IrRead::write_file(String filename, FS* fs) {
         int ch = 1;
         int i = 1;
 
-        displayWarning("File \"" + String(filename) + "\" already exist", true);
+        displayWarning("File \"" + String(filename) + "\" already exists", true);
         display_banner();
 
         // ask to choose one
         options = {
-            {"Add num index",  [&]()   {  ch=1; }},
+            {"Append number",  [&]()   {  ch=1; }},
             {"Overwrite ",     [&]()   {  ch=2; }},
             {"Change name",    [&]()   {  ch=3; }},
         };


### PR DESCRIPTION
Proposed Changes

> A better way to save IR devices

Verification

> Tested on t-embed-cc1101

Testing

> Every way of saving was tested and worked well
> If user presses ESK button when choosing what to do if file exist, it saves using _1 way

User-Facing Change

> Added choosing feature when ir_device file is already exist

Further Comments

> It is such a pain to get a memory card out and in of t-embed every time..