### PR TITLE
Fix taskInputHandler, remove blocking delay, optimisations

### DIFF
--- a/boards/lilygo-t-display-s3/interface.cpp
+++ b/boards/lilygo-t-display-s3/interface.cpp
@@ -90,35 +90,24 @@ void InputHandler(void)
   UpPress = false;
   DownPress = false;
 
-  if (digitalRead(SEL_BTN) == BTN_ACT || digitalRead(UP_BTN) == BTN_ACT || digitalRead(DW_BTN) == BTN_ACT)
-  {
-    if (!wakeUpScreen())
-      AnyKeyPress = true;
-    else
-      goto END;
-  }
+  bool upPressed = (digitalRead(UP_BTN) == BTN_ACT);
+  bool selPressed = (digitalRead(SEL_BTN) == BTN_ACT);
+  bool dwPressed = (digitalRead(DW_BTN) == BTN_ACT);
 
-  if (digitalRead(UP_BTN) == BTN_ACT)
-  {
-    PrevPress = true;
-  }
+  bool anyPressed = upPressed || selPressed || dwPressed;
+  if (anyPressed && wakeUpScreen()) return;
 
-  if (digitalRead(DW_BTN) == BTN_ACT)
-  {
-    NextPress = true;
-  }
+  AnyKeyPress = anyPressed;
+  PrevPress = upPressed;
+  EscPress = upPressed;
+  NextPress = dwPressed;
+  SelPress = selPressed;
 
-  if (digitalRead(SEL_BTN) == BTN_ACT)
-  {
-    SelPress = true;
-  }
-
-END:
-  if (AnyKeyPress)
-  {
+  if (AnyKeyPress) {
     long tmp = millis();
-    while ((millis() - tmp) < 200 && (digitalRead(SEL_BTN) == BTN_ACT || digitalRead(UP_BTN) == BTN_ACT || digitalRead(DW_BTN) == BTN_ACT))
-      ;
+    while ((millis() - tmp) < 200 && (digitalRead(SEL_BTN) == BTN_ACT || digitalRead(UP_BTN) == BTN_ACT || digitalRead(DW_BTN) == BTN_ACT)) {
+      vTaskDelay(pdMS_TO_TICKS(5));  // Small delay instead of busy wait
+    }
   }
 }
 

--- a/boards/m5stack-core/interface.cpp
+++ b/boards/m5stack-core/interface.cpp
@@ -44,25 +44,26 @@ void _setBrightness(uint8_t brightval) {
 **********************************************************************/
 void InputHandler(void) {
     M5.update();
-    if(M5.BtnA.isPressed() || M5.BtnB.isPressed() || M5.BtnC.isPressed()) {
-        if(!wakeUpScreen()) AnyKeyPress = true;
-        else goto END;
-    }    
-    if(M5.BtnA.isPressed()) {
-        PrevPress = true;
-        EscPress = true;
-    }
-    if(M5.BtnC.isPressed()) {
-        NextPress = true;
-    }
-    if(M5.BtnB.isPressed()) {
-        SelPress = true;
-    }
-    END:
+    bool aPressed = (M5.BtnA.isPressed());
+    bool bPressed = (M5.BtnB.isPressed());
+    bool cPressed = (M5.BtnC.isPressed());
+
+    bool anyPressed = aPressed || bPressed || cPressed;
+    if (anyPressed && wakeUpScreen()) return;
+
+    AnyKeyPress = anyPressed;
+    PrevPress = aPressed;
+    EscPress = aPressed;
+    NextPress = cPressed;
+    SelPress = bPressed;
+
     if(AnyKeyPress) {
       long tmp=millis();
       M5.update();
-      while((millis()-tmp)<200 && (M5.BtnA.isPressed() || M5.BtnB.isPressed() || M5.BtnC.isPressed())) { delay(50); M5.update(); };
+      while((millis()-tmp)<200 && (M5.BtnA.isPressed() || M5.BtnB.isPressed() || M5.BtnC.isPressed())) {
+        vTaskDelay(pdMS_TO_TICKS(50));
+        M5.update();
+      };
     }
 }
 

--- a/boards/m5stack-cplus1_1/interface.cpp
+++ b/boards/m5stack-cplus1_1/interface.cpp
@@ -41,26 +41,24 @@ void _setBrightness(uint8_t brightval) {
 ** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
 **********************************************************************/
 void InputHandler(void) {
-    if(axp192.GetBtnPress()) {
-        if(!wakeUpScreen()) AnyKeyPress = true;
-        else goto END;
-        PrevPress = true;
-        EscPress = true;
-    }
-    if(digitalRead(DW_BTN)==LOW) {
-        if(!wakeUpScreen()) AnyKeyPress = true;
-        else goto END;
-        NextPress = true;
-    }
-    if(digitalRead(SEL_BTN)==LOW) {
-        if(!wakeUpScreen()) AnyKeyPress = true;
-        else goto END;
-        SelPress = true;
-    }
-    END:
+    bool upPressed = (axp192.GetBtnPress());
+    bool selPressed = (digitalRead(SEL_BTN)==LOW);
+    bool dwPressed = (digitalRead(DW_BTN)==LOW);
+
+    bool anyPressed = upPressed || selPressed || dwPressed;
+    if (anyPressed && wakeUpScreen()) return;
+
+    AnyKeyPress = anyPressed;
+    PrevPress = upPressed;
+    EscPress = upPressed;
+    NextPress = dwPressed;
+    SelPress = selPressed;
+
     if(AnyKeyPress) {
-      long tmp=millis();
-      while((millis()-tmp)<200 && (axp192.GetBtnPress() || digitalRead(SEL_BTN)==LOW || digitalRead(DW_BTN)==LOW));
+        long tmp=millis();
+        while((millis()-tmp)<200 && (axp192.GetBtnPress() || digitalRead(SEL_BTN)==LOW || digitalRead(DW_BTN)==LOW)) {
+            vTaskDelay(pdMS_TO_TICKS(5));  // Small delay instead of busy wait
+        }
     }
 }
 

--- a/boards/m5stack-cplus2/interface.cpp
+++ b/boards/m5stack-cplus2/interface.cpp
@@ -70,25 +70,26 @@ void _setBrightness(uint8_t brightval) {
 ** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
 **********************************************************************/
 void InputHandler(void) {
-    if(digitalRead(UP_BTN)==LOW || digitalRead(SEL_BTN)==LOW || digitalRead(DW_BTN)==LOW) {
-        if(!wakeUpScreen()) AnyKeyPress = true;
-        else goto END;
-    }    
-    if(digitalRead(UP_BTN)==LOW) {
-        PrevPress = true;
-        EscPress = true;
+  bool upPressed = (digitalRead(UP_BTN) == LOW);
+  bool selPressed = (digitalRead(SEL_BTN) == LOW);
+  bool dwPressed = (digitalRead(DW_BTN) == LOW);
+
+  bool anyPressed = upPressed || selPressed || dwPressed;
+  if (anyPressed && wakeUpScreen()) return;
+
+  AnyKeyPress = anyPressed;
+  PrevPress = upPressed;
+  EscPress = upPressed;
+  NextPress = dwPressed;
+  SelPress = selPressed;
+
+  if (AnyKeyPress) {
+    long startTime = millis();
+    while ((millis() - startTime) < 200) {
+      if (!(digitalRead(UP_BTN) == LOW || digitalRead(SEL_BTN) == LOW || digitalRead(DW_BTN) == LOW)) break;
+      vTaskDelay(pdMS_TO_TICKS(5));  // Small delay instead of busy wait
     }
-    if(digitalRead(DW_BTN)==LOW) {
-        NextPress = true;
-    }
-    if(digitalRead(SEL_BTN)==LOW) {
-        SelPress = true;
-    }
-    END:
-    if(AnyKeyPress) {
-      long tmp=millis();
-      while((millis()-tmp)<200 && (digitalRead(UP_BTN)==LOW || digitalRead(SEL_BTN)==LOW || digitalRead(DW_BTN)==LOW));
-    }
+  }
 }
 
 

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -89,16 +89,16 @@ void turnOffDisplay() {
 
 bool wakeUpScreen(){
   previousMillis = millis();
-  if(isScreenOff){
+  if (isScreenOff) {
     isScreenOff = false;
     dimmer = false;
     getBrightness();
-    delay(200);
+    vTaskDelay(pdMS_TO_TICKS(200));
     return true;
-  }else if(dimmer){
+  } else if(dimmer) {
     dimmer = false;
     getBrightness();
-    delay(200);
+    vTaskDelay(pdMS_TO_TICKS(200));
     return true;
   }
   return false;
@@ -681,7 +681,6 @@ void drawWireguardStatus(int x, int y) {
 Opt_Coord listFiles(int index, std::vector<FileList> fileList) {
     Opt_Coord coord;
     if(index==0){
-      tft.fillScreen(bruceConfig.bgColor);
       tft.fillScreen(bruceConfig.bgColor);
     }
     tft.setCursor(10,10);

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -286,8 +286,8 @@ String keyboard(String mytext, int maxSize, String msg) {
   tft.fillScreen(bruceConfig.bgColor);
 
 #if defined(HAS_3_BUTTONS) // StickCs and Core for long press detection logic
-  bool longNextPress = false;
-  bool longPrevPress = false;
+  uint8_t longNextPress = 0;
+  uint8_t longPrevPress = 0;
   long longPressTmp=millis();
 #endif  
   while(1) {
@@ -439,15 +439,24 @@ String keyboard(String mytext, int maxSize, String msg) {
       }
       /* Down Btn to move in X axis (to the right) */
       if(longNextPress || NextPress) {
-        if(!longNextPress) {
-          longNextPress = true;
-          longPressTmp = millis();
+        unsigned long now = millis();
+        if (!longNextPress) {
+          longNextPress = 1;
+          longPressTmp = now;
         }
-        if(longNextPress && millis()-longPressTmp<200) goto WAITING;
-        longNextPress=false;
-
-        if(check(NextPress)) { x--;  /* delay(250); */ } // Long Press
-        else x++; // Short Press
+        delay(1); // does not work without it
+        // Check if the button is held long enough (long press)
+        if (now - longPressTmp > 300) {
+          x--;  // Long press action
+          longNextPress = 2;
+          longPressTmp = now;
+        } else if (!NextPress) {
+          if (longNextPress != 2) x++;  // Short press action
+          longNextPress = 0;
+        } else {
+          goto WAITING;
+        }
+        // delay(10);
         if(y<0 && x>3) x=0;
         if(x>11) x=0;
         else if (x<0) x=11;
@@ -455,15 +464,23 @@ String keyboard(String mytext, int maxSize, String msg) {
       }
       /* UP Btn to move in Y axis (Downwards) */
       if(longPrevPress || PrevPress) {
-        if(!longPrevPress) {
-          longPrevPress = true;
-          longPressTmp = millis();
+        unsigned long now = millis();
+        if (!longPrevPress) {
+          longPrevPress = 1;
+          longPressTmp = now;
         }
-        if(longPrevPress && millis()-longPressTmp<200) goto WAITING;
-        longPrevPress=false;
-
-        if(check(PrevPress)) { y--; /* delay(250); */ } // Long press
-        else y++; // short press
+        delay(1); // does not work without it
+        // Check if the button is held long enough (long press)
+        if (now - longPressTmp > 300) {
+          y--;  // Long press action
+          longPrevPress = 2;
+          longPressTmp = now;
+        } else if (!PrevPress) {
+          if (longPrevPress != 2) y++;  // Short press action
+          longPrevPress = 0;
+        } else {
+          goto WAITING;
+        }
         if(y>3) { y=-1; }
         else if(y<-1) y=3;
         redraw = true;

--- a/src/core/powerSave.cpp
+++ b/src/core/powerSave.cpp
@@ -3,15 +3,19 @@
 #include "display.h"
 
 /* Check if it's time to put the device to sleep */
-void checkPowerSaveTime(){
-  if(bruceConfig.dimmerSet!=0){
-    if((millis() - previousMillis) >= (bruceConfig.dimmerSet * 1000) && dimmer == false && isSleeping == false){
-      dimmer = true;
-      setBrightness(5, false);
-    }else if((millis() - previousMillis) >= ((bruceConfig.dimmerSet * 1000) + 5000) && isScreenOff == false && isSleeping == false){
-      isScreenOff = true;
-      turnOffDisplay();
-    }
+#define SCREEN_OFF_DELAY 5000
+
+void checkPowerSaveTime() {
+  if (bruceConfig.dimmerSet == 0) return;
+  unsigned long elapsed = millis() - previousMillis;
+
+  if (elapsed >= (bruceConfig.dimmerSet * 1000) && !dimmer && !isSleeping) {
+    dimmer = true;
+    setBrightness(5, false);
+  } 
+  else if (elapsed >= ((bruceConfig.dimmerSet * 1000) + SCREEN_OFF_DELAY) && !isScreenOff && !isSleeping) {
+    isScreenOff = true;
+    turnOffDisplay();
   }
 }
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -422,7 +422,6 @@ void runClockLoop() {
 
   // Delay due to SelPress() detected on run
   tft.fillScreen(bruceConfig.bgColor);
-  tft.fillScreen(bruceConfig.bgColor);
   delay(300);
 
   for (;;){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ void __attribute__((weak)) taskInputHandler(void *parameter) {
       PrevPagePress=false;
       touchPoint.pressed=false;
       InputHandler();
-      vTaskDelay(10 / portTICK_PERIOD_MS);
+      vTaskDelay(pdMS_TO_TICKS(10));
     }
 }
 // Public Globals Variables


### PR DESCRIPTION
#### Proposed Changes ####

- Removed blocking delays in InputHandler tasks
- Optimized button state reading. Instead of calling digitalRead() multiple times for the same button, we read once and store the result.

#### Types of Changes ####

Bugfix

#### Verification ####

Verification
- Test by clicking buttons and waking up the device.
- The device should now wake up instantly when a button is pressed.
- Holding a button should not cause lag or unresponsiveness.
- Keypresses should only be processed after wake-up, after 200ms delay, preventing accidental inputs.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Removed blocking delays in Input Handler
- Optimized button state reading
```

#### Further Comments ####

