### PR TITLE
Add NRF24 support for T-Display S3 board

### DIFF
--- a/boards/lilygo-t-display-s3.ini
+++ b/boards/lilygo-t-display-s3.ini
@@ -21,6 +21,13 @@ build_flags =
 	-DRF_TX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
 	-DRF_RX_PINS='{{"Pin 43", 43}, {"Pin 44", 44}}'
 
+	;NRF24 support SPI
+	-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=3
+	-DNRF24_SS_PIN=SPI_SS_PIN
+	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
+	-DNRF24_SCK_PIN=SPI_SCK_PIN
+	-DNRF24_MISO_PIN=SPI_MISO_PIN
 lib_deps =
 	${env.lib_deps}
 	fastled/FastLED @3.9.4


### PR DESCRIPTION
#### Proposed Changes ####

Enable NRF24 support

#### Types of Changes ####

Enable feature on supported board

#### Notes
Pin mapping between T-Display S3 with NRF24L01
| T-Display S3| NRF24-L01   | 
| :---:   | :---: | 
| 3V| VCC| 
| GND| GND| 
| 3| CE| 
| 10| CSN| 
| 12| SCK| 
| 11| MOSI| 
| 13| MISO| 