### PR TITLE
Fix strcmp in display.cpp

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -274,7 +274,7 @@ void padprintln(const String &s, int16_t padx) {
   }
 }
 void padprintln(const char str[], int16_t padx) {
-  if (strcmp(str, "")) {
+  if (strcmp(str, "") == 0) {
     tft.setCursor(padx * BORDER_PAD_X, tft.getCursorY());
     tft.println(str);
     return;


### PR DESCRIPTION
#### Proposed Changes ####

- Fix the strcmp in display.cpp, the strcmp returns int 0 if strings are equal

#### Types of Changes ####

Bugfix

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

