### PR TITLE
Add IR Tx Repeats support, fix IR on Serial Cmds

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -36,6 +36,7 @@ JsonDocument BruceConfig::toJson() const {
     }
 
     setting["irTx"] = irTx;
+    setting["irTxRepeats"] = irTxRepeats;
     setting["irRx"] = irRx;
 
     setting["rfTx"] = rfTx;
@@ -131,6 +132,7 @@ void BruceConfig::fromFile() {
     if(!setting["bleName"].isNull())  { bleName  = setting["bleName"].as<String>(); } else { count++; log_e("Fail"); }
 
     if(!setting["irTx"].isNull())        { irTx        = setting["irTx"].as<int>(); } else { count++; log_e("Fail"); }
+    if(!setting["irTxRepeats"].isNull()) { irTxRepeats = setting["irTxRepeats"].as<uint8_t>(); } else { count++; log_e("Fail"); }
     if(!setting["irRx"].isNull())        { irRx        = setting["irRx"].as<int>(); } else { count++; log_e("Fail"); }
 
     if(!setting["rfTx"].isNull())        { rfTx        = setting["rfTx"].as<int>(); } else { count++; log_e("Fail"); }
@@ -371,6 +373,12 @@ void BruceConfig::setBleName(String value) {
 
 void BruceConfig::setIrTxPin(int value) {
     irTx = value;
+    saveFile();
+}
+
+
+void BruceConfig::setIrTxRepeats(uint8_t value) {
+    irTxRepeats = value;
     saveFile();
 }
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -66,6 +66,7 @@ public:
 
     // IR
     int irTx = LED;
+    uint8_t irTxRepeats = 0;
     int irRx = GROVE_SCL;
 
     // RF
@@ -148,6 +149,7 @@ public:
 
     // IR
     void setIrTxPin(int value);
+    void setIrTxRepeats(uint8_t value);
     void setIrRxPin(int value);
 
     // RF

--- a/src/core/menu_items/IRMenu.cpp
+++ b/src/core/menu_items/IRMenu.cpp
@@ -16,15 +16,16 @@ void IRMenu::optionsMenu() {
     };
 
     String txt = "Infrared";
-    txt+=" Tx: " + String(bruceConfig.irTx) + " Rx: " + String(bruceConfig.irRx);
+    txt+=" Tx: " + String(bruceConfig.irTx) + " Rx: " + String(bruceConfig.irRx) + " Rpts: " + String(bruceConfig.irTxRepeats);
     loopOptions(options,false,true,txt);
 }
 
 void IRMenu::configMenu() {
     options = {
-        {"Ir TX Pin", [=]() { gsetIrTxPin(true); }},
-        {"Ir RX Pin", [=]() { gsetIrRxPin(true); }},
-        {"Back",      [=]() { optionsMenu(); }},
+        {"Ir TX Pin",     [=]() { gsetIrTxPin(true); }},
+        {"Ir RX Pin",     [=]() { gsetIrRxPin(true); }},
+        {"Ir TX Repeats", [=]() { setIrTxRepeats(); }},
+        {"Back",          [=]() { optionsMenu(); }},
     };
 
     loopOptions(options,false,true,"IR Config");

--- a/src/core/serialcmds.cpp
+++ b/src/core/serialcmds.cpp
@@ -303,6 +303,7 @@ bool processSerialCommand(String cmd_str) {
       }
 
       IRCode code;
+      code.type = "parsed";
       code.protocol = protocolStr;
       code.address = address;
       code.command = command;
@@ -843,6 +844,7 @@ bool processSerialCommand(String cmd_str) {
     }
     if(setting_name=="bleName") bruceConfig.setBleName(setting_value);
     if(setting_name=="irTx") bruceConfig.setIrTxPin(setting_value.toInt());
+    if(setting_name=="irTxRepeats") bruceConfig.setIrTxRepeats(static_cast<uint8_t>(setting_value.toInt()));
     if(setting_name=="irRx") bruceConfig.setIrRxPin(setting_value.toInt());
     if(setting_name=="rfTx") bruceConfig.setRfTxPin(setting_value.toInt());
     if(setting_name=="rfRx") bruceConfig.setRfRxPin(setting_value.toInt());

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -491,6 +491,27 @@ int gsetIrTxPin(bool set){
   return bruceConfig.irTx;
 }
 
+void setIrTxRepeats() {
+  uint8_t chRpts = 0; // Chosen Repeats
+
+  options = {
+    {"None",                        [&]() { chRpts = 0; }},
+    {"5  (+ 1 initial)",            [&]() { chRpts = 5; }},
+    {"10 (+ 1 initial)",            [&]() { chRpts = 10; }},
+    {"Custom",        [&]() {
+      // up to 99 repeats
+      String rpt = keyboard(String(bruceConfig.irTxRepeats), 2, "Nbr of Repeats (+ 1 initial)");
+      chRpts = static_cast<uint8_t>(rpt.toInt());
+    }},
+    {"Main Menu",     [=]() { backToMenu(); }},
+  };
+
+  loopOptions(options);
+
+  if (returnToMenu) return;
+  
+  bruceConfig.setIrTxRepeats(chRpts);
+}
 /*********************************************************************
 **  Function: gsetIrRxPin
 **  get or set IR Rx Pin

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -33,6 +33,8 @@ void runClockLoop();
 
 int gsetIrTxPin(bool set = false);
 
+void setIrTxRepeats();
+
 int gsetIrRxPin(bool set = false);
 
 int gsetRfTxPin(bool set = false);

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -17,44 +17,6 @@ uint32_t swap32(uint32_t value) {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Custom IR
 
-struct IRCode {
-  IRCode(
-    String protocol="",
-    String address="",
-    String command="",
-    String data="",
-    uint8_t bits=32
-  ) : protocol(protocol),
-      address(address),
-      command(command),
-      data(data),
-      bits(bits) { }
-
-  IRCode(IRCode *code) {
-    name = String(code->name);
-    type = String(code->type);
-    protocol = String(code->protocol);
-    address = String(code->address);
-    command = String(code->command);
-    frequency = code->frequency;
-    bits = code->bits;
-    // duty_cycle = code->duty_cycle;
-    data = String(code->data);
-    filepath = String(code->filepath);
-  }
-
-  String protocol="";
-  String address="";
-  String command="";
-  String data="";
-  uint8_t bits=32;
-  String name="";
-  String type="";
-  uint16_t frequency=0;
-  //float duty_cycle;
-  String filepath="";
-};
-
 static std::vector<IRCode*> codes;
 
 void resetCodesArray() {
@@ -84,8 +46,6 @@ void addToRecentCodes(IRCode *ircode)  {
       recent_ircodes.pop_back();
     }
 }
-
-void sendIRCommand(IRCode *code);
 
 void selectRecentIrMenu() {
     // show menu with filenames
@@ -376,15 +336,19 @@ void otherIRcodes() {
 // IR commands
 
 void sendIRCommand(IRCode *code) {
-  if(code->type=="raw")  sendRawCommand(code->frequency, code->data);
-  else if(code->protocol=="NEC") sendNECCommand(code->address, code->command);
-  else if(code->protocol=="NECext") sendNECextCommand(code->address, code->command);
-  else if(code->protocol=="RC5"||code->protocol=="RC5X") sendRC5Command(code->address, code->command);
-  else if(code->protocol=="RC6") sendRC6Command(code->address, code->command);
-  else if(code->protocol=="Samsung32") sendSamsungCommand(code->address, code->command);
-  else if(code->protocol.startsWith("SIRC")) sendSonyCommand(code->address, code->command);
-  else if(code->protocol=="Kaseikyo") sendKaseikyoCommand(code->address, code->command);
-  else if(code->protocol!="") sendDecodedCommand(code->protocol, code->data, code->bits);
+  if(code->type.equalsIgnoreCase("raw"))  sendRawCommand(code->frequency, code->data);
+  else if(code->protocol.equalsIgnoreCase("NEC")) sendNECCommand(code->address, code->command);
+  else if(code->protocol.equalsIgnoreCase("NECext")) sendNECextCommand(code->address, code->command);
+  else if(code->protocol.equalsIgnoreCase("RC5")||
+          code->protocol.equalsIgnoreCase("RC5X")) sendRC5Command(code->address, code->command);
+  else if(code->protocol.equalsIgnoreCase("RC6")) sendRC6Command(code->address, code->command);
+  else if(code->protocol.equalsIgnoreCase("Samsung32")) sendSamsungCommand(code->address, code->command);
+  else if(code->protocol.equalsIgnoreCase("SIRC")   ||
+          code->protocol.equalsIgnoreCase("SIRC15") ||
+          code->protocol.equalsIgnoreCase("SIRC20")) sendSonyCommand(code->address, code->command);
+  else if(code->protocol.equalsIgnoreCase("Kaseikyo")) sendKaseikyoCommand(code->address, code->command);
+  // Others protocols of IRRemoteESP8266, not related to Flipper Zero IR File Format
+  else if(code->protocol!="" && code->data!="" && strToDecodeType(code->protocol.c_str()) != decode_type_t::UNKNOWN) sendDecodedCommand(code->protocol, code->data, code->bits);
 }
 
 void sendNECCommand(String address, String command) {

--- a/src/modules/ir/custom_ir.h
+++ b/src/modules/ir/custom_ir.h
@@ -6,9 +6,46 @@
 #include <SD.h>
 #include <globals.h>
 
+struct IRCode {
+  IRCode(
+    String protocol="",
+    String address="",
+    String command="",
+    String data="",
+    uint8_t bits=32
+  ) : protocol(protocol),
+      address(address),
+      command(command),
+      data(data),
+      bits(bits) { }
 
+  IRCode(IRCode *code) {
+    name = String(code->name);
+    type = String(code->type);
+    protocol = String(code->protocol);
+    address = String(code->address);
+    command = String(code->command);
+    frequency = code->frequency;
+    bits = code->bits;
+    // duty_cycle = code->duty_cycle;
+    data = String(code->data);
+    filepath = String(code->filepath);
+  }
+
+  String protocol="";
+  String address="";
+  String command="";
+  String data="";
+  uint8_t bits=32;
+  String name="";
+  String type="";
+  uint16_t frequency=0;
+  //float duty_cycle;
+  String filepath="";
+};
 
 // Custom IR
+void sendIRCommand(IRCode *code);
 void sendRawCommand(uint16_t frequency, String rawData);
 void sendNECCommand(String address, String command);
 void sendNECextCommand(String address, String command);


### PR DESCRIPTION
#### Proposed Changes ####
- Serial Commands:
  - Added support for all decoded protocols.
  - Added support for RAW type.
- IR:
  - Added "Ir Tx Repeats" setting to specify the number of additional repeats (1 initial + X repeats), when sending a command from Custom IR.
  
#### Linked Issues ####
Resolves #799