### PR TITLE
W328R and S024R port, Invert color option

### DIFF
--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -39,7 +39,7 @@ jobs:
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
-              vendor: "M5Stack",
+              vendor: "LAUNCHER",
               name: "M5StickCPlus_Launcher",
               env: "LAUNCHER_m5stack-cplus1_1",
               family: "ESP32",
@@ -102,7 +102,7 @@ jobs:
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
-              vendor: "CYD",
+              vendor: "WIP",
               name: "CYD-2432W328R",
               env: "CYD-2432W328R",
               family: "ESP32",
@@ -116,28 +116,28 @@ jobs:
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
-              vendor: "CYD",
+              vendor: "WIP",
               name: "CYD-2432S024R",
               env: "CYD-2432S024R",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
-              vendor: "CYD",
+              vendor: "LAUNCHER",
               name: "CYD-2432S028_Launcher",
               env: "LAUNCHER_CYD-2432S028",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
-              vendor: "CYD",
+              vendor: "LAUNCHER",
               name: "CYD-2USB_Launcher",
               env: "LAUNCHER_CYD-2USB",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
-              vendor: "CYD",
+              vendor: "LAUNCHER",
               name: "CYD-2432W328C_Launcher",
               env: "LAUNCHER_CYD-2432W328C",
               family: "ESP32",
@@ -263,7 +263,11 @@ jobs:
 
           echo "$js_content" > "./Bruce-${{ matrix.board.env }}.json"
 
-          html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"
+          if [${{ matrix.board.vendor }} == "LAUNCHER"]; then 
+            html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' onClick=\"downloadFile('${{ matrix.board.env }}')\" /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"
+          else
+            html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"
+          fi
           echo "$html" > ./Bruce-${{ matrix.board.vendor }}.html
           cat ./Bruce-${{ matrix.board.vendor }}.html
           echo $HOME
@@ -302,6 +306,8 @@ jobs:
           lilygo="\n"
           esp32="\n"
           cyd="\n"
+          launcher="\n"
+          wip="\n"
 
 
 
@@ -322,6 +328,12 @@ jobs:
                 "Bruce-CYD.html")
                   cyd+="$content\n"
                   ;;
+                "Bruce-LAUNCHER.html")
+                  launcher+="$content\n"
+                  ;;
+                "Bruce-WIP.html")
+                  wip+="$content\n"
+                  ;;
               esac
               echo "$file" # Exibe o caminho do arquivo processado
             fi
@@ -339,6 +351,12 @@ jobs:
           html+="</ul>"
           html+="<ul class='device-list esp32'>"
           html+="$esp32"
+          html+="</ul>"
+          html+="<ul class='device-list launcher'>"
+          html+="$launcher"
+          html+="</ul>"
+          html+="<ul class='device-list wip'>"
+          html+="$wip"
           html+="</ul>"
 
           # Exibe as quebras de linha

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -263,7 +263,7 @@ jobs:
 
           echo "$js_content" > "./Bruce-${{ matrix.board.env }}.json"
 
-          if [["${{ matrix.board.vendor }}" == "LAUNCHER"]]; then 
+          if [[ "${{ matrix.board.vendor }}" == "LAUNCHER" ]]; then 
             html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' onClick=\"downloadFile('${{ matrix.board.env }}')\" /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"
           else
             html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -19,28 +19,28 @@ jobs:
         board:
           - {
               vendor: "M5Stack",
-              name: "M5Cardputer",
+              name: "Cardputer",
               env: "m5stack-cardputer",
               family: "ESP32-S3",
               partitions: { bootloader_addr: "0x0000" },
             }
           - {
               vendor: "M5Stack",
-              name: "M5StickCPlus2",
+              name: "StickCPlus2",
               env: "m5stack-cplus2",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
               vendor: "M5Stack",
-              name: "M5StickCPlus",
+              name: "StickCPlus 1.1",
               env: "m5stack-cplus1_1",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
               vendor: "LAUNCHER",
-              name: "M5StickCPlus_Launcher",
+              name: "M5StickCPlus 1.1",
               env: "LAUNCHER_m5stack-cplus1_1",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
@@ -89,7 +89,7 @@ jobs:
             }
           - {
               vendor: "CYD",
-              name: "CYD-2USB",
+              name: "CYD-2432S028 (2USB or inverted Colors)",
               env: "CYD-2USB",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
@@ -102,78 +102,78 @@ jobs:
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
+              vendor: "CYD",
+              name: "CYD-2432W328C (inv colors) and CYD-2432S024C",
+              env: "CYD-2432W328C_2",
+              family: "ESP32",
+              partitions: { bootloader_addr: "0x1000" },
+            }            
+          - {
               vendor: "WIP",
-              name: "CYD-2432W328R",
+              name: "CYD-2432W328R (touch not working)",
               env: "CYD-2432W328R",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
-              vendor: "CYD",
-              name: "CYD-2432W328C(inv_colors)_and_CYD-2432S024C",
-              env: "CYD-2432W328C_2",
-              family: "ESP32",
-              partitions: { bootloader_addr: "0x1000" },
-            }
-          - {
               vendor: "WIP",
-              name: "CYD-2432S024R",
+              name: "CYD-2432S024R  (touch not working)",
               env: "CYD-2432S024R",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
               vendor: "LAUNCHER",
-              name: "CYD-2432S028_Launcher",
+              name: "CYD-2432S028",
               env: "LAUNCHER_CYD-2432S028",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
               vendor: "LAUNCHER",
-              name: "CYD-2USB_Launcher",
+              name: "CYD-2432S028 (2USB or Inverted Colors)",
               env: "LAUNCHER_CYD-2USB",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
               vendor: "LAUNCHER",
-              name: "CYD-2432W328C_Launcher",
+              name: "CYD-2432W328C",
               env: "LAUNCHER_CYD-2432W328C",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }
           - {
               vendor: "Lilygo",
-              name: "Lilygo_T-Embed_CC1101",
+              name: "Lilygo T-Embed CC1101",
               env: "lilygo-t-embed-cc1101",
               family: "ESP32-S3",
               partitions: { bootloader_addr: "0x0" },
             }
           - {
               vendor: "Lilygo",
-              name: "Lilygo_T-Embed",
+              name: "Lilygo T-Embed",
               env: "lilygo-t-embed",
               family: "ESP32-S3",
               partitions: { bootloader_addr: "0x0" },
             }
           - {
               vendor: "Lilygo",
-              name: "Lilygo_T-Deck",
+              name: "Lilygo T-Deck",
               env: "lilygo-t-deck",
               family: "ESP32-S3",
               partitions: { bootloader_addr: "0x0" },
             }
           - {
               vendor: "Lilygo",
-              name: "Lilygo_T-Deck-Pro",
+              name: "Lilygo T-Deck-Plus",
               env: "lilygo-t-deck-pro",
               family: "ESP32-S3",
               partitions: { bootloader_addr: "0x0" },
             }
           - {
               vendor: "Lilygo",
-              name: "Lilygo_T-Display-s3",
+              name: "Lilygo T-Display-S3",
               env: "lilygo-t-display-s3",
               family: "ESP32-S3",
               partitions: { bootloader_addr: "0x0" },

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -109,9 +109,16 @@ jobs:
               partitions: { bootloader_addr: "0x1000" },
             }            
           - {
-              vendor: "WIP",
+              vendor: "CYD",
               name: "CYD-2432W328R or 2432S024R",
               env: "CYD-2432W328R-or-S024R",
+              family: "ESP32",
+              partitions: { bootloader_addr: "0x1000" },
+            }
+          - {
+              vendor: "LAUNCHER",
+              name: "CYD-2432W328R or 2432S024R",
+              env: "LAUNCHER_CYD-2432W328R-or-S024R",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -110,15 +110,8 @@ jobs:
             }            
           - {
               vendor: "WIP",
-              name: "CYD-2432W328R (touch not working)",
-              env: "CYD-2432W328R",
-              family: "ESP32",
-              partitions: { bootloader_addr: "0x1000" },
-            }
-          - {
-              vendor: "WIP",
-              name: "CYD-2432S024R  (touch not working)",
-              env: "CYD-2432S024R",
+              name: "CYD-2432W328R or 2432S024R",
+              env: "CYD-2432W328R-or-S024R",
               family: "ESP32",
               partitions: { bootloader_addr: "0x1000" },
             }

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -263,7 +263,7 @@ jobs:
 
           echo "$js_content" > "./Bruce-${{ matrix.board.env }}.json"
 
-          if ["${{ matrix.board.vendor }}" == "LAUNCHER"]; then 
+          if [["${{ matrix.board.vendor }}" == "LAUNCHER"]]; then 
             html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' onClick=\"downloadFile('${{ matrix.board.env }}')\" /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"
           else
             html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -263,7 +263,7 @@ jobs:
 
           echo "$js_content" > "./Bruce-${{ matrix.board.env }}.json"
 
-          if [${{ matrix.board.vendor }} == "LAUNCHER"]; then 
+          if ["${{ matrix.board.vendor }}" == "LAUNCHER"]; then 
             html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' onClick=\"downloadFile('${{ matrix.board.env }}')\" /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"
           else
             html="<input type='radio' name='type' value='${{ matrix.board.env }}' id='${{ matrix.board.env }}' /><label for='${{ matrix.board.env }}'>${{ matrix.board.name }}</label>"

--- a/boards/CYD-2432S028.ini
+++ b/boards/CYD-2432S028.ini
@@ -208,32 +208,12 @@ build_flags =
 	-DLITE_VERSION=1
 
 
-[env:CYD-2432W328R] 
-extends = CYD_base
-build_flags = 
-	${env:CYD_base.build_flags}
-	-DTFT_INVERSION_ON # TFT is not color inverted
-	-DTFT_BL=27
-	# from https://github.com/pr3y/Bruce/issues/690#issuecomment-2602933450
-	# uses the same driver as CYD-2432S024R, but with different calibration Data, trying same as 2432S028R
-	-DESP32_DMA
-	-DTOUCH_OFFSET_ROTATION=1
-	-DSPI_FREQUENCY=55000000
-	-DSPI_READ_FREQUENCY=20000000
-	-DSPI_TOUCH_FREQUENCY=2500000
-	-DTOUCH_CS=33
-	-DUSE_TFT_eSPI_TOUCH
-	-DTOUCH_CONFIG_INT_GPIO_NUM=36
-	-DCYD2432W328R
-
-
-[env:CYD-2432S024R] # CYD-2432S024R
+[env:CYD-2432W328R-or-S024R] 
 extends = CYD_base
 build_flags = 
 	${CYD_base.build_flags}
 	-DTFT_INVERSION_ON # TFT is not color inverted
 	-DTFT_BL=27
-	# https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/master/User_Setup_cyd24.h
 	-DTOUCH_OFFSET_ROTATION=1
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
@@ -241,7 +221,5 @@ build_flags =
 	-DTOUCH_CS=33
 	-DUSE_TFT_eSPI_TOUCH
 	-DTOUCH_CONFIG_INT_GPIO_NUM=36
-	-DCYD2432S024R
-
 
 ################################# END OF CYD MODELS ####################################################

--- a/boards/CYD-2432S028.ini
+++ b/boards/CYD-2432S028.ini
@@ -179,7 +179,7 @@ build_flags =
 [env:CYD-2432W328C]
 extends = CYD_base
 build_flags = 
-	${env:CYD_base.build_flags}
+	${CYD_base.build_flags}
 	-DTFT_INVERSION_ON
 	-DTFT_BL=27
 	-DSPI_FREQUENCY=55000000

--- a/boards/CYD-2432S028.ini
+++ b/boards/CYD-2432S028.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 ##################################### CYD MODELS ####################################################
-[env:CYD-2432S028]
+[CYD_base]
 board = CYD-2432S028
 monitor_speed = 115200
 board_build.partitions = custom_4Mb_full.csv
@@ -68,7 +68,6 @@ build_flags =
 	-DHAS_BTN=0
 	-DBTN_ALIAS='"Ok"'
 	-DBTN_PIN=0
-	-DBTN_ACT=LOw
 
 	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
 
@@ -124,13 +123,8 @@ build_flags =
 	-DTFT_CS=15
 	-DTFT_DC=2
 	-DTFT_RST=-1
-	-DTFT_BL=21
 	-DTFT_BACKLIGHT_ON=HIGH
 	-DSMOOTH_FONT=1
-	-DSPI_FREQUENCY=40000000
-	-DSPI_READ_FREQUENCY=16000000
-	-DSPI_TOUCH_FREQUENCY=2500000
-	-DTOUCH_CS=33
 
 	;TouchScreen Controller
 	-DHAS_TOUCH=1
@@ -159,6 +153,15 @@ lib_deps =
 	${env.lib_deps}
 
 ##################################### CYD MODELS ####################################################
+[env:CYD-2432S028]
+extends=CYD_base
+build_flags =
+	${CYD_base.build_flags}
+	-DTFT_BL=21
+	-DSPI_FREQUENCY=40000000
+	-DSPI_READ_FREQUENCY=16000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+	-DTOUCH_CS=33
 
 [env:CYD-2USB]
 extends=env:CYD-2432S028
@@ -173,12 +176,10 @@ build_flags =
 	-DTFT_INVERSION_ON	
 	-DLITE_VERSION=1
 
-
-
 [env:CYD-2432W328C]
-extends = env:CYD-2432S028
+extends = CYD_base
 build_flags = 
-	${env:CYD-2432S028.build_flags}
+	${env:CYD_base.build_flags}
 	-DTFT_INVERSION_ON
 	-DTFT_BL=27
 	-DSPI_FREQUENCY=55000000
@@ -195,54 +196,49 @@ build_flags =
 
 
 [env:CYD-2432W328C_2] # commom to CYD-2432S024 Capacitive board
-extends = env:CYD-2432S028
-build_flags = 
-	${env:CYD-2432S028.build_flags}
-	;-DTFT_INVERSION_ON TFT is not color inverted
-	-DTFT_BL=27
-	-DSPI_FREQUENCY=55000000
-	-DSPI_READ_FREQUENCY=20000000
-	-DSPI_TOUCH_FREQUENCY=2500000
-	-DHAS_CAPACITIVE_TOUCH=1
- 	-DTOUCH_CS=-1 # This pin is used for I2C communication, not for CS SPI control in this device
+extends = env:CYD-2432W328C
+build_unflags = 
+	# TFT is not color inverted
+	-DTFT_INVERSION_ON 
 
 [env:LAUNCHER_CYD-2432W328C]
-extends=env:CYD-2432S028
+extends=env:CYD-2432W328C
 build_flags =
 	${env:CYD-2432W328C.build_flags}
 	-DLITE_VERSION=1
 
 
 [env:CYD-2432W328R] 
-extends = env:CYD-2432S028
+extends = CYD_base
 build_flags = 
-	${env:CYD-2432S028.build_flags}
+	${env:CYD_base.build_flags}
 	-DTFT_INVERSION_ON # TFT is not color inverted
 	-DTFT_BL=27
 	# from https://github.com/pr3y/Bruce/issues/690#issuecomment-2602933450
 	# uses the same driver as CYD-2432S024R, but with different calibration Data, trying same as 2432S028R
-	-DESP32DMA
+	-DESP32_DMA
 	-DTOUCH_OFFSET_ROTATION=1
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
+	-DTOUCH_CS=33
 	-DUSE_TFT_eSPI_TOUCH
 	-DTOUCH_CONFIG_INT_GPIO_NUM=36
 	-DCYD2432W328R
 
 
 [env:CYD-2432S024R] # CYD-2432S024R
-extends = env:CYD-2432S028
+extends = CYD_base
 build_flags = 
-	${env:CYD-2432S028.build_flags}
+	${CYD_base.build_flags}
 	-DTFT_INVERSION_ON # TFT is not color inverted
 	-DTFT_BL=27
 	# https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/master/User_Setup_cyd24.h
-	-DESP32DMA
 	-DTOUCH_OFFSET_ROTATION=1
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
+	-DTOUCH_CS=33
 	-DUSE_TFT_eSPI_TOUCH
 	-DTOUCH_CONFIG_INT_GPIO_NUM=36
 	-DCYD2432S024R

--- a/boards/CYD-2432S028.ini
+++ b/boards/CYD-2432S028.ini
@@ -198,7 +198,6 @@ build_flags =
 [env:CYD-2432W328C_2] # commom to CYD-2432S024 Capacitive board
 extends = env:CYD-2432W328C
 build_unflags = 
-	# TFT is not color inverted
 	-DTFT_INVERSION_ON 
 
 [env:LAUNCHER_CYD-2432W328C]
@@ -212,7 +211,7 @@ build_flags =
 extends = CYD_base
 build_flags = 
 	${CYD_base.build_flags}
-	-DTFT_INVERSION_ON # TFT is not color inverted
+	-DTFT_INVERSION_ON 
 	-DTFT_BL=27
 	-DTOUCH_OFFSET_ROTATION=1
 	-DSPI_FREQUENCY=55000000
@@ -222,4 +221,9 @@ build_flags =
 	-DUSE_TFT_eSPI_TOUCH
 	-DTOUCH_CONFIG_INT_GPIO_NUM=36
 
+[env:LAUNCHER_CYD-2432W328R-or-S024R] 
+extends = env:CYD-2432W328R-or-S024R
+build_flags =
+	${env:CYD-2432W328R-or-S024R.build_flags}
+	-DLITE_VERSION=1
 ################################# END OF CYD MODELS ####################################################

--- a/boards/CYD-2432S028/interface.cpp
+++ b/boards/CYD-2432S028/interface.cpp
@@ -50,7 +50,28 @@ void _setup_gpio() {
 void _post_setup_gpio() { 
     #if defined(USE_TFT_eSPI_TOUCH)
         pinMode(TOUCH_CS, OUTPUT);
-        uint16_t calData[5] = { 277,3653,293,3525,0 };
+        uint16_t calData[5]; 
+        File caldata = LittleFS.open("/calData", "r"); 
+        
+        if (!caldata) { 
+            tft.setRotation(ROTATION);
+            tft.calibrateTouch(calData, TFT_WHITE, TFT_BLACK, 10);
+            
+            caldata = LittleFS.open("/calData", "w"); 
+            if (caldata) { 
+                caldata.printf("%d\n%d\n%d\n%d\n%d\n", calData[0], calData[1], calData[2], calData[3], calData[4]);
+                caldata.close(); 
+            } 
+        } else {
+            Serial.print("\ntft Calibration data: ");
+            for (int i = 0; i < 5; i++) {
+                String line = caldata.readStringUntil('\n'); 
+                calData[i] = line.toInt();
+                Serial.printf("%d, ", calData[i]);
+            }
+            Serial.println(); 
+            caldata.close(); 
+        } 
         tft.setTouch(calData);
     #endif
 

--- a/boards/CYD-2432S028/interface.cpp
+++ b/boards/CYD-2432S028/interface.cpp
@@ -48,13 +48,11 @@ void _setup_gpio() {
 ** Description:   second stage gpio setup to make a few functions work
 ***************************************************************************************/
 void _post_setup_gpio() { 
-    #if defined(CYD2432S024R)
-    pinMode(TOUCH_CS, OUTPUT);
-        uint16_t calData[5] = { 277,3653,293,3525,0 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L43
-    #elif defined(CYD2432W328R)
-        uint16_t calData[5] = { 350, 3465, 188, 3431, 2 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L40
+    #if defined(USE_TFT_eSPI_TOUCH)
+        pinMode(TOUCH_CS, OUTPUT);
+        uint16_t calData[5] = { 277,3653,293,3525,0 };
+        tft.setTouch(calData);
     #endif
-    tft.setTouch(calData);
 
     // Brightness control must be initialized after tft in this case @Pirata
     pinMode(TFT_BL,OUTPUT);
@@ -80,18 +78,6 @@ void _setBrightness(uint8_t brightval) {
     log_i("dutyCycle for bright 0-255: %d",dutyCycle);
     ledcWrite(TFT_BRIGHT_CHANNEL,dutyCycle); // Channel 0
 }
-
-#if defined(USE_TFT_eSPI_TOUCH)
-void _setup_touch() {
-    #if defined(CYD2432S024R)
-    pinMode(TOUCH_CS, OUTPUT);
-        uint16_t calData[5] = { 277,3653,293,3525,0 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L43
-    #elif defined(CYD2432W328R)
-        uint16_t calData[5] = { 277,3653,293,3525,0 }; //{ 350, 3465, 188, 3431, 2 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L40
-    #endif
-    tft.setTouch(calData);
-}
-#endif
 
 /*********************************************************************
 ** Function: InputHandler

--- a/boards/CYD-2432S028/interface.cpp
+++ b/boards/CYD-2432S028/interface.cpp
@@ -10,10 +10,6 @@
     CYD28_TouchC touch(CYD28_DISPLAY_HOR_RES_MAX, CYD28_DISPLAY_VER_RES_MAX);
 #elif defined(USE_TFT_eSPI_TOUCH)
     #define XPT2046_CS TOUCH_CS
-    bool _IH_touched = false;
-    void IRAM_ATTR _IH_touch(void){
-        _IH_touched=true;
-    }
 #else
     #include "CYD28_TouchscreenR.h"
     #define CYD28_DISPLAY_HOR_RES_MAX 320
@@ -44,10 +40,6 @@ void _setup_gpio() {
         log_i("Touch IC not Started");
     } else log_i("Touch IC Started");
     #endif
-    #if defined(USE_TFT_eSPI_TOUCH)
-        pinMode(TOUCH_CS, OUTPUT);
-        attachInterrupt(TOUCH_CONFIG_INT_GPIO_NUM,_IH_touch,FALLING);
-    #endif
 }
 
 /***************************************************************************************
@@ -56,6 +48,14 @@ void _setup_gpio() {
 ** Description:   second stage gpio setup to make a few functions work
 ***************************************************************************************/
 void _post_setup_gpio() { 
+    #if defined(CYD2432S024R)
+    pinMode(TOUCH_CS, OUTPUT);
+        uint16_t calData[5] = { 277,3653,293,3525,0 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L43
+    #elif defined(CYD2432W328R)
+        uint16_t calData[5] = { 350, 3465, 188, 3431, 2 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L40
+    #endif
+    tft.setTouch(calData);
+
     // Brightness control must be initialized after tft in this case @Pirata
     pinMode(TFT_BL,OUTPUT);
     ledcSetup(TFT_BRIGHT_CHANNEL,TFT_BRIGHT_FREQ, TFT_BRIGHT_Bits); //Channel 0, 10khz, 8bits
@@ -81,26 +81,30 @@ void _setBrightness(uint8_t brightval) {
     ledcWrite(TFT_BRIGHT_CHANNEL,dutyCycle); // Channel 0
 }
 
+#if defined(USE_TFT_eSPI_TOUCH)
+void _setup_touch() {
+    #if defined(CYD2432S024R)
+    pinMode(TOUCH_CS, OUTPUT);
+        uint16_t calData[5] = { 277,3653,293,3525,0 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L43
+    #elif defined(CYD2432W328R)
+        uint16_t calData[5] = { 277,3653,293,3525,0 }; //{ 350, 3465, 188, 3431, 2 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L40
+    #endif
+    tft.setTouch(calData);
+}
+#endif
+
 /*********************************************************************
 ** Function: InputHandler
 ** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
 **********************************************************************/
 void InputHandler(void) {
-    static long tmp=0;
-    if (millis()-tmp>200) { // I know R3CK.. I Should NOT nest if statements..
+    static long d_tmp=0;
+    if (millis()-d_tmp>200) { // I know R3CK.. I Should NOT nest if statements..
                             // but it is needed to not keep SPI bus used without need, it save resources
-      
       #if defined(USE_TFT_eSPI_TOUCH)
-        #if defined(CYD2432S024R)
-            //uint16_t calData[5] = { 481, 3053, 433, 3296, 3 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L43
-        #elif defined(CYD2432W328R)
-            //uint16_t calData[5] = { 350, 3465, 188, 3431, 2 }; // from https://github.com/Fr4nkFletcher/ESP32-Marauder-Cheap-Yellow-Display/blob/3eed991e9336d3e711e3eb5d6ece7ba023132fef/esp32_marauder/Display.cpp#L40
-        #endif
-        uint16_t calData[5] = { 391, 3491, 266, 3505, 7 };
-        tft.setTouch(calData);
         TouchPoint t;
         checkPowerSaveTime();
-
+        bool _IH_touched = tft.getTouch(&t.x, &t.y);
         if(_IH_touched) {
             NextPress=false;
             PrevPress=false;
@@ -113,17 +117,12 @@ void InputHandler(void) {
             PrevPagePress=false;
             touchPoint.pressed=false;
             _IH_touched=false;
-            digitalWrite(TFT_CS,HIGH);
-            digitalWrite(TOUCH_CS,LOW);
-            tft.getTouch(&t.x, &t.y,50);
-            digitalWrite(TOUCH_CS,HIGH);
-            Serial.printf("Touched with Z=%d", tft.getTouchRawZ());
       #else
       if(touch.touched()) { 
         auto t = touch.getPointScaled();
         t = touch.getPointScaled();
       #endif
-
+        //Serial.printf("\nRAW: Touch Pressed on x=%d, y=%d",t.x, t.y);
         if(bruceConfig.rotation==3) {
             t.y = (tftHeight+20)-t.y;
             t.x = tftWidth-t.x;
@@ -138,7 +137,7 @@ void InputHandler(void) {
             t.x = t.y;
             t.y = (tftHeight+20)-tmp;
         }
-        Serial.printf("Touch Pressed on x=%d, y=%d\n",t.x, t.y);
+        //Serial.printf("\nROT: Touch Pressed on x=%d, y=%d\n",t.x, t.y);
 
         if(!wakeUpScreen()) AnyKeyPress = true;
         else goto END;
@@ -149,7 +148,7 @@ void InputHandler(void) {
         touchPoint.pressed=true;
         touchHeatMap(touchPoint);
 
-        tmp=millis();
+        d_tmp=millis();
       }
     }
     END:

--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -174,9 +174,7 @@ void InputHandler(void) {
 
 void powerOff() {
   #ifdef T_EMBED_1101
-    digitalWrite(PIN_POWER_ON,LOW); 
-    esp_sleep_enable_ext0_wakeup(GPIO_NUM_6,LOW); 
-    esp_deep_sleep_start();
+    PPM.shutdown();
   #endif
 }
 
@@ -194,12 +192,14 @@ void checkReboot() {
                 tft.setTextSize(1);
                 tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
                 countDown = (millis() - time_count) / 1000 + 1;
-                if(countDown<4) tft.drawCentreString("PWR OFF IN "+String(countDown)+"/3",tftWidth/2,12,1);
+                if(countDown<4) tft.drawCentreString("DeepSleep in "+String(countDown)+"/3",tftWidth/2,12,1);
                 else { 
                   tft.fillScreen(bruceConfig.bgColor);
                   while(digitalRead(BK_BTN)==BTN_ACT);
                   delay(200);
-                  powerOff();
+                  digitalWrite(PIN_POWER_ON,LOW); 
+                  esp_sleep_enable_ext0_wakeup(GPIO_NUM_6,LOW); 
+                  esp_deep_sleep_start();
                 }
                 delay(10);
             }

--- a/include/VectorDisplay.h
+++ b/include/VectorDisplay.h
@@ -399,6 +399,8 @@ public:
         args.twoByte[3] = y2;
         sendCommand('R', &args, 8);
     }
+
+    void invertDisplay(bool i) { delay(0); }
     
     void rectangle(int x1, int y1, int x2, int y2, bool fill=false) {
         if (fill)

--- a/include/precompiler_flags.h
+++ b/include/precompiler_flags.h
@@ -116,3 +116,7 @@
 #define DW_BTN -1
 #define BTN_ACT LOW
 #endif
+
+#ifndef SMOOTH_FONT
+#define SMOOTH_FONT
+#endif

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -55,6 +55,7 @@ JsonDocument BruceConfig::toJson() const {
     setting["startupApp"] = startupApp;
     setting["wigleBasicToken"] = wigleBasicToken;
     setting["devMode"] = devMode;
+    setting["colorInverted"] = colorInverted;
 
     JsonArray dm = setting["disabledMenus"].to<JsonArray>();
     for(int i=0; i < disabledMenus.size(); i++){
@@ -152,6 +153,7 @@ void BruceConfig::fromFile() {
     if(!setting["startupApp"].isNull())      { startupApp  = setting["startupApp"].as<String>(); } else { count++; log_e("Fail"); }
     if(!setting["wigleBasicToken"].isNull()) { wigleBasicToken  = setting["wigleBasicToken"].as<String>(); } else { count++; log_e("Fail"); }
     if(!setting["devMode"].isNull())         { devMode  = setting["devMode"].as<int>(); } else { count++; log_e("Fail"); }
+    if(!setting["colorInverted"].isNull())   { colorInverted  = setting["colorInverted"].as<int>(); } else { count++; log_e("Fail"); }
 
     if(!setting["disabledMenus"].isNull()) {
         disabledMenus.clear();
@@ -220,6 +222,7 @@ void BruceConfig::validateConfig() {
     validateMifareKeysItems();
     validateGpsBaudrateValue();
     validateDevModeValue();
+    validateColorInverted();
 }
 
 
@@ -502,6 +505,15 @@ void BruceConfig::validateDevModeValue() {
     if (devMode > 1) devMode = 1;
 }
 
+void BruceConfig::setColorInverted(int value) {
+    colorInverted = value;
+    validateColorInverted();
+    saveFile();
+}
+
+void BruceConfig::validateColorInverted() {
+    if (colorInverted > 1) colorInverted = 1;
+}
 
 void BruceConfig::addDisabledMenu(String value) {
     // TODO: check if duplicate

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -10,6 +10,11 @@
 
 #define DEFAULT_PRICOLOR 0xA80F
 
+#ifdef TFT_INVERSION_ON
+#define COLOR_INVERTED 1
+#else
+#define COLOR_INVERTED 0
+#endif
 enum RFIDModules {
     M5_RFID2_MODULE  = 0,
     PN532_I2C_MODULE = 1,
@@ -87,6 +92,7 @@ public:
     String startupApp = "";
     String wigleBasicToken = "";
     int devMode = 0;
+    int colorInverted = COLOR_INVERTED;
 
     std::vector<String> disabledMenus = {};
 
@@ -175,6 +181,8 @@ public:
     void setWigleBasicToken(String value);
     void setDevMode(int value);
     void validateDevModeValue();
+    void setColorInverted(int value);
+    void validateColorInverted();
     void addDisabledMenu(String value);
     // TODO: removeDisabledMenu(String value);
 };

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -561,12 +561,16 @@ void drawMainBorder(bool clear) {
     // if(wifiConnected) {tft.print(timeStr);} else {tft.print("BRUCE 1.0b");}
 
     int i=0;
-    drawBatteryStatus();
-    if(sdcardMounted) { tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor); tft.setTextSize(FP); tft.drawString("SD", tftWidth - (85 + 20*i),12); i++; } // Indication for SD card on screen
-    if(gpsConnected) { drawGpsSmall(tftWidth - (85 + 20*i), 7); i++; }
-    if(wifiConnected) { drawWifiSmall(tftWidth - (85 + 20*i), 7); i++;}               //Draw Wifi Symbol beside battery
-    if(BLEConnected) { drawBLESmall(tftWidth - (85 + 20*i), 7); i++; }       //Draw BLE beside Wifi
-    if(isConnectedWireguard) { drawWireguardStatus(tftWidth - (85 + 21*i), 7); i++; }//Draw Wg bedide BLE, if the others exist, if not, beside battery
+    uint8_t bat = getBattery();
+    uint8_t bat_margin = 85;
+    if(bat>0) {
+      drawBatteryStatus(bat);
+    } else bat_margin = 20;
+    if(sdcardMounted) { tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor); tft.setTextSize(FP); tft.drawString("SD", tftWidth - (bat_margin + 20*i),12); i++; } // Indication for SD card on screen
+    if(gpsConnected) { drawGpsSmall(tftWidth - (bat_margin + 20*i), 7); i++; }
+    if(wifiConnected) { drawWifiSmall(tftWidth - (bat_margin + 20*i), 7); i++;}               //Draw Wifi Symbol beside battery
+    if(BLEConnected) { drawBLESmall(tftWidth - (bat_margin + 20*i), 7); i++; }       //Draw BLE beside Wifi
+    if(isConnectedWireguard) { drawWireguardStatus(tftWidth - (bat_margin + 21*i), 7); i++; }//Draw Wg bedide BLE, if the others exist, if not, beside battery
 
 
     tft.drawRoundRect(5, 5, tftWidth - 10, tftHeight - 10, 5, bruceConfig.priColor);
@@ -645,9 +649,9 @@ int getBattery() {
 ** Function name: drawBatteryStatus()
 ** Description:   Delivers the battery value from 1-100
 ***************************************************************************************/
-void drawBatteryStatus() {
+void drawBatteryStatus(uint8_t bat) {
+    if(bat==0) return;
     tft.drawRoundRect(tftWidth - 42, 7, 34, 17, 2, bruceConfig.priColor);
-    int bat = getBattery();
     tft.setTextSize(FP);
     tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
     tft.drawRightString((bat==100 ? "" : " ")  + String(bat) + "%", tftWidth - 45, 12, 1);

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -155,7 +155,7 @@ void progressHandler(int progress, size_t total, String message = "Running, Wait
 
 int getBattery() __attribute__((weak));
 
-void drawBatteryStatus();
+void drawBatteryStatus(uint8_t bat);
 
 void drawWifiSmall(int x, int y);
 

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -28,7 +28,8 @@ void ConfigMenu::optionsMenu() {
     };
 
 #if defined(T_EMBED_1101)
-    options.emplace_back("Turn-off", [=]() { digitalWrite(PIN_POWER_ON,LOW); esp_sleep_enable_ext0_wakeup(GPIO_NUM_6,LOW); esp_deep_sleep_start(); });
+    options.emplace_back("Turn-off", [=]() { powerOff(); });
+    options.emplace_back("DeepSleep", [=]() { digitalWrite(PIN_POWER_ON,LOW); esp_sleep_enable_ext0_wakeup(GPIO_NUM_6,LOW); esp_deep_sleep_start(); });
 #elif defined(T_DISPLAY_S3)
     options.emplace_back("Turn-off", [=]()
     {

--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -38,6 +38,8 @@ if(sdcardMounted) return true;
 
 #if TFT_MOSI == SDCARD_MOSI && TFT_MOSI>0
   if (!SD.begin(SDCARD_CS, tft.getSPIinstance()))
+#elif defined(USE_TFT_eSPI_TOUCH)
+  if (!SD.begin(SDCARD_CS))
 #else
   sdcardSPI.end();
   sdcardSPI.begin(SDCARD_SCK, SDCARD_MISO, SDCARD_MOSI, SDCARD_CS); // start SPI communications

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -188,6 +188,7 @@ void setUIColor(){
   };
 
   if (idx == 9) options.push_back({"Custom Theme", [=]() { backToMenu(); }, true});
+  options.push_back({"Invert Color", [=]() { bruceConfig.setColorInverted(!bruceConfig.colorInverted); tft.invertDisplay(bruceConfig.colorInverted); }, bruceConfig.colorInverted});
   options.push_back({"Main Menu", [=]() { backToMenu(); }});
 
   loopOptions(options, idx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,7 @@ void setup_gpio() {
 *********************************************************************/
 void begin_tft(){
   tft.setRotation(bruceConfig.rotation); //sometimes it misses the first command
+  tft.invertDisplay(bruceConfig.colorInverted);
   tft.setRotation(bruceConfig.rotation);
   tftWidth = tft.width();
   #ifdef HAS_TOUCH

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,11 +186,11 @@ void boot_screen() {
   tft.setTextColor(bruceConfig.priColor, TFT_BLACK);
   tft.setTextSize(FM);
   tft.drawPixel(0,0,TFT_BLACK);
-  tft.drawCentreString("Bruce", tftWidth / 2, 10, SMOOTH_FONT);
+  tft.drawCentreString("Bruce", tftWidth / 2, 10, 1);
   tft.setTextSize(FP);
-  tft.drawCentreString(BRUCE_VERSION, tftWidth / 2, 25, SMOOTH_FONT);
+  tft.drawCentreString(BRUCE_VERSION, tftWidth / 2, 25, 1);
   tft.setTextSize(FM);
-  tft.drawCentreString("PREDATORY FIRMWARE", tftWidth / 2, tftHeight+2, SMOOTH_FONT); // will draw outside the screen on non touch devices
+  tft.drawCentreString("PREDATORY FIRMWARE", tftWidth / 2, tftHeight+2, 1); // will draw outside the screen on non touch devices
 }
 
 /*********************************************************************

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,7 +436,8 @@ void loop() {
     // update battery and clock once every 30 seconds
     // it was added to avoid delays in btns readings from Core and improves overall performance
     if(millis()-clock_update>30000) {
-      drawBatteryStatus();
+      uint8_t bat = getBattery();
+      drawBatteryStatus(bat);
       if (clock_set) {
         #if defined(HAS_RTC)
           _rtc.GetTime(&_time);


### PR DESCRIPTION
#### Proposed Changes ####

* Ports to 2432S024R and JC2432W328R, these devices need to calibrate the Touchscreen, which is done at first install and saving the data in the file "calData" in the LiffleFS
* Added Option to save InvertedColor state, some CYD have this issue dependig on the manufacturer, this setting is saved and restored in the bruce.conf
* Removed battery indication if value is 0%, so CYDs won't display it (unless you make it yourself)
* Added Full turn-off in T-embed CC1101 device, accessible from Config > Turn Off.

#### Types of Changes ####

New device port

#### Linked Issues ####

https://github.com/pr3y/Bruce/issues/660
https://github.com/pr3y/Bruce/issues/690
https://github.com/pr3y/Bruce/issues/792
https://github.com/pr3y/Bruce/issues/777
