### PR TITLE
Fix/Remove some warnings during building

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,3 +1,9 @@
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    Import: Any = None
+    env: Any = {}
+
 Import("env")
 
 env.Append(CXXFLAGS=["-Wno-conversion-null"])

--- a/build.py
+++ b/build.py
@@ -1,4 +1,6 @@
 Import("env")
+
+env.Append(CXXFLAGS=["-Wno-conversion-null"])
 env.AddCustomTarget(
     "build-firmware",
     ["$BUILD_DIR/bootloader.bin","$BUILD_DIR/partitions.bin","$BUILD_DIR/firmware.bin"],

--- a/patch.py
+++ b/patch.py
@@ -1,3 +1,9 @@
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    Import: Any = None
+    env: Any = {}
+
 from os.path import join, isfile
 from os import rename, remove
 import sys

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,24 +40,28 @@ monitor_filters = esp32_exception_decoder, send_on_enter, colorize
 framework = arduino
 board_build.variants_dir = boards
 board_build.filesystem = littlefs
-build_flags =
-	-DBRUCE_VERSION='"dev"'
-	-DEEPROMSIZE=128
-	-DLH=8
-	-DLW=6
-	-O2
+build_src_flags =
 	; warnings:
 	-Wall
 	-Wclobbered
 	-Wempty-body
 	-Wignored-qualifiers 
 	; -Wmissing-field-initializers
-	-Wsign-compare
+	; -Wsign-compare ; commented because it produces too much warnings, some of them are imposible to fix due to external deps
 	-Wtype-limits
 	-Wno-unused-label
 	-Wno-comment
 	-Wno-unused-variable
 	; warnings end
+
+; build_unflags = -Os ; uncomment this line and "-O2" for speed optimisations, but bigger size
+
+build_flags =
+	-DBRUCE_VERSION='"dev"'
+	-DEEPROMSIZE=128
+	-DLH=8
+	-DLW=6
+	; -O2
 	-Wl,--print-memory-usage
 	-Wl,--gc-sections
 	-DGIT_COMMIT_HASH='"Homebrew"'

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -815,8 +815,8 @@ void jpegRender(int xpos, int ypos) {
     pImg = JpegDec.pImage ;   // Decode a MCU (Minimum Coding Unit, typically a 8x8 or 16x16 pixel block)
 
     // Calculate coordinates of top left corner of current MCU
-    int mcu_x = JpegDec.MCUx * mcu_w + xpos;
-    int mcu_y = JpegDec.MCUy * mcu_h + ypos;
+    uint32_t mcu_x = JpegDec.MCUx * mcu_w + xpos;
+    uint32_t mcu_y = JpegDec.MCUy * mcu_h + ypos;
 
     // check if the image block size needs to be changed for the right edge
     if (mcu_x + mcu_w <= max_x) win_w = mcu_w;
@@ -832,10 +832,10 @@ void jpegRender(int xpos, int ypos) {
       uint16_t *cImg;
       int p = 0;
       cImg = pImg + win_w;
-      for (int h = 1; h < win_h; h++)
+      for (uint32_t h = 1; h < win_h; h++)
       {
         p += mcu_w;
-        for (int w = 0; w < win_w; w++)
+        for (uint32_t w = 0; w < win_w; w++)
         {
           *cImg = *(pImg + w + p);
           cImg++;

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -815,8 +815,8 @@ void jpegRender(int xpos, int ypos) {
     pImg = JpegDec.pImage ;   // Decode a MCU (Minimum Coding Unit, typically a 8x8 or 16x16 pixel block)
 
     // Calculate coordinates of top left corner of current MCU
-    uint32_t mcu_x = JpegDec.MCUx * mcu_w + xpos;
-    uint32_t mcu_y = JpegDec.MCUy * mcu_h + ypos;
+    int mcu_x = JpegDec.MCUx * mcu_w + xpos;
+    int mcu_y = JpegDec.MCUy * mcu_h + ypos;
 
     // check if the image block size needs to be changed for the right edge
     if (mcu_x + mcu_w <= max_x) win_w = mcu_w;
@@ -832,10 +832,10 @@ void jpegRender(int xpos, int ypos) {
       uint16_t *cImg;
       int p = 0;
       cImg = pImg + win_w;
-      for (uint32_t h = 1; h < win_h; h++)
+      for (int h = 1; h < win_h; h++)
       {
         p += mcu_w;
-        for (uint32_t w = 0; w < win_w; w++)
+        for (int w = 0; w < win_w; w++)
         {
           *cImg = *(pImg + w + p);
           cImg++;

--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -392,7 +392,7 @@ BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
     case Samsung: {
 
       uint8_t model = watch_models[random(26)].value;
-      uint8_t Samsung_Data[15] = { 0x0E, 0xFF, 0x75, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01, 0x01, 0xFF, 0x00, 0x00, 0x43, (model >> 0x00) & 0xFF };
+      uint8_t Samsung_Data[15] = { 0x0E, 0xFF, 0x75, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01, 0x01, 0xFF, 0x00, 0x00, 0x43, (uint8_t)((model >> 0x00) & 0xFF) };
       AdvData.addData(std::string((char *)Samsung_Data, 15));
 
       break;
@@ -401,8 +401,8 @@ BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
       const uint32_t model = android_models[rand() % android_models_count].value; // Action Type
       uint8_t Google_Data[14] = {
         0x03, 0x03, 0x2C, 0xFE, //First 3 data to announce Fast Pair
-        0x06, 0x16, 0x2C, 0xFE, (model >> 0x10) & 0xFF, (model >> 0x08) & 0xFF, (model >> 0x00) & 0xFF, // 6 more data to inform FastPair and device data
-        0x02, 0x0A, (rand() % 120) - 100 }; // 2 more data to inform RSSI data.
+        0x06, 0x16, 0x2C, 0xFE, (uint8_t)((model >> 0x10) & 0xFF), (uint8_t)((model >> 0x08) & 0xFF), (uint8_t)((model >> 0x00) & 0xFF), // 6 more data to inform FastPair and device data
+        0x02, 0x0A, (uint8_t)((rand() % 120) - 100) }; // 2 more data to inform RSSI data.
       AdvData.addData(std::string((char *)Google_Data, 14));
       break;
     }

--- a/src/modules/fm/fm.cpp
+++ b/src/modules/fm/fm.cpp
@@ -25,7 +25,7 @@ uint16_t fm_scan() {
   if (!fm_begin()) {
     return 0;
   }
-  char display_freq[10];
+  char display_freq[16];
   uint16_t f = 8750;
   uint16_t min_noise;
   uint16_t freq_candidate = f;
@@ -62,7 +62,7 @@ uint16_t fm_scan() {
 
 // Choose between 92.0 - 92.1 - 92.2 - 92.3 etc.
 void fm_options_frq(uint16_t f_min, bool reserved) {
-  char f_str[5];
+  char f_str[9];
   uint16_t f_max;
   // Choose between scan for best freq or select freq
   displayTextLine("Choose frequency");
@@ -94,7 +94,7 @@ void fm_options_frq(uint16_t f_min, bool reserved) {
 
 // Choose between 91 - 92 - 93 etc.
 void fm_options_digit(uint16_t f_min, bool reserved) {
-  char f_str[5];
+  char f_str[10];
   uint16_t f_max;
   // Choose between scan for best freq or select freq
   displayTextLine("Choose digit");
@@ -132,7 +132,7 @@ void fm_options_digit(uint16_t f_min, bool reserved) {
 
 // Choose between 80 - 90 - 100
 void fm_options(uint16_t f_min, uint16_t f_max, bool reserved) {
-  char f_str[5];
+  char f_str[15];
   // Choose between scan for best freq or select freq
   displayTextLine("Choose tens");
   delay(1000);

--- a/src/modules/gps/gps_tracker.cpp
+++ b/src/modules/gps/gps_tracker.cpp
@@ -143,12 +143,12 @@ void GPSTracker::create_filename() {
     sprintf(
         timestamp,
         "%02d%02d%02d_%02d%02d%02d",
-        gps.date.year(),
-        gps.date.month(),
-        gps.date.day(),
-        gps.time.hour(),
-        gps.time.minute(),
-        gps.time.second()
+        gps.date.year() % 100,
+        gps.date.month() % 100,
+        gps.date.day() % 100,
+        gps.time.hour() % 100,
+        gps.time.minute() % 100,
+        gps.time.second() % 100
     );
     filename = String(timestamp) + "_gps_tracker.gpx";
 }

--- a/src/modules/gps/wardriving.cpp
+++ b/src/modules/gps/wardriving.cpp
@@ -181,12 +181,12 @@ void Wardriving::create_filename() {
     sprintf(
         timestamp,
         "%02d%02d%02d_%02d%02d%02d",
-        gps.date.year(),
-        gps.date.month(),
-        gps.date.day(),
-        gps.time.hour(),
-        gps.time.minute(),
-        gps.time.second()
+        gps.date.year() % 100,
+        gps.date.month() % 100,
+        gps.date.day() % 100,
+        gps.time.hour() % 100,
+        gps.time.minute() % 100,
+        gps.time.second() % 100
     );
     filename = String(timestamp) + "_wardriving.csv";
 }

--- a/src/modules/others/bad_usb.cpp
+++ b/src/modules/others/bad_usb.cpp
@@ -53,14 +53,12 @@ void key_input(FS fs, String bad_script) {
       char ArgChar;
       bool ArgIsCmd;  // Verifies if the Argument is DELETE, TAB or F1-F12
       int cmdFail;    // Verifies if the command is supported, mus pass through 2 if else statemens and summ 2 to not be supported
-      int line;       // Shows 3 commands of the payload on screen to follow the execution
 
 
       Kb.releaseAll();
       tft.setTextSize(1);
       tft.setCursor(0, 0);
       tft.fillScreen(bruceConfig.bgColor);
-      line = 0;
 
       while (payloadFile.available()) {
         previousMillis = millis(); // resets DimScreen

--- a/src/modules/others/timer.cpp
+++ b/src/modules/others/timer.cpp
@@ -37,7 +37,7 @@ void Timer::setup() {
     delay(DELAY_VALUE);
 
     while (true) {
-        snprintf(timeString, sizeof(timeString), "%02d:%02d:%02d", hours, minutes, seconds);
+        snprintf(timeString, sizeof(timeString), "%02d:%02d:%02d", hours%100, minutes%100, seconds%100);
 
         drawMainBorderWithTitle("Set a timer", false);
         tft.setTextSize(fontSize);
@@ -102,7 +102,7 @@ void Timer::loop() {
 
         int seconds = (remainingMillis / 1000) % 60;
         int minutes = (remainingMillis / 60000) % 60;
-        int hours = (remainingMillis / 3600000);
+        int hours = (remainingMillis / 3600000) % 100;
 
         snprintf(timeString, sizeof(timeString), "%02d:%02d:%02d", hours, minutes, seconds);
 

--- a/src/modules/pwnagotchi/spam.cpp
+++ b/src/modules/pwnagotchi/spam.cpp
@@ -257,7 +257,8 @@ Default: // This is default pwngrid faces to spam, removing the necessity to hav
     i=0;
     names[i++]="my name is... BRUCE!";
     names[i++]="Check M5 Bruce Project";
-    names[i++]="┌∩┐(◣_◢)┌∩┐","(╯°□°)╯╭╮(XoX)";
+    names[i++]="┌∩┐(◣_◢)┌∩┐";
+    names[i++]="(╯°□°)╯╭╮(XoX)";
     names[i++]="STOP DEAUTH SKIDZ!";
     names[i++]="System Breached oups";
     names[i++]="Unauthorized  Access";

--- a/src/modules/rfid/PN532.cpp
+++ b/src/modules/rfid/PN532.cpp
@@ -260,7 +260,7 @@ bool PN532::read_data_blocks() {
 
 bool PN532::read_mifare_classic_data_blocks() {
     byte no_of_sectors = 0;
-    bool sectorReadSuccess;
+    bool sectorReadSuccess = false;
 
     switch (uid.sak) {
         case PICC_TYPE_MIFARE_MINI:


### PR DESCRIPTION
#### Proposed Changes ####

- Fixed/Removed some warnings during building

Some of them cannot be fixed, because they are in external dependencies, I tried to use the script proposed here:
https://community.platformio.org/t/silence-warnings-for-dependencies-external-libraries/33387/4
It suppresses the warnings if they are in external dependencies, but I cannot make it work.

#### Types of Changes ####

Bugfix

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

