### PR TITLE
RF Scan/Copy improvements

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -9,7 +9,7 @@
 #include "modules/rf/rf.h"  // for initRfModule
 
 #ifdef USE_CC1101_VIA_SPI
-#include <ELECHOUSE_CC1101_SRC_DRV.h>
+#include "../lib/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.h"
 #endif
 
 // This function comes from interface.h
@@ -266,7 +266,7 @@ void setRFFreqMenu() {
   String freq_str = keyboard(String(bruceConfig.rfFreq), 10, "Default frequency:");
   if(freq_str.length() > 1) {
     result = freq_str.toFloat();  // returns 0 if not valid
-    if(result>=300 && result<=928) { // TODO: check valid freq according to current module?
+    if(result>=280 && result<=928) { // TODO: check valid freq according to current module?
       bruceConfig.setRfFreq(result);
       return;
     }

--- a/src/core/startup_app.cpp
+++ b/src/core/startup_app.cpp
@@ -13,8 +13,10 @@
 #include "modules/gps/wardriving.h"
 #include "modules/rfid/pn532ble.h"
 #include "modules/others/webInterface.h"
+#include "modules/rf/rf.h"
 
 StartupApp::StartupApp() {
+    _startupApps["RF"] = []() { otherRFcodes(); };
     _startupApps["GPS Tracker"] = []() { GPSTracker(); };
     _startupApps["PN532 BLE"]  = []() { Pn532ble(); };
     _startupApps["Wardriving"]  = []() { Wardriving(); };

--- a/src/core/startup_app.cpp
+++ b/src/core/startup_app.cpp
@@ -16,7 +16,7 @@
 #include "modules/rf/rf.h"
 
 StartupApp::StartupApp() {
-    _startupApps["RF"] = []() { otherRFcodes(); };
+    _startupApps["Custom SubGHz"] = []() { otherRFcodes(); };
     _startupApps["GPS Tracker"] = []() { GPSTracker(); };
     _startupApps["PN532 BLE"]  = []() { Pn532ble(); };
     _startupApps["Wardriving"]  = []() { Wardriving(); };

--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -1505,7 +1505,7 @@ void RCSwitch_Enable_Receive(RCSwitch rcswitch) {
 void rf_scan_copy() {
 	RfCodes received;
 	RCSwitch rcswitch = RCSwitch();
-    bool codesOnly = true;
+    bool codesOnly = false;
 	int range_limits[][2] = {
 		{ 0, 23 },  // 300-348 MHz
 		{ 24, 47 }, // 387-464 MHz

--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -1,7 +1,7 @@
 //@IncursioHack - github.com/IncursioHack
 
 #include <driver/rmt.h>
-#include "../lib/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.h"
+#include <ELECHOUSE_CC1101_SRC_DRV.h>
 //#include "PCA9554.h"
 #include <globals.h>
 #include "core/mykeyboard.h"
@@ -1578,6 +1578,8 @@ RestartScan:
             bruceConfig.setRfFreq(433.92, 2);
             #endif
         }
+        
+        if (check(EscPress) || returnToMenu) goto END;
 
 		if (rcswitch.available() && !ReadRAW) { // Add decoded data only (if any) to the RCCode
 			uint64_t decoded = rcswitch.getReceivedValue();

--- a/src/modules/rf/rf.h
+++ b/src/modules/rf/rf.h
@@ -1,5 +1,6 @@
 // @IncursioHack - https://github.com/IncursioHack
 #include <Wire.h>
+#include <RCSwitch.h>
 #include <SD.h>
 // #include "PCA9554.h" // Biblioteca para PCA9554
 
@@ -10,6 +11,7 @@ struct RfCodes {
   String preset = "";
   String data = "";
   int te = 0;
+  std::vector<int> indexed_durations;
   String filepath = "";
   int Bit=0;
   int BitRAW=0;
@@ -29,7 +31,7 @@ void rf_spectrum();
 void rf_SquareWave();
 void rf_jammerIntermittent();
 void rf_jammerFull();
-void rf_scan_copy_draw_signal(RfCodes received, int signals, bool ReadRAW=false);
+void rf_scan_copy_draw_signal(RfCodes received, int signals, bool ReadRAW=false, bool codesOnly=false);
 String rf_scan(float start_freq, float stop_freq, int max_loops=-1);
 void otherRFcodes();
 bool txSubFile(FS *fs, String filepath);
@@ -43,3 +45,6 @@ void initCC1101once(SPIClass* SSPI);
 void deinitRfModule();
 uint8_t hexCharToDecimal(char c);
 void rf_scan_copy();
+void RCSwitch_Enable_Receive(RCSwitch rcswitch);
+uint64_t crc64_ecma(const std::vector<int>& data);
+int find_pulse_index(const std::vector<int>& indexed_durations, int duration);


### PR DESCRIPTION
This PR aims to bring the following improvements to Bruce:

- The CC1101 chip can actually emit down to 280MHz, so allow that frequency range to be selected
- Add "Custom SubGHz" as a startup app option
- Ability to save/emit received RCSwitch codes as RAW, in case the decoding/encoding process mangles the signal
- Adds a calculation for non-decoded RAW signals, with which, if two pulses >5ms are found, the signal contained within is indexed and a CRC is calculated, so that the user can see at a glance if the code being emitted is changing or fixed.
- Adds an option to the menu to discard RAW signals which do not contain either a decoded or CRC-able code
- Remove the OnlyRAW option, since we can now choose whether to save the RCSwitch codes as RAW or not.