### PR TITLE
Lilygo T-Watch S3 port and RTC lib adaptation

### DIFF
--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -165,7 +165,7 @@ jobs:
               partitions: { bootloader_addr: "0x0" },
             }
           - {
-              vendor: "WIP",
+              vendor: "Lilygo",
               name: "Lilygo T-Watch S3",
               env: "lilygo-t-watch-s3",
               family: "ESP32-S3",

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -165,6 +165,13 @@ jobs:
               partitions: { bootloader_addr: "0x0" },
             }
           - {
+              vendor: "WIP",
+              name: "Lilygo T-Watch S3",
+              env: "lilygo-t-watch-s3",
+              family: "ESP32-S3",
+              partitions: { bootloader_addr: "0x0" },
+            }
+          - {
               vendor: "Lilygo",
               name: "Lilygo T-Deck-Plus",
               env: "lilygo-t-deck-pro",

--- a/boards/lilygo-t-watch-s3.ini
+++ b/boards/lilygo-t-watch-s3.ini
@@ -1,0 +1,166 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:lilygo-t-watch-s3]
+board = lilygo-t-watch-s3
+board_build.partitions = custom_16Mb.csv
+build_src_filter =${env.build_src_filter} +<../boards/lilygo-t-watch-s3>
+build_flags =
+	${env.build_flags}
+	-Iboards/lilygo-t-watch-s3
+	-mfix-esp32-psram-cache-issue
+	-mfix-esp32-psram-cache-strategy=memw
+	-Os
+	-DCORE_DEBUG_LEVEL=5
+
+	-DREMOVE_RF_MENU
+	-DREMOVE_RFID_MENU
+
+	;Features Enabled
+	# Config to use IRQ and RST pins of PN532, if needed
+	;-DPN532_RF_REST=-1
+	;-DPN532_IRQ=-1
+
+	;FM Radio
+	;-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+	-DFM_RSTPIN=-1
+	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+	;Microphone
+	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+	-DPIN_CLK=44
+	-DI2S_SCLK_PIN=44
+	-DI2S_DATA_PIN=47
+	-DPIN_DATA=47
+
+	; SERIAL (GPS) dedicated pins
+	-DSERIAL_TX=42 ;may be wrong
+	-DSERIAL_RX=41
+
+	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+	;-DHAS_RGB_LED=1  ;uncomment to enable
+	-DRGB_LED=-1
+
+	;Have RTC Chip
+	-DHAS_RTC=1
+	-DRTC_SDA=10
+	-DRTC_SCL=11
+
+	;Speaker to run music, compatible with NS4168
+	-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DBCLK=48
+	-DWCLK=15
+	-DDOUT=46
+	-DMCLK=44
+
+	;Can run USB as HID
+	-DUSB_as_HID=1 ;uncomment to enable
+	-DBAD_TX=GROVE_SDA
+	-DBAD_RX=GROVE_SCL
+
+	;Battery ADC read pin
+	-DBAT_PIN=4
+
+	;Buttons configuration
+	-DHAS_BTN=1
+	-DBTN_ALIAS='"Mid"'
+	-DBTN_PIN=0
+	-DBTN_ACT=LOW
+
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	;Infrared Led default pin and state
+	-DIR_TX_PINS='{{"IO 2", 2}}'
+	-DIR_RX_PINS='{{"Unavailable", -1}}'
+	-DLED=2		;NEED TO SET SOMETHING HERE, at least -1
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"Unavailable", -1}}'
+	-DRF_RX_PINS='{{"Unavailable", -1}}'
+
+	;CC1101 SPI connection pins
+	; best connection pins for higher speed https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/spi_master.html#gpio-matrix-and-io-mux
+	;-DUSE_CC1101_VIA_SPI
+	-DCC1101_GDO0_PIN=8
+	-DCC1101_SS_PIN=5
+	-DCC1101_MOSI_PIN=1
+	-DCC1101_SCK_PIN=3
+	-DCC1101_MISO_PIN=4
+	-DCC1101_GDO2_PIN=7  ; optional
+
+	; connections are the same as CC1101
+	;-DUSE_NRF24_VIA_SPI
+	-DNRF24_CE_PIN=-1
+	-DNRF24_SS_PIN=-1  ; chip select
+	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
+	-DNRF24_SCK_PIN=SPI_SCK_PIN
+	-DNRF24_MISO_PIN=SPI_MISO_PIN
+
+	;Font sizes, depending on device
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	;Screen Setup
+	-DHAS_SCREEN=1
+	-DROTATION=2
+	-DBACKLIGHT=-1
+	-DMINBRIGHT=1
+
+	;tft Brighness Control
+	-DTFT_BRIGHT_CHANNEL=3
+	-DTFT_BRIGHT_Bits=8
+	-DTFT_BRIGHT_FREQ=1000
+
+	;TFT_eSPI display
+	-DUSER_SETUP_LOADED=1
+	-DUSE_HSPI_PORT=1
+	;-DUSER_SETUP_ID=214
+	-DST7789_DRIVER=1
+	-DTFT_WIDTH=240
+	-DTFT_HEIGHT=240
+	-DTFT_INVERSION_ON
+	-DTFT_BL=45
+	-DTFT_MISO=-1   
+	-DTFT_MOSI=13
+	-DTFT_SCLK=18
+	-DTFT_CS=12
+	-DTFT_DC=38
+	-DTFT_RST=-1 
+	-DTOUCH_CS=-1
+
+	;TouchScreen Controller
+	-DHAS_TOUCH=1
+
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=40000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+
+	;SD Card Setup pins
+	-DSDCARD_CS=-1
+	-DSDCARD_SCK=-1
+	-DSDCARD_MISO=-1
+	-DSDCARD_MOSI=-1
+
+	;Default I2C port
+	-DGROVE_SDA=10 # maybe need to switch pins
+	-DGROVE_SCL=11 # maybe need to switch pins
+
+	-DSPI_SCK_PIN=-1
+	-DSPI_MOSI_PIN=-1
+	-DSPI_MISO_PIN=-1
+	-DSPI_SS_PIN=-1
+
+lib_deps =
+	${env.lib_deps}
+	lewisxhe/XPowersLib @0.2.7
+	https://github.com/lewisxhe/SensorLib

--- a/boards/lilygo-t-watch-s3.ini
+++ b/boards/lilygo-t-watch-s3.ini
@@ -48,7 +48,7 @@ build_flags =
 	-DRGB_LED=-1
 
 	;Have RTC Chip
-	-DHAS_RTC=1
+	;-DHAS_RTC=1
 	-DRTC_SDA=10
 	-DRTC_SCL=11
 

--- a/boards/lilygo-t-watch-s3.ini
+++ b/boards/lilygo-t-watch-s3.ini
@@ -48,7 +48,7 @@ build_flags =
 	-DRGB_LED=-1
 
 	;Have RTC Chip
-	;-DHAS_RTC=1
+	-DHAS_RTC=1
 	-DRTC_SDA=10
 	-DRTC_SCL=11
 

--- a/boards/lilygo-t-watch-s3.json
+++ b/boards/lilygo-t-watch-s3.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DT_WATCH_S3",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "pinouts"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "lora"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "LilyGo T-Deck (16M Flash 8M OPI PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.lilygo.cc",
+  "vendor": "LilyGo"
+}

--- a/boards/lilygo-t-watch-s3/interface.cpp
+++ b/boards/lilygo-t-watch-s3/interface.cpp
@@ -1,0 +1,197 @@
+#include "interface.h"
+#include "core/powerSave.h"
+#include "core/utils.h"
+#include <Wire.h>
+#include <XPowersLib.h>
+
+XPowersAXP2101 axp192;
+#include <TouchDrvFT6X36.hpp>
+TouchDrvFT6X36 touch;
+
+
+/***************************************************************************************
+** Function name: _setup_gpio()
+** Location: main.cpp
+** Description:   initial setup for the device
+***************************************************************************************/
+void _setup_gpio() {
+    pinMode(16,INPUT); // Touch IRQ
+    Wire.begin(10,11);  // sensors
+    delay(10);
+    Wire1.begin(39,40); // touchscreen
+    delay(10);
+    axp192.init(Wire,10,11);
+    axp192.setVbusVoltageLimit(XPOWERS_AXP2101_VBUS_VOL_LIM_4V36);
+    axp192.setVbusCurrentLimit(XPOWERS_AXP2101_VBUS_CUR_LIM_900MA);
+    axp192.setSysPowerDownVoltage(2600);
+    axp192.setALDO1Voltage(3300);
+    axp192.setALDO2Voltage(3300);
+    axp192.setALDO3Voltage(3300);
+    axp192.setALDO4Voltage(3300);
+    axp192.setBLDO2Voltage(3300);
+    axp192.setDC3Voltage(3300);
+    axp192.enableDC3(); // gps
+    axp192.disableDC2();
+    axp192.disableDC4();
+    axp192.disableDC5();
+    axp192.disableBLDO1();
+    axp192.disableCPUSLDO();
+    axp192.disableDLDO1();
+    axp192.disableDLDO2();
+    axp192.enableALDO1();  //! RTC VBAT
+    axp192.enableALDO2();  //! TFT BACKLIGHT   VDD
+    axp192.enableALDO3();  //! Screen touch VDD
+    axp192.enableALDO4();  //! Radio VDD
+    axp192.enableBLDO2();  //! drv2605 enable
+    // Set the time of pressing the button to turn off
+    axp192.setPowerKeyPressOffTime(XPOWERS_POWEROFF_4S);
+    // Set the button power-on press time
+    axp192.setPowerKeyPressOnTime(XPOWERS_POWERON_128MS);
+    // It is necessary to disable the detection function of the TS pin on the board
+    // without the battery temperature detection function, otherwise it will cause abnormal charging
+    axp192.disableTSPinMeasure();
+    // Enable internal ADC detection
+    axp192.enableBattDetection();
+    axp192.enableVbusVoltageMeasure();
+    axp192.enableBattVoltageMeasure();
+    axp192.enableSystemVoltageMeasure();
+    //t-watch no chg led
+    axp192.setChargingLedMode(XPOWERS_CHG_LED_OFF);
+    axp192.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+    // Enable the required interrupt function
+    axp192.enableIRQ(
+        XPOWERS_AXP2101_BAT_INSERT_IRQ    | XPOWERS_AXP2101_BAT_REMOVE_IRQ      |   //BATTERY
+        XPOWERS_AXP2101_VBUS_INSERT_IRQ   | XPOWERS_AXP2101_VBUS_REMOVE_IRQ     |   //VBUS
+        XPOWERS_AXP2101_PKEY_SHORT_IRQ    | XPOWERS_AXP2101_PKEY_LONG_IRQ       |   //POWER KEY
+        XPOWERS_AXP2101_BAT_CHG_DONE_IRQ  | XPOWERS_AXP2101_BAT_CHG_START_IRQ       //CHARGE
+    );
+
+    // Clear all interrupt flags
+    axp192.clearIrqStatus();
+    // Set the precharge charging current
+    axp192.setPrechargeCurr(XPOWERS_AXP2101_PRECHARGE_50MA);
+    // Set constant current charge current limit
+    axp192.setChargerConstantCurr(XPOWERS_AXP2101_CHG_CUR_300MA);
+    // Set stop charging termination current
+    axp192.setChargerTerminationCurr(XPOWERS_AXP2101_CHG_ITERM_25MA);
+    // Set charge cut-off voltage
+    axp192.setChargeTargetVoltage(XPOWERS_AXP2101_CHG_VOL_4V35);
+    // Set RTC Battery voltage to 3.3V
+    axp192.setButtonBatteryChargeVoltage(3300);
+    axp192.enableButtonBatteryCharge();
+
+    touch.begin(Wire1,FT6X36_SLAVE_ADDRESS,39,40);
+    touch.setSwapXY(true);    
+
+ }
+
+/***************************************************************************************
+** Function name: _post_setup_gpio()
+** Location: main.cpp
+** Description:   second stage gpio setup to make a few functions work
+***************************************************************************************/
+void _post_setup_gpio() {
+    pinMode(TFT_BL,OUTPUT);
+    digitalWrite(TFT_BL, HIGH);
+    ledcSetup(TFT_BRIGHT_CHANNEL,TFT_BRIGHT_FREQ, TFT_BRIGHT_Bits); //Channel 0, 10khz, 8bits
+    ledcAttachPin(TFT_BL, TFT_BRIGHT_CHANNEL);
+    ledcWrite(TFT_BRIGHT_CHANNEL,255);
+}
+
+/***************************************************************************************
+** Function name: getBattery()
+** location: display.cpp
+** Description:   Delivers the battery value from 1-100
+***************************************************************************************/
+int getBattery() { 
+    int percent = axp192.getBatteryPercent();
+    return percent; 
+}
+
+
+/*********************************************************************
+** Function: setBrightness
+** location: settings.cpp
+** set brightness value
+**********************************************************************/
+void _setBrightness(uint8_t brightval) { 
+    int dutyCycle;
+    if (brightval==100) dutyCycle=255;
+    else if (brightval==75) dutyCycle=130;
+    else if (brightval==50) dutyCycle=70;
+    else if (brightval==25) dutyCycle=20;
+    else if (brightval==0) dutyCycle=0;
+    else dutyCycle = ((brightval*255)/100);
+
+    log_i("dutyCycle for bright 0-255: %d",dutyCycle);
+    ledcWrite(TFT_BRIGHT_CHANNEL,dutyCycle); // Channel 0
+}
+
+bool getTouched()
+{
+    return digitalRead(16) == LOW;
+}
+struct TP {
+    int16_t x[1], y[1];
+};
+/*********************************************************************
+** Function: InputHandler
+** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
+**********************************************************************/
+void InputHandler(void) {
+    TP t;
+    static long d_tmp=0;
+    if (millis()-d_tmp>200) { // I know R3CK.. I Should NOT nest if statements..
+                            // but it is needed to not keep SPI bus used without need, it save resources
+      if(getTouched()) { 
+        touch.getPoint(t.x,t.y,1);
+        //Serial.printf("\nRAW: Touch Pressed on x=%d, y=%d",t.x, t.y);
+        if(bruceConfig.rotation==3) {
+            t.y[0] = (tftHeight+20)-t.y[0];
+            t.x[0] = t.x[0];
+        }
+        if(bruceConfig.rotation==0) {
+            int tmp=t.x[0];
+            t.x[0] = tftWidth-t.y[0];
+            t.y[0] = tftHeight - tmp;
+        }
+        if(bruceConfig.rotation==2) {
+            int tmp=t.x[0];
+            t.x[0] = t.y[0];
+            t.y[0] = tmp;
+        }
+        if(bruceConfig.rotation==1) {
+            t.x[0] = tftWidth-t.x[0];
+        }
+        //Serial.printf("\nROT: Touch Pressed on x=%d, y=%d\n",t.x[0], t.y[0]);
+
+        if(!wakeUpScreen()) AnyKeyPress = true;
+        else goto END;
+
+        // Touch point global variable
+        touchPoint.x = t.x[0];
+        touchPoint.y = t.y[0];
+        touchPoint.pressed=true;
+        touchHeatMap(touchPoint);
+
+        d_tmp=millis();
+      }
+    }
+    END:
+    delay(0);
+}
+
+/*********************************************************************
+** Function: powerOff
+** location: mykeyboard.cpp
+** Turns off the device (or try to)
+**********************************************************************/
+void powerOff() { }
+
+
+/*********************************************************************
+** Function: checkReboot
+** location: mykeyboard.cpp
+** Btn logic to tornoff the device (name is odd btw)
+**********************************************************************/
+void checkReboot() { }

--- a/boards/lilygo-t-watch-s3/interface.cpp
+++ b/boards/lilygo-t-watch-s3/interface.cpp
@@ -20,6 +20,8 @@ void _setup_gpio() {
     delay(10);
     Wire1.begin(39,40); // touchscreen
     delay(10);
+    _rtc.setWire(&Wire); // Cplus uses Wire1 default, the lib had been changed to accept setting I2C bus
+                         // StickCPlus uses BM8563 that is the same as PCF8536
     axp192.init(Wire,10,11);
     axp192.setVbusVoltageLimit(XPOWERS_AXP2101_VBUS_VOL_LIM_4V36);
     axp192.setVbusCurrentLimit(XPOWERS_AXP2101_VBUS_CUR_LIM_900MA);
@@ -41,8 +43,8 @@ void _setup_gpio() {
     axp192.enableALDO1();  //! RTC VBAT
     axp192.enableALDO2();  //! TFT BACKLIGHT   VDD
     axp192.enableALDO3();  //! Screen touch VDD
-    axp192.enableALDO4();  //! Radio VDD
-    axp192.enableBLDO2();  //! drv2605 enable
+    //axp192.enableALDO4();  //! Radio VDD
+    //axp192.enableBLDO2();  //! drv2605 enable
     // Set the time of pressing the button to turn off
     axp192.setPowerKeyPressOffTime(XPOWERS_POWEROFF_4S);
     // Set the button power-on press time
@@ -166,7 +168,7 @@ void InputHandler(void) {
         //Serial.printf("\nROT: Touch Pressed on x=%d, y=%d\n",t.x[0], t.y[0]);
 
         if(!wakeUpScreen()) AnyKeyPress = true;
-        else goto END;
+        else return;
 
         // Touch point global variable
         touchPoint.x = t.x[0];
@@ -177,8 +179,6 @@ void InputHandler(void) {
         d_tmp=millis();
       }
     }
-    END:
-    delay(0);
 }
 
 /*********************************************************************

--- a/boards/pinouts/lilygo-t-watch-s3.h
+++ b/boards/pinouts/lilygo-t-watch-s3.h
@@ -1,0 +1,73 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+// Some boards have too low voltage on this pin (board design bug)
+// Use different pin with 3V and connect with 48
+// and change this setup for the chosen pin (for example 38)
+#define PIN_NEOPIXEL        48
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
+#define HAS_KEYBOARD    //has keyboard to use 
+#define HAS_KEYBOARD_HID //has keyboard to use 
+#define KB_HID_EXIT_MSG "Mid Btn + Space to exit"
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+static const uint8_t SS    = 10;
+static const uint8_t MOSI  = 11;
+static const uint8_t MISO  = 13;
+static const uint8_t SCK   = 12;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/boards/pinouts/pins_arduino.h
+++ b/boards/pinouts/pins_arduino.h
@@ -24,4 +24,6 @@
 #include "ESP-General.h"
 #elif SMOOCHIEE_BOARD
 #include "smoochiee-board.h"
+#elif T_WATCH_S3
+#include "lilygo-t-watch-s3.h"
 #endif

--- a/include/globals.h
+++ b/include/globals.h
@@ -21,6 +21,9 @@
 
 #if defined(HAS_RTC)
   #include "../lib/RTC/cplus_RTC.h"
+  extern cplus_RTC _rtc;
+  extern RTC_TimeTypeDef _time;
+  extern RTC_DateTypeDef _date;
 #endif
 
 // Declaração dos objetos TFT

--- a/lib/RTC/cplus_RTC.cpp
+++ b/lib/RTC/cplus_RTC.cpp
@@ -9,22 +9,22 @@
 #define RTC_SCL 22
 #endif
 void cplus_RTC::begin(void) {
-    Wire1.begin(RTC_SDA, RTC_SCL);
+    wr->begin(RTC_SDA, RTC_SCL);
 }
 
 void cplus_RTC::GetBm8563Time(void) {
-    Wire1.beginTransmission(0x51);
-    Wire1.write(0x02);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x51, 7);
-    while (Wire1.available()) {
-        trdata[0] = Wire1.read();
-        trdata[1] = Wire1.read();
-        trdata[2] = Wire1.read();
-        trdata[3] = Wire1.read();
-        trdata[4] = Wire1.read();
-        trdata[5] = Wire1.read();
-        trdata[6] = Wire1.read();
+    wr->beginTransmission(0x51);
+    wr->write(0x02);
+    wr->endTransmission();
+    wr->requestFrom(0x51, 7);
+    while (wr->available()) {
+        trdata[0] = wr->read();
+        trdata[1] = wr->read();
+        trdata[2] = wr->read();
+        trdata[3] = wr->read();
+        trdata[4] = wr->read();
+        trdata[5] = wr->read();
+        trdata[6] = wr->read();
     }
 
     DataMask();
@@ -94,15 +94,15 @@ void cplus_RTC::GetTime(RTC_TimeTypeDef* RTC_TimeStruct) {
     // if()
     uint8_t buf[3] = {0};
 
-    Wire1.beginTransmission(0x51);
-    Wire1.write(0x02);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x51, 3);
+    wr->beginTransmission(0x51);
+    wr->write(0x02);
+    wr->endTransmission();
+    wr->requestFrom(0x51, 3);
 
-    while (Wire1.available()) {
-        buf[0] = Wire1.read();
-        buf[1] = Wire1.read();
-        buf[2] = Wire1.read();
+    while (wr->available()) {
+        buf[0] = wr->read();
+        buf[1] = wr->read();
+        buf[2] = wr->read();
     }
 
     RTC_TimeStruct->Seconds = Bcd2ToByte(buf[0] & 0x7f);  //秒
@@ -113,27 +113,27 @@ void cplus_RTC::GetTime(RTC_TimeTypeDef* RTC_TimeStruct) {
 void cplus_RTC::SetTime(RTC_TimeTypeDef* RTC_TimeStruct) {
     if (RTC_TimeStruct == NULL) return;
 
-    Wire1.beginTransmission(0x51);
-    Wire1.write(0x02);
-    Wire1.write(ByteToBcd2(RTC_TimeStruct->Seconds));
-    Wire1.write(ByteToBcd2(RTC_TimeStruct->Minutes));
-    Wire1.write(ByteToBcd2(RTC_TimeStruct->Hours));
-    Wire1.endTransmission();
+    wr->beginTransmission(0x51);
+    wr->write(0x02);
+    wr->write(ByteToBcd2(RTC_TimeStruct->Seconds));
+    wr->write(ByteToBcd2(RTC_TimeStruct->Minutes));
+    wr->write(ByteToBcd2(RTC_TimeStruct->Hours));
+    wr->endTransmission();
 }
 
 void cplus_RTC::GetDate(RTC_DateTypeDef* RTC_DateStruct) {
     uint8_t buf[4] = {0};
 
-    Wire1.beginTransmission(0x51);
-    Wire1.write(0x05);
-    Wire1.endTransmission();
-    Wire1.requestFrom(0x51, 4);
+    wr->beginTransmission(0x51);
+    wr->write(0x05);
+    wr->endTransmission();
+    wr->requestFrom(0x51, 4);
 
-    while (Wire1.available()) {
-        buf[0] = Wire1.read();
-        buf[1] = Wire1.read();
-        buf[2] = Wire1.read();
-        buf[3] = Wire1.read();
+    while (wr->available()) {
+        buf[0] = wr->read();
+        buf[1] = wr->read();
+        buf[2] = wr->read();
+        buf[3] = wr->read();
     }
 
     RTC_DateStruct->Date    = Bcd2ToByte(buf[0] & 0x3f);
@@ -149,22 +149,22 @@ void cplus_RTC::GetDate(RTC_DateTypeDef* RTC_DateStruct) {
 
 void cplus_RTC::SetDate(RTC_DateTypeDef* RTC_DateStruct) {
     if (RTC_DateStruct == NULL) return;
-    Wire1.beginTransmission(0x51);
-    Wire1.write(0x05);
-    Wire1.write(ByteToBcd2(RTC_DateStruct->Date));
-    Wire1.write(ByteToBcd2(RTC_DateStruct->WeekDay));
+    wr->beginTransmission(0x51);
+    wr->write(0x05);
+    wr->write(ByteToBcd2(RTC_DateStruct->Date));
+    wr->write(ByteToBcd2(RTC_DateStruct->WeekDay));
 
     if (RTC_DateStruct->Year < 2000) {
-        Wire1.write(ByteToBcd2(RTC_DateStruct->Month) | 0x80);
-        Wire1.write(ByteToBcd2((uint8_t)(RTC_DateStruct->Year % 100)));
+        wr->write(ByteToBcd2(RTC_DateStruct->Month) | 0x80);
+        wr->write(ByteToBcd2((uint8_t)(RTC_DateStruct->Year % 100)));
 
     } else {
         /* code */
-        Wire1.write(ByteToBcd2(RTC_DateStruct->Month) | 0x00);
-        Wire1.write(ByteToBcd2((uint8_t)(RTC_DateStruct->Year % 100)));
+        wr->write(ByteToBcd2(RTC_DateStruct->Month) | 0x00);
+        wr->write(ByteToBcd2((uint8_t)(RTC_DateStruct->Year % 100)));
     }
 
-    Wire1.endTransmission();
+    wr->endTransmission();
 }
 
 
@@ -172,18 +172,18 @@ void cplus_RTC::SetDate(RTC_DateTypeDef* RTC_DateStruct) {
 
 
 void cplus_RTC::WriteReg(uint8_t reg, uint8_t data) {
-  Wire1.beginTransmission(0x51);
-  Wire1.write(reg);
-  Wire1.write(data);
-  Wire1.endTransmission();
+  wr->beginTransmission(0x51);
+  wr->write(reg);
+  wr->write(data);
+  wr->endTransmission();
 }
 
 uint8_t cplus_RTC::ReadReg(uint8_t reg) {
-  Wire1.beginTransmission(0x51);
-  Wire1.write(reg);
-  Wire1.endTransmission(false);
-  Wire1.requestFrom(0x51, 1);
-  return Wire1.read();
+  wr->beginTransmission(0x51);
+  wr->write(reg);
+  wr->endTransmission(false);
+  wr->requestFrom(0x51, 1);
+  return wr->read();
 }
 
 

--- a/lib/RTC/cplus_RTC.cpp
+++ b/lib/RTC/cplus_RTC.cpp
@@ -2,9 +2,14 @@
 
 // RTC::RTC() {
 // }
-
+#ifndef RTC_SDA
+#define RTC_SDA 21
+#endif
+#ifndef RTC_SCL
+#define RTC_SCL 22
+#endif
 void cplus_RTC::begin(void) {
-    Wire1.begin(21, 22);
+    Wire1.begin(RTC_SDA, RTC_SCL);
 }
 
 void cplus_RTC::GetBm8563Time(void) {

--- a/lib/RTC/cplus_RTC.h
+++ b/lib/RTC/cplus_RTC.h
@@ -20,6 +20,7 @@ class cplus_RTC {
     // cplus_RTC();
 
     void begin(void);
+    void setWire(TwoWire* obj) { wr = obj; }
     void GetBm8563Time(void);
 
     void SetTime(RTC_TimeTypeDef* RTC_TimeStruct);
@@ -51,6 +52,7 @@ class cplus_RTC {
     uint8_t asc[14];
 
    private:
+    TwoWire *wr = &Wire1; // Default I2C bus for StickCPluses
     void Bcd2asc(void);
     void DataMask();
     void Str2Time(void);

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -547,10 +547,6 @@ void drawSubmenu(int index,std::vector<Option>& options, String system) {
 }
 
 void drawStatusBar() {
-  #if defined(HAS_RTC)
-    cplus_RTC _rtc;
-    RTC_TimeTypeDef _time;
-  #endif
   int i=0;
   uint8_t bat = getBattery();
   uint8_t bat_margin = 85;

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -7,10 +7,16 @@ MainMenu::MainMenu() {
     _menuItems = {
         &wifiMenu,
         &bleMenu,
+    #if !defined(REMOVE_RF_MENU)
         &rfMenu,
+    #endif
+    #if !defined(REMOVE_RFID_MENU)
         &rfidMenu,
+    #endif
         &irMenu,
+    #if defined(FM_SI4713)
         &fmMenu,
+    #endif
         &fileMenu,
         &gpsMenu,
     #if defined(USE_NRF24_VIA_SPI)

--- a/src/core/serialcmds.cpp
+++ b/src/core/serialcmds.cpp
@@ -1239,9 +1239,6 @@ bool processSerialCommand(String cmd_str) {
           Serial.println(rtc.getDateTime());
           //Serial.println(rtc.getTime("%A, %B %d %Y %H:%M:%S"));
         #else
-          RTC_TimeTypeDef _time;
-          RTC_DateTypeDef _date;
-          cplus_RTC _rtc;
           _rtc.begin();
           _rtc.GetTime(&_time);
           _rtc.GetDate(&_date);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -379,7 +379,6 @@ void setClock() {
 
   #if defined(HAS_RTC)
     RTC_TimeTypeDef TimeStruct;
-    cplus_RTC _rtc;
     _rtc.GetBm8563Time();
   #endif
 
@@ -474,8 +473,6 @@ void runClockLoop() {
   int tmp=0;
 
   #if defined(HAS_RTC)
-    RTC_TimeTypeDef _time;
-    cplus_RTC _rtc;
     _rtc.GetBm8563Time();
     _rtc.GetTime(&_time);
   #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,8 @@ time_t localTime;
 struct tm* timeInfo;
 #if defined(HAS_RTC)
 cplus_RTC _rtc;
+RTC_TimeTypeDef _time;
+RTC_DateTypeDef _date;
 bool clock_set = true;
 #else
 ESP32Time rtc;
@@ -248,8 +250,7 @@ void boot_screen_anim() {
  *********************************************************************/
 void init_clock() {
 #if defined(HAS_RTC)
-  RTC_TimeTypeDef _time;
-  cplus_RTC _rtc;
+  
   _rtc.begin();
   _rtc.GetBm8563Time();
   _rtc.GetTime(&_time);
@@ -384,9 +385,6 @@ void setup() {
  **********************************************************************/
 #if defined(HAS_SCREEN)
 void loop() {
-#if defined(HAS_RTC)
-  RTC_TimeTypeDef _time;
-#endif
   bool redraw = true;
   long clock_update=0;
   mainMenu.begin();


### PR DESCRIPTION
#### Proposed Changes ####

* Added support to Lilygo T-Watch S3.
* Adapted RTC lib to accept other setups, as this watch uses the same chip as StickCPlus, BM8563 that is the same as PCF8536, but with different pinouts and Wire object point.
* Added flags to disable permanently RF and RFID menu, and removinf FM Radio from menu if not available.
