### PR TITLE
Cardputer Keyboard enhancement, (all) BLE Pairing fix

### DIFF
--- a/boards/pinouts/m5stack-cardputer.h
+++ b/boards/pinouts/m5stack-cardputer.h
@@ -9,7 +9,7 @@
 
 #define HAS_KEYBOARD    //has keyboard to use 
 #define HAS_KEYBOARD_HID //has keyboard to use 
-#define KB_HID_EXIT_MSG "fn + esc to exit"
+#define KB_HID_EXIT_MSG "fn + Ok to exit"
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -57,7 +57,7 @@ static const uint8_t ADC2 = 8;
 #define KEY_LEFT_SHIFT 0x81
 #define KEY_LEFT_ALT 0x82
 #define KEY_FN 0xff
-#define KEY_OPT 0x00
+#define KEY_OPT 0x83
 #define KEY_BACKSPACE 0x2a
 #define KEY_TAB 0x2b
 #define KEY_ENTER 0x28

--- a/include/globals.h
+++ b/include/globals.h
@@ -89,6 +89,9 @@ struct keyStroke { // DO NOT CHANGE IT!!!!!
     bool fn = false;
     bool del = false;
     bool enter = false;
+    bool alt = false;
+    bool ctrl = false;
+    bool gui = false;
     uint8_t modifiers = 0;
     std::vector<char> word;
     std::vector<uint8_t> hid_keys;
@@ -102,6 +105,9 @@ struct keyStroke { // DO NOT CHANGE IT!!!!!
         fn = false;
         del = false;
         enter = false;
+        bool alt = false;
+        bool ctrl = false;
+        bool gui = false;
         modifiers = 0;
         word.clear();
         hid_keys.clear();

--- a/lib/Bad_Usb_Lib/BleKeyboard.cpp
+++ b/lib/Bad_Usb_Lib/BleKeyboard.cpp
@@ -142,12 +142,13 @@ void BleKeyboard::begin(const uint8_t *layout)
 
   advertising = pServer->getAdvertising();
   advertising->setAppearance(HID_KEYBOARD);
-  advertising->addServiceUUID(hid->hidService()->getUUID());
+  NimBLEUUID uuid((uint32_t)(ESP.getEfuseMac() & 0xFFFFF));
+  advertising->addServiceUUID(uuid); // ljkjlkhn.
   advertising->setScanResponse(false);
   advertising->start();
   hid->setBatteryLevel(batteryLevel);
 
-  ESP_LOGD(LOG_TAG, "Advertising started!");
+  ESP_LOGD(LOG_TAG, "Advertising started with UUID: %s", uuid.toString());
 }
 
 void BleKeyboard::end(void)

--- a/lib/utility/Keyboard.cpp
+++ b/lib/utility/Keyboard.cpp
@@ -171,6 +171,7 @@ void Keyboard_Class::updateKeysState()
         if (getKeyValue(i).value_first == KEY_OPT)
         {
             _keys_state_buffer.opt = true;
+            _key_pos_modifier_keys.push_back(i);
             continue;
         }
 
@@ -184,7 +185,7 @@ void Keyboard_Class::updateKeysState()
         if (getKeyValue(i).value_first == KEY_LEFT_SHIFT)
         {
             _keys_state_buffer.shift = true;
-            _key_pos_modifier_keys.push_back(i);
+           _key_pos_modifier_keys.push_back(i);
             continue;
         }
 
@@ -254,7 +255,7 @@ void Keyboard_Class::updateKeysState()
     // Deal what left
     for (auto &i : _key_pos_print_keys)
     {
-        if (_keys_state_buffer.ctrl || _keys_state_buffer.shift ||
+        if (_keys_state_buffer.shift ||
             _is_caps_locked)
         {
             _keys_state_buffer.word.push_back(getKeyValue(i).value_second);

--- a/src/modules/ble/bad_ble.cpp
+++ b/src/modules/ble/bad_ble.cpp
@@ -391,10 +391,13 @@ Reconnect:
     tft.setTextSize(FM);
     String _mymsg="";
     keyStroke key;
+    long debounce;
     while(Kble.isConnected()) {
       key=_getKeyPress();
-      if (key.pressed) {
-        if(key.enter) Kble.println();
+      if (key.pressed && (millis()-debounce>200)) {
+        if(key.alt) Kble.press(KEY_LEFT_ALT);
+        if(key.ctrl) Kble.press(KEY_LEFT_CTRL);
+        if(key.gui) Kble.press(KEY_LEFT_GUI);
         else if(key.del) Kble.press(KEYBACKSPACE);
         else {
           for(char k : key.word) {
@@ -425,7 +428,7 @@ Reconnect:
           tft.drawCentreString("Pressed: " + keyStr, tftWidth / 2, tftHeight / 2,1);
           _mymsg=keyStr;
         }
-        delay(200);
+        debounce = millis();
       }
     }
     if(BLEConnected && !Kble.isConnected()) goto Reconnect;

--- a/src/modules/others/bad_usb.cpp
+++ b/src/modules/others/bad_usb.cpp
@@ -397,9 +397,13 @@ void usb_keyboard() {
   tft.setTextSize(FM);
   String _mymsg="";
   keyStroke key;
+  long debounce=millis();
   while(1) {
     key=_getKeyPress();
-    if (key.pressed) {
+    if (key.pressed && (millis()-debounce>200)) {
+      if(key.alt) Kb.press(KEY_LEFT_ALT);
+      if(key.ctrl) Kb.press(KEY_LEFT_CTRL);
+      if(key.gui) Kb.press(KEY_LEFT_GUI);
       if(key.enter) Kb.println();
       else if(key.del) Kb.press(KEYBACKSPACE);
       else {
@@ -430,7 +434,7 @@ void usb_keyboard() {
         tft.drawCentreString("Pressed: " + keyStr, tftWidth / 2, tftHeight / 2,1);
         _mymsg=keyStr;
       }
-      delay(200);
+      debounce=millis();
     }
   }
 }


### PR DESCRIPTION
#### Proposed Changes ####

* USB and BLE keyboard now accept TAB Arrows (fn+','  fn+'.'  fn+';'  and fn+'/'),  DEL, ESC and the modifiers Alc, Ctrl, GUI ( GUI+r is working now)
* In Cardputer, to exit USB and BLE Keyboard, now you need to use FN+Ok ( as ESC is Fn+'`' that was used before)
* Ble Pairing, now BLE uses different UUID for each device, based on its HWID. https://github.com/pr3y/Bruce/issues/902
