### PR TITLE
Use a single RMT channel for LED control

### DIFF
--- a/src/core/led_control.cpp
+++ b/src/core/led_control.cpp
@@ -5,9 +5,8 @@
 #include "core/utils.h"
 
 #define FASTLED_RMT_BUILTIN_DRIVER 1  // Use the ESP32 RMT built-in driver
-#define FASTLED_RMT_MAX_CHANNELS 2    // Maximum number of RMT channels
+#define FASTLED_RMT_MAX_CHANNELS 1    // Maximum number of RMT channels
 #define FASTLED_ESP32_RMT_CHANNEL_0 0 // Use RMT channel 0 for FastLED
-#define FASTLED_ESP32_RMT_CHANNEL_1 1 // Use RMT channel 1 for FastLED
 #include <FastLED.h>
 #include "driver/rmt.h"
 #include <freertos/FreeRTOS.h>
@@ -78,26 +77,23 @@ void beginLed() {
  *  by the RF functions, in this case, we are restarting it all the time
  */
 // -- RMT configuration for transmission
-for (int i = 0; i < 2; i += 1)
-    {
-        rmt_config_t rmt_tx;
-        memset(&rmt_tx, 0, sizeof(rmt_config_t));
-        rmt_tx.channel = rmt_channel_t(i);
-        rmt_tx.rmt_mode = RMT_MODE_TX;
-        rmt_tx.gpio_num = (gpio_num_t)RGB_LED;
-        rmt_tx.mem_block_num = 2;
-        rmt_tx.clk_div = 2;
-        rmt_tx.tx_config.loop_en = false;
-        rmt_tx.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
-        rmt_tx.tx_config.carrier_en = false;
-        rmt_tx.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
-        rmt_tx.tx_config.idle_output_en = true;
+    rmt_config_t rmt_tx;
+    memset(&rmt_tx, 0, sizeof(rmt_config_t));
+    rmt_tx.channel = rmt_channel_t(FASTLED_ESP32_RMT_CHANNEL_0);
+    rmt_tx.rmt_mode = RMT_MODE_TX;
+    rmt_tx.gpio_num = (gpio_num_t)RGB_LED;
+    rmt_tx.mem_block_num = 2;
+    rmt_tx.clk_div = 2;
+    rmt_tx.tx_config.loop_en = false;
+    rmt_tx.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
+    rmt_tx.tx_config.carrier_en = false;
+    rmt_tx.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
+    rmt_tx.tx_config.idle_output_en = true;
 
-        // -- Apply the configuration
-        rmt_config(&rmt_tx);
-        rmt_driver_uninstall(rmt_channel_t(i));
-        rmt_driver_install(rmt_channel_t(i), 0, 0);
-    }
+    // -- Apply the configuration
+    rmt_config(&rmt_tx);
+    rmt_driver_uninstall(rmt_channel_t(FASTLED_ESP32_RMT_CHANNEL_0));
+    rmt_driver_install(rmt_channel_t(FASTLED_ESP32_RMT_CHANNEL_0), 0, 0);
 
 
     if(bruceConfig.ledColor == LED_COLOR_WHEEL && colorWheelTaskHandle == NULL){

--- a/src/modules/rf/record.cpp
+++ b/src/modules/rf/record.cpp
@@ -34,7 +34,7 @@ float phase = 0.0;
 float lastPhase = 2 * PI;
 unsigned long lastAnimationUpdate = 0;
 void sinewave_animation(){
-    if(millis() - lastAnimationUpdate < 100) return;
+    if(millis() - lastAnimationUpdate < 10) return;
 
     tft.drawPixel(0,0,0);
 
@@ -50,7 +50,7 @@ void sinewave_animation(){
     }
 
     lastPhase = phase;
-    phase += 1;
+    phase += 0.15;
     if (phase >= 2 * PI) {
         phase = 0.0;
     }

--- a/src/modules/rf/record.cpp
+++ b/src/modules/rf/record.cpp
@@ -31,23 +31,25 @@ void init_rmt_raw_recording() {
 }
 
 float phase = 0.0;
+float lastPhase = 2 * PI;
 unsigned long lastAnimationUpdate = 0;
 void sinewave_animation(){
     if(millis() - lastAnimationUpdate < 100) return;
 
     tft.drawPixel(0,0,0);
-    tft.fillRect(10, 50, TFT_HEIGHT - 20, TFT_WIDTH - 60, bruceConfig.bgColor);
 
     int centerY = (TFT_WIDTH / 2) + 20;
     int amplitude = (TFT_WIDTH / 2) - 40;
-    int squareSize = 5;
-    int halfSize = squareSize / 2;
+    int sinewaveWidth = 5;
 
     for (int x = 20; x < TFT_HEIGHT - 20; x++) {
+        int lastY = centerY + amplitude * sin(lastPhase + x * 0.05);
         int y = centerY + amplitude * sin(phase + x * 0.05);
-        tft.fillRect(x - halfSize, y - halfSize, squareSize, squareSize, bruceConfig.priColor);
+        tft.drawFastVLine(x, lastY, sinewaveWidth, bruceConfig.bgColor);
+        tft.drawFastVLine(x, y, sinewaveWidth, bruceConfig.priColor);
     }
 
+    lastPhase = phase;
     phase += 1;
     if (phase >= 2 * PI) {
         phase = 0.0;


### PR DESCRIPTION
Super small PR: 
I noticed that assigning just RMT channel 0 to FastLed it still works, so there's no need to sacrifice any more channels to it.
