### PR TITLE
Fix build Lilygo T-Display-S3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -115,6 +115,6 @@ lib_deps =
 	tobozo/ESP32-PSRamFS
 	;chegewara/EspTinyUSB
 	bitbank2/AnimatedGIF
-	https://github.com/bitbank2/PNGdec
+	https://github.com/Tawank/PNGdec
 
 monitor_speed = 115200

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -33,14 +33,14 @@ void ConfigMenu::optionsMenu() {
     options.push_back({"Turn-off",   [=]() { powerOff(); }});
     options.push_back({"Deep Sleep", [=]() { digitalWrite(PIN_POWER_ON,LOW); esp_sleep_enable_ext0_wakeup(GPIO_NUM_6,LOW); esp_deep_sleep_start(); }});
 #elif defined(T_DISPLAY_S3)
-    options.push_back({"Turn-off", [=]}()
+    options.push_back({"Turn-off", [=]()
     {
         tft.fillScreen(bruceConfig.bgColor);
         digitalWrite(PIN_POWER_ON, LOW);
         digitalWrite(TFT_BL, LOW);
         tft.writecommand(0x10);
         esp_deep_sleep_start();
-    });
+    }});
 #endif
     if (bruceConfig.devMode) options.push_back({"Dev Mode", [=]() { devMenu(); }});
 


### PR DESCRIPTION
#### Proposed Changes ####

- Fix build Lilygo T-Display-S3
- Change the source of PNGDec library.
Because the autor made a new version 7h ago which does not support TFT_eSPI.
https://github.com/bitbank2/PNGdec/blob/b416f1989feb352e6e39f94ce820f17ee92cece7/src/PNGDisplay.h#L22
In this file he includes `#include <bb_spi_lcd.h>` other library for lcd screens.

#### Types of Changes ####

Bugfix

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
