### PR TITLE
create new profiles for quick remote setup and get rid of * char lists

### DIFF
--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -50,7 +50,6 @@ IrRead::IrRead(bool headless_mode, bool raw_mode) {
     setup();
 }
 bool quickloop = false;
-int button_pos = 0;
 std::vector<String> quickButtonsTV = {
     "POWER",
     "UP",

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -51,7 +51,7 @@ IrRead::IrRead(bool headless_mode, bool raw_mode) {
 }
 bool quickloop = false;
 int button_pos = 0;
-const char* quickButtons[] = {
+std::vector<String> quickButtonsTV = {
     "POWER",
     "UP",
     "DOWN",
@@ -63,11 +63,13 @@ const char* quickButtons[] = {
     "VOL-",
     "CHA+",
     "CHA-",
+    "MUTE",
     "SETTINGS",
     "NETFLIX",
     "HOME",
     "BACK",
     "EXIT",
+    "SMART",
     "1",
     "2",
     "3",
@@ -79,6 +81,46 @@ const char* quickButtons[] = {
     "9",
     "0"
 };
+std::vector<String> quickButtonsAC = {
+    "POWER",
+    "TEMP+",
+    "TEMP-",
+    "SPEED",
+    "SWING",
+    "SWING+",
+    "SWING-",
+    "JET",
+    "UP",
+    "DOWN",
+    "MODE"
+};
+std::vector<String> quickButtonsSOUND = {
+    "POWER",
+    "UP",
+    "DOWN",
+    "LEFT",
+    "RIGHT",
+    "OK",
+    "SOURCES",
+    "VOL+",
+    "VOL-",
+    "MUTE",
+    "SETTINGS",
+    "BACK",
+    "EQ",
+    "REC",
+    "PLAY/PAUSE",
+    "STOP",
+    "NEXT",
+    "PREV",
+    "SHUFFLE",
+    "REPEAT"
+};
+std::vector<String>& quickButtons = quickButtonsTV;
+
+
+
+
 void IrRead::setup() {
     irrecv.enableIRIn();
 
@@ -94,9 +136,14 @@ void IrRead::setup() {
     if(headless) return;
     // else
     returnToMenu = true;  // make sure menu is redrawn when quitting in any point
+    std::vector<Option> quickRemoteOptions = {
+        {"TV", [&]() { quickButtons = quickButtonsTV; begin(); return loop(); }},
+        {"AC", [&]() { quickButtons = quickButtonsAC; begin(); return loop(); }},
+        {"SOUND", [&]() { quickButtons = quickButtonsSOUND; begin(); return loop(); }},
+    };
     options = {
         {"Custom Read", [&]() { begin(); return loop(); }},
-        {"Quick Remote Setup  ", [&]() { quickloop = true; begin(); return loop();}},
+        {"Quick Remote Setup  ", [&]() { quickloop = true; loopOptions(quickRemoteOptions);}},
         {"Menu", yield},
     };
     loopOptions(options);
@@ -192,7 +239,6 @@ void IrRead::read_signal() {
 
 void IrRead::discard_signal() {
     if (!_read_signal) return;
-
     irrecv.resume();
     begin();
 }

--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -50,72 +50,7 @@ IrRead::IrRead(bool headless_mode, bool raw_mode) {
     setup();
 }
 bool quickloop = false;
-std::vector<String> quickButtonsTV = {
-    "POWER",
-    "UP",
-    "DOWN",
-    "LEFT",
-    "RIGHT",
-    "OK",
-    "SOURCES",
-    "VOL+",
-    "VOL-",
-    "CHA+",
-    "CHA-",
-    "MUTE",
-    "SETTINGS",
-    "NETFLIX",
-    "HOME",
-    "BACK",
-    "EXIT",
-    "SMART",
-    "1",
-    "2",
-    "3",
-    "4",
-    "5",
-    "6",
-    "7",
-    "8",
-    "9",
-    "0"
-};
-std::vector<String> quickButtonsAC = {
-    "POWER",
-    "TEMP+",
-    "TEMP-",
-    "SPEED",
-    "SWING",
-    "SWING+",
-    "SWING-",
-    "JET",
-    "UP",
-    "DOWN",
-    "MODE"
-};
-std::vector<String> quickButtonsSOUND = {
-    "POWER",
-    "UP",
-    "DOWN",
-    "LEFT",
-    "RIGHT",
-    "OK",
-    "SOURCES",
-    "VOL+",
-    "VOL-",
-    "MUTE",
-    "SETTINGS",
-    "BACK",
-    "EQ",
-    "REC",
-    "PLAY/PAUSE",
-    "STOP",
-    "NEXT",
-    "PREV",
-    "SHUFFLE",
-    "REPEAT"
-};
-std::vector<String>& quickButtons = quickButtonsTV;
+
 
 
 

--- a/src/modules/ir/ir_read.h
+++ b/src/modules/ir/ir_read.h
@@ -36,7 +36,8 @@ private:
 	uint16_t* rawcode;
 	uint16_t raw_data_len;
 	int signals_read = 0;
-	String strDeviceContent = "";
+    int button_pos = 0;
+    String strDeviceContent = "";
 	bool headless = false;
 	bool raw = false;
 

--- a/src/modules/ir/ir_read.h
+++ b/src/modules/ir/ir_read.h
@@ -60,4 +60,73 @@ private:
     bool write_file(String filename, FS* fs);
     String parse_raw_signal();
     String parse_state_signal();
+	/////////////////////////////////////////////////////////////////////////////////////
+	// Quick Remotes
+	/////////////////////////////////////////////////////////////////////////////////////
+	std::vector<String> quickButtonsTV = {
+		"POWER",
+		"UP",
+		"DOWN",
+		"LEFT",
+		"RIGHT",
+		"OK",
+		"SOURCES",
+		"VOL+",
+		"VOL-",
+		"CHA+",
+		"CHA-",
+		"MUTE",
+		"SETTINGS",
+		"NETFLIX",
+		"HOME",
+		"BACK",
+		"EXIT",
+		"SMART",
+		"1",
+		"2",
+		"3",
+		"4",
+		"5",
+		"6",
+		"7",
+		"8",
+		"9",
+		"0"
+	};
+	std::vector<String> quickButtonsAC = {
+		"POWER",
+		"TEMP+",
+		"TEMP-",
+		"SPEED",
+		"SWING",
+		"SWING+",
+		"SWING-",
+		"JET",
+		"UP",
+		"DOWN",
+		"MODE"
+	};
+	std::vector<String> quickButtonsSOUND = {
+		"POWER",
+		"UP",
+		"DOWN",
+		"LEFT",
+		"RIGHT",
+		"OK",
+		"SOURCES",
+		"VOL+",
+		"VOL-",
+		"MUTE",
+		"SETTINGS",
+		"BACK",
+		"EQ",
+		"REC",
+		"PLAY/PAUSE",
+		"STOP",
+		"NEXT",
+		"PREV",
+		"SHUFFLE",
+		"REPEAT"
+	};
+	std::vector<String>& quickButtons = quickButtonsTV;
 };


### PR DESCRIPTION
#### Proposed Changes ####

New quick remote setup profiles

#### Types of Changes ####

Make profiles for quick remote setup (AC, SOUND, TV)

#### Verification ####

IR -> IR Read -> Quick Remote Setup

#### Testing ####

IR -> IR Read -> Quick Remote Setup -> Choose an option and start capturing

#### Linked Issues ####

No related issues

#### User-Facing Change ####
none

```release-note

```

#### Further Comments ####

