### PR TITLE
Change 'const char*' to String in loopOptions

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -78,11 +78,11 @@ extern bool BLEConnected;  // inform if BLE is active or not
 extern bool gpsConnected; // inform if GPS is active or not
 
 struct Option {
-  const char *label;
+  String label;
   std::function<void()> operation;
   bool selected = false;
 
-  Option(const char *lbl, const std::function<void()>& op, bool sel = false)
+  Option(String lbl, const std::function<void()>& op, bool sel = false)
     : label(lbl), operation(op), selected(sel) {}
 };
 

--- a/src/core/connect/esp_connection.cpp
+++ b/src/core/connect/esp_connection.cpp
@@ -24,10 +24,6 @@ bool EspConnection::beginSend() {
 
     loopOptions(peerOptions);
 
-    for (auto& opt : peerOptions) {
-        if (strcmp(opt.label, "Broadcast") != 0 )
-          free((void*)opt.label);
-      }
     peerOptions.clear();
 
     if (!setupPeer(dstAddress)) {
@@ -182,7 +178,7 @@ String EspConnection::macToString(const uint8_t *mac) {
 }
 
 void EspConnection::appendPeerToList(const uint8_t *mac) {
-    peerOptions.push_back({strdup(macToString(mac).c_str()), [=]() { setDstAddress(mac); }});
+    peerOptions.push_back({macToString(mac).c_str(), [=]() { setDstAddress(mac); }});
 }
 
 void EspConnection::onDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -577,14 +577,14 @@ void drawSubmenu(int index, std::vector<Option>& options, const char *title) {
     tft.drawString(title, 12, 30);
 
     const char *firstOption = index - 1 >= 0
-                                  ? options[index - 1].label
-                                  : options[menuSize - 1].label;
+                                  ? options[index - 1].label.c_str()
+                                  : options[menuSize - 1].label.c_str();
     tft.setTextSize(FM);
     tft.setTextColor(bruceConfig.secColor);
     tft.fillRect(12, 42+(tftHeight-134)/2, tftWidth-24, 8 * FM, bruceConfig.bgColor);
     tft.drawCentreString(firstOption,tftWidth/2, 42+(tftHeight-134)/2,SMOOTH_FONT);
 
-    int selectedTextSize = strlen(options[index].label) <= tftWidth/(LW*FG)-1 ? FG : FM;
+    int selectedTextSize = options[index].label.length() <= tftWidth/(LW*FG)-1 ? FG : FM;
     tft.setTextSize(selectedTextSize);
     tft.setTextColor(bruceConfig.priColor);
     tft.fillRect(12, 67+(tftHeight-134)/2+((FG-1)%2)*LH/2, tftWidth-24, 8 * FG + 1, bruceConfig.bgColor);
@@ -596,17 +596,17 @@ void drawSubmenu(int index, std::vector<Option>& options, const char *title) {
     );
 
     const char *thirdOption = index + 1 < menuSize
-                                  ? options[index+1].label
-                                  : options[0].label;
+                                  ? options[index+1].label.c_str()
+                                  : options[0].label.c_str();
     tft.setTextSize(FM);
     tft.setTextColor(bruceConfig.secColor);
     tft.fillRect(12, 102+(tftHeight-134)/2, tftWidth-24, 8 * FM, bruceConfig.bgColor);
     tft.drawCentreString(thirdOption,tftWidth/2, 102+(tftHeight-134)/2,SMOOTH_FONT);
 
     tft.drawFastHLine(
-      tftWidth/2 - strlen(options[index].label)*selectedTextSize*LW/2,
+      tftWidth/2 - strlen(options[index].label.c_str())*selectedTextSize*LW/2,
       67+(tftHeight-134)/2+((selectedTextSize-1)%2)*LH/2+selectedTextSize*LH,
-      strlen(options[index].label)*selectedTextSize*LW,
+      strlen(options[index].label.c_str())*selectedTextSize*LW,
       bruceConfig.priColor
     );
     tft.fillRect(tftWidth-5,0,5,tftHeight,bruceConfig.bgColor);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -442,27 +442,18 @@ void setClock() {
         options = {};
         for (int i = 0; i < 12; i++) {
             String tmp = String(i < 10 ? "0" : "") + String(i);
-            options.push_back({strdup(tmp.c_str()), [&]() { delay(1); }});
+            options.push_back({tmp.c_str(), [&]() { delay(1); }});
         }
 
         hr = loopOptions(options, false, true, "Set Hour");
-        for (auto& opt : options) {
-            if (strcmp(opt.label, "Main Menu") != 0)
-              free((void*)opt.label);
-          }
         options.clear();
 
         for (int i = 0; i < 60; i++) {
             String tmp = String(i < 10 ? "0" : "") + String(i);
-            options.push_back({strdup(tmp.c_str()), [&]() { delay(1); }});
+            options.push_back({tmp.c_str(), [&]() { delay(1); }});
         }
 
         mn = loopOptions(options, false, true, "Set Minute");
-
-        for (auto& opt : options) {
-            if (strcmp(opt.label, "Main Menu") != 0)
-              free((void*)opt.label);
-          }
         options.clear();
 
         options = {
@@ -556,15 +547,11 @@ int gsetIrTxPin(bool set) {
                 i != TOUCH_CS && i != SDCARD_CS && i != SDCARD_MOSI && i != SDCARD_MISO)
 #endif
                 options.push_back(
-                    {strdup(pin.first), [=]() { bruceConfig.setIrTxPin(pin.second); }, pin.second == bruceConfig.irTx}
+                    {pin.first, [=]() { bruceConfig.setIrTxPin(pin.second); }, pin.second == bruceConfig.irTx}
                 );
         }
 
         loopOptions(options, idx);
-        for (auto& opt : options) {
-            if (strcmp(opt.label, "Main Menu") != 0)
-              free((void*)opt.label);
-          }
         options.clear();
 
         Serial.println("Saved pin: " + String(bruceConfig.irTx));
@@ -655,15 +642,11 @@ int gsetRfTxPin(bool set) {
                 i != TOUCH_CS && i != SDCARD_CS && i != SDCARD_MOSI && i != SDCARD_MISO)
 #endif
                 options.push_back(
-                    {strdup(pin.first), [=]() { bruceConfig.setRfTxPin(pin.second); }, pin.second == bruceConfig.rfTx}
+                    {pin.first, [=]() { bruceConfig.setRfTxPin(pin.second); }, pin.second == bruceConfig.rfTx}
                 );
         }
 
         loopOptions(options);
-        for (auto& opt : options) {
-            if (strcmp(opt.label, "Main Menu") != 0)
-              free((void*)opt.label);
-          }
         options.clear();
     }
 
@@ -694,15 +677,11 @@ int gsetRfRxPin(bool set) {
                 i != TOUCH_CS && i != SDCARD_CS && i != SDCARD_MOSI && i != SDCARD_MISO)
 #endif
                 options.push_back(
-                    {strdup(pin.first), [=]() { bruceConfig.setRfRxPin(pin.second); }, pin.second == bruceConfig.rfRx}
+                    {pin.first, [=]() { bruceConfig.setRfRxPin(pin.second); }, pin.second == bruceConfig.rfRx}
                 );
         }
 
         loopOptions(options);
-        for (auto& opt : options) {
-            if (strcmp(opt.label, "Main Menu") != 0)
-              free((void*)opt.label);
-          }
         options.clear();
     }
 
@@ -727,15 +706,11 @@ void setStartupApp() {
         if (bruceConfig.startupApp == appName) idx = index++;
 
         options.push_back({
-            strdup(appName.c_str()), [=]() { bruceConfig.setStartupApp(appName); }, bruceConfig.startupApp == appName
+            appName.c_str(), [=]() { bruceConfig.setStartupApp(appName); }, bruceConfig.startupApp == appName
         });
     }
 
     loopOptions(options, idx);
-    for (auto& opt : options) {
-        if (strcmp(opt.label, "None") != 0)
-          free((void*)opt.label);
-      }
     options.clear();
 }
 
@@ -885,13 +860,9 @@ RELOAD:
         gpio_num_t sel = GPIO_NUM_NC;
         for (int8_t i = -1; i <= GPIO_NUM_MAX; i++) {
             String tmp = String(i);
-            options.push_back({strdup(tmp.c_str()), [i, &sel]() { sel = (gpio_num_t)i; }});
+            options.push_back({tmp.c_str(), [i, &sel]() { sel = (gpio_num_t)i; }});
         }
         loopOptions(options);
-        for (auto& opt : options) {
-            if (strcmp(opt.label, "Main Menu") != 0)
-              free((void*)opt.label);
-          }
         options.clear();
         if (opt == 1) points.sck = sel;
         else if (opt == 2) points.miso = sel;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -606,7 +606,7 @@ int gsetIrRxPin(bool set) {
                 i != TOUCH_CS && i != SDCARD_CS && i != SDCARD_MOSI && i != SDCARD_MISO)
 #endif
                 options.push_back(
-                    {strdup(pin.first), [=]() { bruceConfig.setIrRxPin(pin.second); }, pin.second == bruceConfig.irRx}
+                    {pin.first, [=]() { bruceConfig.setIrRxPin(pin.second); }, pin.second == bruceConfig.irRx}
                 );
         }
 

--- a/src/core/wifi_common.cpp
+++ b/src/core/wifi_common.cpp
@@ -127,17 +127,13 @@ bool wifiConnectMenu(wifi_mode_t mode) {
                      default: encryptionTypeStr = "Unknown"; break;
                  }
                  String optionText = encryptionPrefix + ssid + "(" + String(rssi) + "|" + encryptionTypeStr + ")";
-                 options.emplace_back(strdup(optionText.c_str()), [=]() { _wifiConnect(ssid, encryptionType); });
+                 options.push_back({optionText.c_str(), [=]() { _wifiConnect(ssid, encryptionType); }});
 
             }
-            options.emplace_back("Hidden SSID", [=]() { String __ssid = keyboard("", 32, "Your SSID"); _wifiConnect(__ssid.c_str(), 8); });
+            options.push_back({"Hidden SSID", [=]() { String __ssid = keyboard("", 32, "Your SSID"); _wifiConnect(__ssid.c_str(), 8); }});
             addOptionToMainMenu();
 
             loopOptions(options);
-            for (auto& opt : options) {
-              if (strcmp(opt.label, "Main Menu") != 0 && strcmp(opt.label, "Hidden SSID") != 0)
-                free((void*)opt.label);
-            }
             options.clear();
 
             if (check(EscPress)) {

--- a/src/modules/bjs_interpreter/dialog_js.cpp
+++ b/src/modules/bjs_interpreter/dialog_js.cpp
@@ -138,7 +138,7 @@ duk_ret_t native_dialogChoice(duk_context *ctx) {
     }
     duk_pop_2(ctx);
     options.push_back(
-        {strdup(choiceKey), [choiceValue, &result]() { result = choiceValue; }});
+        {choiceKey, [choiceValue, &result]() { result = choiceValue; }});
   }
 
   if (legacy) {
@@ -146,10 +146,6 @@ duk_ret_t native_dialogChoice(duk_context *ctx) {
   }
 
   loopOptions(options);
-  for (auto& opt : options) {
-    if (strcmp(opt.label, "Cancel") != 0)
-      free((void*)opt.label);
-  }
   options.clear();
 
   duk_push_string(ctx, result);

--- a/src/modules/ble/bad_ble.cpp
+++ b/src/modules/ble/bad_ble.cpp
@@ -234,7 +234,7 @@ bool ask_restart() {
   return false;
 }
 void addKeyboardOption(const char* name, const uint8_t* layout) {
-  options.push_back({strdup(name), [=]() { chooseKb_ble(layout); }});
+  options.push_back({name, [=]() { chooseKb_ble(layout); }});
 }
 
 void ble_setup() {
@@ -286,10 +286,6 @@ NewScript:
         index = loopOptions(
             options, false, true, "Keyboard Layout", index
         ); // It will ask for the keyboard each time, but will save the last chosen to be faster
-        for (auto& opt : options) {
-          if (strcmp(opt.label, "Main Menu") != 0)
-            free((void*)opt.label);
-        }
         options.clear();
         if (returnToMenu) return;
         if (!kbChosen_ble)

--- a/src/modules/ble/ble_common.cpp
+++ b/src/modules/ble/ble_common.cpp
@@ -81,7 +81,7 @@ class AdvertisedDeviceCallbacks : public NimBLEAdvertisedDeviceCallbacks {
         if(bt_title.isEmpty()) bt_title = bt_address;
         if(bt_name.isEmpty()) bt_name="<no name>";
         // If BT name is empty, set NONAME
-        if(ESP.getFreeHeap()>4096) options.emplace_back(strdup(bt_title.c_str()), [=]() { ble_info(bt_name, bt_address, bt_signal); });
+        if(ESP.getFreeHeap()>4096) options.emplace_back(bt_title.c_str(), [=]() { ble_info(bt_name, bt_address, bt_signal); });
         else {
             Serial.println("Memory low, stopping BLE scan...");
             pBLEScan->stop();
@@ -117,10 +117,6 @@ void ble_scan()
     addOptionToMainMenu();
 
     loopOptions(options);
-    for (auto& opt : options) {
-        if (strcmp(opt.label, "Main Menu") != 0)
-          free((void*)opt.label);
-    }
     options.clear();
 
     // Delete results fromBLEScan buffer to release memory

--- a/src/modules/fm/fm.cpp
+++ b/src/modules/fm/fm.cpp
@@ -85,15 +85,11 @@ void fm_options_frq(uint16_t f_min, bool reserved) {
   options = { };
   for(uint16_t f=f_min; f<f_max; f+=10){
     sprintf(f_str, "%d Hz", f);
-    options.push_back({strdup(f_str),      [=]() { set_frq(f); }});
+    options.push_back({f_str,      [=]() { set_frq(f); }});
   }
   addOptionToMainMenu();
 
   loopOptions(options);
-  for (auto& opt : options) {
-    if (strcmp(opt.label, "Main Menu") != 0)
-      free((void*)opt.label);
-  }
   options.clear();
 }
 
@@ -128,16 +124,12 @@ void fm_options_digit(uint16_t f_min, bool reserved) {
   options = { };
   for(uint16_t f=f_min; f<f_max; f+=1){
     sprintf(f_str, "%d MHz", f);
-    options.push_back({strdup(f_str),      [=]() { fm_options_frq(f, reserved); }});
+    options.push_back({f_str,      [=]() { fm_options_frq(f, reserved); }});
   }
   addOptionToMainMenu();
 
   loopOptions(options);
-  for (auto& opt : options) {
-    if (strcmp(opt.label, "Main Menu") != 0)
-      free((void*)opt.label);
-  }
-options.clear();
+  options.clear();
 }
 
 // Choose between 80 - 90 - 100
@@ -153,15 +145,11 @@ void fm_options(uint16_t f_min, uint16_t f_max, bool reserved) {
   }
   for(uint16_t f=f_min; f<f_max; f+=10){
     sprintf(f_str, "%d MHz", f);
-    options.push_back({strdup(f_str),      [=]() { fm_options_digit(f, reserved); }});
+    options.push_back({f_str,      [=]() { fm_options_digit(f, reserved); }});
   }
   addOptionToMainMenu();
 
   loopOptions(options);
-  for (auto& opt : options) {
-    if (strcmp(opt.label, "Main Menu") != 0)
-      free((void*)opt.label);
-  }
   options.clear();
 
   if (auto_scan == true) {

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -56,7 +56,7 @@ void selectRecentIrMenu() {
     for (auto recent_ircode : recent_ircodes) {
       if(recent_ircode->filepath=="") continue; // not inited
       // else
-      options.push_back({ strdup(recent_ircode->filepath.c_str()), [recent_ircode, &selected_code](){ selected_code = recent_ircode; }});
+      options.push_back({ recent_ircode->filepath.c_str(), [recent_ircode, &selected_code](){ selected_code = recent_ircode; }});
     }
     options.push_back({ "Main Menu" , [&](){ exit=true; }});
 
@@ -68,10 +68,6 @@ void selectRecentIrMenu() {
         selected_code = NULL;
       }
       if(check(EscPress) || exit) break;
-    }
-    for (auto& opt : options) {
-      if (strcmp(opt.label, "Main Menu") != 0)
-        free((void*)opt.label);
     }
     options.clear();
 
@@ -327,7 +323,7 @@ void otherIRcodes() {
   options = { };
   for(auto code : codes) {
     if (code->name != "") {
-      options.push_back({ strdup(code->name.c_str()), [code](){ sendIRCommand(code); addToRecentCodes(code); }});
+      options.push_back({ code->name.c_str(), [code](){ sendIRCommand(code); addToRecentCodes(code); }});
     }
   }
   options.push_back({ "Main Menu" , [&](){ exit=true; }});
@@ -338,10 +334,6 @@ void otherIRcodes() {
   while (1) {
     idx=loopOptions(options,idx);
     if(check(EscPress) || exit) break;
-  }
-  for (auto& opt : options) {
-    if (strcmp(opt.label, "Main Menu") != 0)
-      free((void*)opt.label);
   }
   options.clear();
 }  // end of otherIRcodes

--- a/src/modules/others/ibutton.cpp
+++ b/src/modules/others/ibutton.cpp
@@ -123,13 +123,9 @@ void setiButtonPinMenu() {
   gpio_num_t sel = GPIO_NUM_NC;
   for (int8_t i = -1; i <= GPIO_NUM_MAX; i++) {
       String tmp = "GPIO " + String(i);
-      options.push_back({strdup(tmp.c_str()), [i, &sel]() { sel = (gpio_num_t)i; }});
+      options.push_back({tmp.c_str(), [i, &sel]() { sel = (gpio_num_t)i; }});
   }
   loopOptions(options,bruceConfig.iButton+1);
-  for (auto& opt : options) {
-    if (strcmp(opt.label, "Main Menu") != 0)
-      free((void*)opt.label);
-  }
   options.clear();
   bruceConfig.setiButtonPin(sel);
 }

--- a/src/modules/others/qrcode_menu.cpp
+++ b/src/modules/others/qrcode_menu.cpp
@@ -70,7 +70,7 @@ void qrcode_menu() {
 
     // Add QR codes from the config
     for (const auto& entry : bruceConfig.qrCodes) {
-        options.push_back({strdup(entry.menuName.c_str()), lambdaHelper(qrcode_display, entry.content)});
+        options.push_back({entry.menuName.c_str(), lambdaHelper(qrcode_display, entry.content)});
     }
 
     options.push_back({"PIX", pix_qrcode});
@@ -78,11 +78,7 @@ void qrcode_menu() {
     addOptionToMainMenu();
 
     loopOptions(options);
-    for (auto& opt : options) {
-        if (strcmp(opt.label, "Main Menu") != 0 && strcmp(opt.label, "Custom") != 0 && strcmp(opt.label, "PIX") != 0)
-          free((void*)opt.label);
-      }
-      options.clear();
+    options.clear();
 }
 
 void custom_qrcode_menu() {

--- a/src/modules/rf/record.cpp
+++ b/src/modules/rf/record.cpp
@@ -157,20 +157,16 @@ float rf_freq_scan(){
 void rf_range_selection(float currentFrequency = 0.0) {
     int option=0;
     options = {
-        { strdup(String("Fixed [" + String(bruceConfig.rfFreq) + "]").c_str()), [=]()  { bruceConfig.setRfFreq(bruceConfig.rfFreq,2); } },
-        { strdup(String("Choose Fixed").c_str()), [&]()  { option = 1; } },
-        { strdup(subghz_frequency_ranges[0]), [=]()  { bruceConfig.setRfScanRange(0); } },
-        { strdup(subghz_frequency_ranges[1]), [=]()  { bruceConfig.setRfScanRange(1); } },
-        { strdup(subghz_frequency_ranges[2]), [=]()  { bruceConfig.setRfScanRange(2); } },
-        { strdup(subghz_frequency_ranges[3]), [=]()  { bruceConfig.setRfScanRange(3); } },
+        { String("Fixed [" + String(bruceConfig.rfFreq) + "]").c_str(), [=]()  { bruceConfig.setRfFreq(bruceConfig.rfFreq,2); } },
+        { String("Choose Fixed").c_str(), [&]()  { option = 1; } },
+        { subghz_frequency_ranges[0], [=]()  { bruceConfig.setRfScanRange(0); } },
+        { subghz_frequency_ranges[1], [=]()  { bruceConfig.setRfScanRange(1); } },
+        { subghz_frequency_ranges[2], [=]()  { bruceConfig.setRfScanRange(2); } },
+        { subghz_frequency_ranges[3], [=]()  { bruceConfig.setRfScanRange(3); } },
     };
 
     loopOptions(options);
-    for (auto& opt : options) {
-        if (strcmp(opt.label, "Main Menu") != 0 && strcmp(opt.label, "Custom") != 0 && strcmp(opt.label, "PIX") != 0)
-          free((void*)opt.label);
-      }
-      options.clear();
+    options.clear();
 
     if(option == 1) { // Fixed Frequency Selector
         options = {};
@@ -178,15 +174,11 @@ void rf_range_selection(float currentFrequency = 0.0) {
         int arraySize = sizeof(subghz_frequency_list) / sizeof(subghz_frequency_list[0]);
         for(int i=0; i<arraySize;i++) {
             String tmp = String(subghz_frequency_list[i], 2) + "Mhz";
-            options.push_back({ strdup(tmp.c_str()), [=]()  { bruceConfig.setRfFreq(subghz_frequency_list[i],2); } });
+            options.push_back({ tmp.c_str(), [=]()  { bruceConfig.setRfFreq(subghz_frequency_list[i],2); } });
             if(int(currentFrequency*100)==int(subghz_frequency_list[i]*100)) ind=i;
         }
         loopOptions(options,ind);
-        for (auto& opt : options) {
-            if (strcmp(opt.label, "Main Menu") != 0 && strcmp(opt.label, "Custom") != 0 && strcmp(opt.label, "PIX") != 0)
-              free((void*)opt.label);
-          }
-          options.clear();
+        options.clear();
     }
 
     if (bruceConfig.rfFxdFreq) displayTextLine("Scan freq set to " + String(bruceConfig.rfFreq));

--- a/src/modules/rf/rf.cpp
+++ b/src/modules/rf/rf.cpp
@@ -1144,15 +1144,11 @@ struct RfCodes selectRecentRfMenu() {
     for(int i=0; i<16; i++) {
         if(recent_rfcodes[i].filepath=="") continue; // not inited
         // else
-        options.push_back({ strdup(recent_rfcodes[i].filepath.c_str()), [i, &selected_code](){ selected_code = recent_rfcodes[i]; }});
+        options.push_back({ recent_rfcodes[i].filepath.c_str(), [i, &selected_code](){ selected_code = recent_rfcodes[i]; }});
     }
     options.push_back({ "Main Menu" , [&](){ exit=true; }});
     loopOptions(options);
-    for (auto& opt : options) {
-        if (strcmp(opt.label, "Main Menu") != 0)
-          free((void*)opt.label);
-      }
-      options.clear();
+    options.clear();
     return(selected_code);
 }
 
@@ -1649,19 +1645,15 @@ RestartScan:
 			if (option == 1) { // Range submenu
                 option=0;
 				options = {
-					{ strdup(String("Fxd [" + String(bruceConfig.rfFreq) + "]").c_str()), [=]()  { bruceConfig.setRfScanRange(bruceConfig.rfScanRange, 1); } },
-                    { strdup(String("Choose Fxd").c_str()), [&]()  { option = 1; } },
-					{ strdup(subghz_frequency_ranges[0]), [=]()  { bruceConfig.setRfScanRange(0); } },
-					{ strdup(subghz_frequency_ranges[1]), [=]()  { bruceConfig.setRfScanRange(1); } },
-					{ strdup(subghz_frequency_ranges[2]), [=]()  { bruceConfig.setRfScanRange(2); } },
-					{ strdup(subghz_frequency_ranges[3]), [=]()  { bruceConfig.setRfScanRange(3); } },
+					{ String("Fxd [" + String(bruceConfig.rfFreq) + "]").c_str(), [=]()  { bruceConfig.setRfScanRange(bruceConfig.rfScanRange, 1); } },
+                    { "Choose Fxd", [&]()  { option = 1; } },
+					{ subghz_frequency_ranges[0], [=]()  { bruceConfig.setRfScanRange(0); } },
+					{ subghz_frequency_ranges[1], [=]()  { bruceConfig.setRfScanRange(1); } },
+					{ subghz_frequency_ranges[2], [=]()  { bruceConfig.setRfScanRange(2); } },
+					{ subghz_frequency_ranges[3], [=]()  { bruceConfig.setRfScanRange(3); } },
 				};
 
 				loopOptions(options);
-                for (auto& opt : options) {
-                    if (strcmp(opt.label, "Main Menu") != 0 && strcmp(opt.label, "Custom") != 0 && strcmp(opt.label, "PIX") != 0)
-                      free((void*)opt.label);
-                  }
                 options.clear();
 
                 if(option == 1) { // Range
@@ -1670,15 +1662,11 @@ RestartScan:
                     int arraySize = sizeof(subghz_frequency_list) / sizeof(subghz_frequency_list[0]);
                     for(int i=0; i<arraySize;i++) {
                         String tmp = String(subghz_frequency_list[i],2) + "Mhz";
-                        options.push_back({ strdup(tmp.c_str()), [=]()  { bruceConfig.rfFreq=subghz_frequency_list[i]; } });
+                        options.push_back({ tmp.c_str(), [=]()  { bruceConfig.rfFreq=subghz_frequency_list[i]; } });
                         if(int(frequency*100)==int(subghz_frequency_list[i]*100)) ind=i;
                     }
 				    loopOptions(options,ind);
-                    for (auto& opt : options) {
-                        if (strcmp(opt.label, "Main Menu") != 0)
-                          free((void*)opt.label);
-                      }
-                      options.clear();
+                    options.clear();
                     bruceConfig.setRfScanRange(bruceConfig.rfScanRange, 1);
                 }
 

--- a/src/modules/rfid/chameleon.cpp
+++ b/src/modules/rfid/chameleon.cpp
@@ -138,7 +138,7 @@ void Chameleon::loop() {
 }
 
 void Chameleon::addOptionSetMode(const char* name, AppMode mode) {
-    options.push_back({strdup(name), [=]() { setMode(mode); }});
+    options.push_back({name, [=]() { setMode(mode); }});
 }
 
 void Chameleon::selectMode() {
@@ -169,10 +169,6 @@ void Chameleon::selectMode() {
     addOptionSetMode("Factory Reset", FACTORY_RESET_MODE);
 
     loopOptions(options);
-    for (auto& opt : options) {
-        if (strcmp(opt.label, "Main Menu") != 0)
-          free((void*)opt.label);
-      }
     options.clear();
 }
 

--- a/src/modules/wifi/scan_hosts.cpp
+++ b/src/modules/wifi/scan_hosts.cpp
@@ -94,15 +94,11 @@ void local_scan_setup() {
         for(auto host:hostslist) {
           String result = host.ip.toString();
           if( host.ip == gateway ) result += "(GTW)";
-          options.emplace_back(strdup(result.c_str()), [=](){ afterScanOptions(host); });
+          options.push_back({result.c_str(), [=](){ afterScanOptions(host); }});
         }
         addOptionToMainMenu();
 
         loopOptions(options);
-        for (auto& opt : options) {
-          if (strcmp(opt.label, "Main Menu") != 0)
-            free((void*)opt.label);
-        }
         options.clear();
 
         if(!returnToMenu) goto ScanHostMenu;

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -155,7 +155,7 @@ void wifi_atk_menu()
        }
        String optionText = encryptionPrefix + ssid + " (" + String(rssi) + "|" + encryptionTypeStr + ")";
 
-       options.push_back({strdup(optionText.c_str()), [=]()
+       options.push_back({optionText.c_str(), [=]()
                           {
                             ap_record = ap_records[i];
                             target_atk_menu(WiFi.SSID(i).c_str(), WiFi.BSSIDstr(i), static_cast<uint8_t>(WiFi.channel(i)));
@@ -165,10 +165,6 @@ void wifi_atk_menu()
      addOptionToMainMenu();
 
      loopOptions(options);
-    for (auto& opt : options) {
-      if (strcmp(opt.label, "Main Menu") != 0 && strcmp(opt.label, "Custom") != 0 && strcmp(opt.label, "PIX") != 0)
-        free((void*)opt.label);
-    }
     options.clear();
    }
  }
@@ -181,7 +177,7 @@ void deauthFloodAttack()
     displayError("Failed to start AP");
     while (!check(SelPress))
     {
-      yield();
+      delay(10);
     }
     return;
   }


### PR DESCRIPTION
#### Proposed Changes ####

- Changed `const char *` to `String` in Option struct

#### Types of Changes ####

Bugfix

#### Verification ####

You can go into Wifi > Wifi Atks > Target Atks, the list of wifi AP should work properly.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

I did comparison between const char *, String and std::string in loopOptions.
I compared build size between them when I changed type here https://github.com/pr3y/Bruce/blob/main/include/globals.h#L81

This is result:
`const char *`: 3.610.093 bytes
`String`:       3.628.405 bytes +18kB
`std::string`:  3.634.465 bytes +18kB +6kB


I think we should switch to String this is 18kB more, but it is 6kB less than before.
Now we must allocate and dealocate strings, and we must remember to do it every time.
And I also wanted to add a feature to run js scripts in the background and if js script and bruce gui tried to run loopOptions at the same time it could lead to memory leaks.
