### PR TITLE
Fix: Reset image interval on manual navigation

### DIFF
--- a/boards.html
+++ b/boards.html
@@ -408,14 +408,21 @@
         function nextImage() {
             currentImageIndex = (currentImageIndex + 1) % images.length;
             updateImage();
+            resetImageInterval(); // reset interval
         }
 
         function prevImage() {
             currentImageIndex = (currentImageIndex - 1 + images.length) % images.length;
             updateImage();
+            resetImageInterval(); // reset interval
         }
 
         let imageInterval = setInterval(nextImage, 3000);
+
+        function resetImageInterval() {
+            clearInterval(imageInterval);
+            imageInterval = setInterval(nextImage, 3000);
+        }
 
         pcbImage.addEventListener('mouseenter', () => {
             clearInterval(imageInterval);


### PR DESCRIPTION
#### Proposed Changes ####

This PR fixes an issue in the image carousel on the WebPage branch.  
When users manually click the "Next" or "Previous" buttons, the interval timer now resets.  
This prevents images from auto-changing immediately after manual navigation and improves user experience.

#### Types of Changes ####

- [x] Bugfix

#### Verification ####

Manually tested in the browser:
- Clicked through "Next" and "Previous"
- Verified that auto-play resumes with a delay, not immediatel

#### User-Facing Change ####
```release-note
The image carousel now resets its interval after user interaction.
