### PR TITLE
refactor MainMenu to use loopOptions

### DIFF
--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -127,7 +127,9 @@ int getBattery() {
 void _setBrightness(uint8_t brightval) {
     if(brightval == 0){
       analogWrite(TFT_BL, brightval);
-    } else {
+    } else if(brightval > 99){
+      analogWrite(TFT_BL, 254);
+    }else {
       int bl = MINBRIGHT + round(((255 - MINBRIGHT) * brightval /100 ));
       analogWrite(TFT_BL, bl);
     }

--- a/include/globals.h
+++ b/include/globals.h
@@ -81,15 +81,17 @@ struct Option {
   String label;
   std::function<void()> operation;
   bool selected = false;
-  std::function<void()> hover;
-  std::function<void()> render;
+  void ( *hover )();
+  void ( *render )(void *pointer);
+  void *pointer;
 
   Option(String lbl,
          const std::function<void()>& op,
          bool sel = false,
-         const std::function<void()>& hov = nullptr,
-         const std::function<void()>& ren = nullptr)
-    : label(lbl), operation(op), selected(sel), hover(hov), render(ren) {}
+         void ( *hov )() = nullptr,
+         void ( *ren )(void *pointer) = nullptr,
+         void *ptr = nullptr)
+    : label(lbl), operation(op), selected(sel), hover(hov), render(ren), pointer(ptr) {}
 };
 
 struct keyStroke { // DO NOT CHANGE IT!!!!!

--- a/include/globals.h
+++ b/include/globals.h
@@ -81,17 +81,15 @@ struct Option {
   String label;
   std::function<void()> operation;
   bool selected = false;
-  void ( *hover )();
-  void ( *render )(void *pointer);
-  void *pointer;
+  bool ( *hover )(void *hoverPointer, bool shouldRender);
+  void *hoverPointer;
 
   Option(String lbl,
          const std::function<void()>& op,
          bool sel = false,
-         void ( *hov )() = nullptr,
-         void ( *ren )(void *pointer) = nullptr,
+         bool ( *hov )(void *hoverPointer, bool shouldRender) = nullptr, // hover lambda returns true if it already handled rendering
          void *ptr = nullptr)
-    : label(lbl), operation(op), selected(sel), hover(hov), render(ren), pointer(ptr) {}
+    : label(lbl), operation(op), selected(sel), hover(hov), hoverPointer(ptr) {}
 };
 
 struct keyStroke { // DO NOT CHANGE IT!!!!!

--- a/include/globals.h
+++ b/include/globals.h
@@ -81,9 +81,15 @@ struct Option {
   String label;
   std::function<void()> operation;
   bool selected = false;
+  std::function<void()> hover;
+  std::function<void()> render;
 
-  Option(String lbl, const std::function<void()>& op, bool sel = false)
-    : label(lbl), operation(op), selected(sel) {}
+  Option(String lbl,
+         const std::function<void()>& op,
+         bool sel = false,
+         const std::function<void()>& hov = nullptr,
+         const std::function<void()>& ren = nullptr)
+    : label(lbl), operation(op), selected(sel), hover(hov), render(ren) {}
 };
 
 struct keyStroke { // DO NOT CHANGE IT!!!!!

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -411,7 +411,7 @@ void padprintln(double n, int digits, int16_t padx) {
 **  Function: loopOptions
 **  Where you choose among the options in menu
 **********************************************************************/
-int loopOptions(std::vector<Option>& options, bool bright, bool submenu, const char *subText, int index){
+int loopOptions(std::vector<Option>& options, bool submenu, const char *subText, int index){
   Opt_Coord coord;
   bool redraw = true;
   int menuSize = options.size();
@@ -426,11 +426,7 @@ int loopOptions(std::vector<Option>& options, bool bright, bool submenu, const c
     if (redraw) {
       if(submenu) drawSubmenu(index, options, subText);
       else coord=drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor);
-      if(bright){
-        uint8_t bv = String(options[index].label).toInt();  // Grabs the int value from menu option
-        if(bv>0) setBrightness(bv,false);                           // If valid, apply brightnes
-        else setBrightness(bruceConfig.bright,false);               // if "Main Menu", bv==0, return brightness to default
-      }
+      if (options[index].hover) { options[index].hover(); }
       redraw=false;
       if(first) while(SelPress) delay(100); // to avoid miss click due to heavy fingers
     }

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -526,10 +526,16 @@ Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, 
     int menuSize = options.size();
     if(options.size()>MAX_MENU_SIZE) {
       menuSize = MAX_MENU_SIZE;
-      }
+    }
 
-    if(index==0) tft.fillRoundRect(tftWidth*0.10,tftHeight/2-menuSize*(FM*8+4)/2 -5,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bgcolor);
-    else tft.fillRoundRect(tftWidth*0.10,tftHeight/2-menuSize*(FM*8+4)/2 -5,tftWidth*0.8,10,5,bgcolor);
+    int32_t optionsTopY = tftHeight/2-menuSize*(FM*8+4)/2 -5;
+    if(index==0) tft.fillRoundRect(tftWidth*0.10,optionsTopY,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bgcolor);
+    else if(optionsTopY < 25) {
+        int32_t occupiedStatusBarHeight = 25 - optionsTopY;
+        tft.fillRoundRect(
+            tftWidth * 0.10, optionsTopY, tftWidth * 0.8, occupiedStatusBarHeight + 5, 5, bgcolor
+        );
+    }
 
     tft.setTextColor(fgcolor,bgcolor);
     tft.setTextSize(FM);

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -424,11 +424,13 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
   drawMainBorder();
   while(1){
     if (redraw) {
-      if (options[index].render) {
-        options[index].render(options[index].pointer);
-      } else if (submenu) drawSubmenu(index, options, subText);
-      else coord=drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor);
-      if (options[index].hover) options[index].hover();
+      bool renderedByLambda = false;
+      if (options[index].hover) renderedByLambda = options[index].hover(options[index].hoverPointer, true);
+
+      if (!renderedByLambda) {
+        if (submenu) drawSubmenu(index, options, subText);
+        else coord = drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor);
+      }
       redraw=false;
       if(first) while(SelPress) delay(100); // to avoid miss click due to heavy fingers
     }

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -420,7 +420,7 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
     }
   if(index>0) tft.fillRoundRect(tftWidth*0.10,tftHeight/2-menuSize*(FM*8+4)/2 -5,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bruceConfig.bgColor);
   if(index>=options.size()) index=0;
-  bool first=true;
+  bool firstRender = true;
   drawMainBorder();
   while(1){
     if (redraw) {
@@ -429,10 +429,11 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
 
       if (!renderedByLambda) {
         if (submenu) drawSubmenu(index, options, subText);
-        else coord = drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor);
+        else coord = drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor, firstRender);
       }
-      redraw=false;
-      if(first) while(SelPress) delay(100); // to avoid miss click due to heavy fingers
+      firstRender = false;
+      redraw = false;
+      while(SelPress) delay(100); // to avoid miss click due to heavy fingers
     }
 
     handleSerialCommands();
@@ -520,7 +521,7 @@ void progressHandler(int progress, size_t total, String message) {
 ** Function name: drawOptions
 ** Description:   Função para desenhar e mostrar as opçoes de contexto
 ***************************************************************************************/
-Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, uint16_t bgcolor) {
+Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, uint16_t bgcolor, bool firstRender) {
     drawStatusBar();
     Opt_Coord coord;
     int menuSize = options.size();
@@ -529,8 +530,9 @@ Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, 
     }
 
     int32_t optionsTopY = tftHeight/2-menuSize*(FM*8+4)/2 -5;
-    if(index==0) tft.fillRoundRect(tftWidth*0.10,optionsTopY,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bgcolor);
-    else if(optionsTopY < 25) {
+    if(firstRender) {
+      tft.fillRoundRect(tftWidth*0.10,optionsTopY,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bgcolor);
+    } else if(optionsTopY < 25) {
         int32_t occupiedStatusBarHeight = 25 - optionsTopY;
         tft.fillRoundRect(
             tftWidth * 0.10, optionsTopY, tftWidth * 0.8, occupiedStatusBarHeight + 5, 5, bgcolor
@@ -544,7 +546,6 @@ Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, 
     int i=0;
     int init = 0;
     int cont = 1;
-    if(index==0) tft.fillRoundRect(tftWidth*0.10,tftHeight/2-menuSize*(FM*8+4)/2 -5,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bgcolor);
     menuSize = options.size();
     if(index>=MAX_MENU_SIZE) init=index-MAX_MENU_SIZE+1;
     for(i=0;i<menuSize;i++) {
@@ -579,7 +580,7 @@ Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, 
 }
 
 /***************************************************************************************
-** Function name: drawOptions
+** Function name: drawSubmenu
 ** Description:   Função para desenhar e mostrar as opçoes de contexto
 ***************************************************************************************/
 void drawSubmenu(int index, std::vector<Option>& options, const char *title) {

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -425,8 +425,9 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
   while(1){
     handleSerialCommands();
     if (redraw) {
-      if (options[index].render) options[index].render();
-      else if(submenu) drawSubmenu(index, options, subText);
+      if (options[index].render) {
+        options[index].render(options[index].pointer);
+      } else if (submenu) drawSubmenu(index, options, subText);
       else coord=drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor);
       if (options[index].hover) options[index].hover();
       redraw=false;

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -521,6 +521,7 @@ void progressHandler(int progress, size_t total, String message) {
 ** Description:   Função para desenhar e mostrar as opçoes de contexto
 ***************************************************************************************/
 Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, uint16_t bgcolor) {
+    drawStatusBar();
     Opt_Coord coord;
     int menuSize = options.size();
     if(options.size()>MAX_MENU_SIZE) {
@@ -528,6 +529,7 @@ Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, 
       }
 
     if(index==0) tft.fillRoundRect(tftWidth*0.10,tftHeight/2-menuSize*(FM*8+4)/2 -5,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bgcolor);
+    else tft.fillRoundRect(tftWidth*0.10,tftHeight/2-menuSize*(FM*8+4)/2 -5,tftWidth*0.8,10,5,bgcolor);
 
     tft.setTextColor(fgcolor,bgcolor);
     tft.setTextSize(FM);
@@ -575,6 +577,7 @@ Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, 
 ** Description:   Função para desenhar e mostrar as opçoes de contexto
 ***************************************************************************************/
 void drawSubmenu(int index, std::vector<Option>& options, const char *title) {
+    drawStatusBar();
     int menuSize = options.size();
     tft.setTextColor(bruceConfig.priColor,bruceConfig.bgColor);
     tft.setTextSize(FP);

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -424,9 +424,10 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
   drawMainBorder();
   while(1){
     if (redraw) {
-      if(submenu) drawSubmenu(index, options, subText);
+      if (options[index].render) options[index].render();
+      else if(submenu) drawSubmenu(index, options, subText);
       else coord=drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor);
-      if (options[index].hover) { options[index].hover(); }
+      if (options[index].hover) options[index].hover();
       redraw=false;
       if(first) while(SelPress) delay(100); // to avoid miss click due to heavy fingers
     }

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -423,7 +423,6 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
   bool first=true;
   drawMainBorder();
   while(1){
-    handleSerialCommands();
     if (redraw) {
       if (options[index].render) {
         options[index].render(options[index].pointer);
@@ -433,6 +432,12 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
       redraw=false;
       if(first) while(SelPress) delay(100); // to avoid miss click due to heavy fingers
     }
+
+    handleSerialCommands();
+    #ifdef HAS_KEYBOARD
+        checkShortcutPress();  // shortctus to quickly start apps without navigating the menus
+    #endif
+
     if(!submenu) {
       String txt=options[index].label;
       displayScrollingText(txt, coord);
@@ -450,6 +455,7 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
       break;
     }
     else {
+      checkReboot();
       if(index==0) index = options.size() - 1;
       else if(index>0) index--;
       redraw = true;

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -524,22 +524,27 @@ void progressHandler(int progress, size_t total, String message) {
 ** Description:   Função para desenhar e mostrar as opçoes de contexto
 ***************************************************************************************/
 Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, uint16_t bgcolor, bool firstRender) {
-    drawStatusBar();
     Opt_Coord coord;
     int menuSize = options.size();
     if(options.size()>MAX_MENU_SIZE) {
       menuSize = MAX_MENU_SIZE;
     }
 
+    // Uncomment to update the statusBar (causes flickering)
+    //drawStatusBar();
+
     int32_t optionsTopY = tftHeight/2-menuSize*(FM*8+4)/2 -5;
+
     if(firstRender) {
       tft.fillRoundRect(tftWidth*0.10,optionsTopY,tftWidth*0.8,(FM*8+4)*menuSize+10,5,bgcolor);
-    } else if(optionsTopY < 25) {
-        int32_t occupiedStatusBarHeight = 25 - optionsTopY;
-        tft.fillRoundRect(
-            tftWidth * 0.10, optionsTopY, tftWidth * 0.8, occupiedStatusBarHeight + 5, 5, bgcolor
-        );
     }
+    // Uncomment to update the statusBar (causes flickering)
+    // else if(optionsTopY < 25) {
+    //     int32_t occupiedStatusBarHeight = 25 - optionsTopY;
+    //     tft.fillRoundRect(
+    //         tftWidth * 0.10, optionsTopY, tftWidth * 0.8, occupiedStatusBarHeight + 5, 5, bgcolor
+    //     );
+    // }
 
     tft.setTextColor(fgcolor,bgcolor);
     tft.setTextSize(FM);

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -423,6 +423,7 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
   bool first=true;
   drawMainBorder();
   while(1){
+    handleSerialCommands();
     if (redraw) {
       if (options[index].render) options[index].render();
       else if(submenu) drawSubmenu(index, options, subText);

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -3,6 +3,7 @@
 
 #include <globals.h>
 #include "sd_functions.h" // to catch FileList Struct
+#include "core/serialcmds.h"
 #include <SD.h>
 #include <FS.h>
 #include <LittleFS.h>

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -151,9 +151,9 @@ void padprintln(unsigned long long n, int base=DEC, int16_t padx=1);
 void padprintln(double n, int digits, int16_t padx=1);
 
 //loopOptions will now return the last index used in the function
-int loopOptions(std::vector<Option>& options, bool bright, bool submenu, const char *subText,int index = 0);
-inline int loopOptions(std::vector<Option>& options, int _index) { return loopOptions(options, false, false, "", _index); }
-inline int loopOptions(std::vector<Option>& options) { return loopOptions(options, false, false, "", 0); }
+int loopOptions(std::vector<Option>& options, bool submenu, const char *subText, int index = 0);
+inline int loopOptions(std::vector<Option>& options, int _index) { return loopOptions(options, false, "", _index); }
+inline int loopOptions(std::vector<Option>& options) { return loopOptions(options, false, "", 0); }
 
 Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, uint16_t bgcolor);
 

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -156,7 +156,7 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
 inline int loopOptions(std::vector<Option>& options, int _index) { return loopOptions(options, false, "", _index); }
 inline int loopOptions(std::vector<Option>& options) { return loopOptions(options, false, "", 0); }
 
-Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, uint16_t bgcolor);
+Opt_Coord drawOptions(int index,std::vector<Option>& options, uint16_t fgcolor, uint16_t bgcolor, bool firstRender = true);
 
 void drawSubmenu(int index,std::vector<Option>& options, const char *title);
 

--- a/src/core/led_control.cpp
+++ b/src/core/led_control.cpp
@@ -163,11 +163,12 @@ void setLedBrightnessConfig() {
     else if (bruceConfig.ledBright==100) idx=4;
 
     options = {
-        {"10 %", [=]() { bruceConfig.setLedBright(10);  }, bruceConfig.ledBright == 10 },
-        {"25 %", [=]() { bruceConfig.setLedBright(25);  }, bruceConfig.ledBright == 25 },
-        {"50 %", [=]() { bruceConfig.setLedBright(50);  }, bruceConfig.ledBright == 50 },
-        {"75 %", [=]() { bruceConfig.setLedBright(75);  }, bruceConfig.ledBright == 75 },
-        {"100%", [=]() { bruceConfig.setLedBright(100); }, bruceConfig.ledBright == 100 },
+        {"OFF",  [=]() { bruceConfig.setLedBright(10);  }, bruceConfig.ledBright == 10,  [](void* pointer, bool shouldRender) { setLedBrightness(0);   return false; } },
+        {"10 %", [=]() { bruceConfig.setLedBright(10);  }, bruceConfig.ledBright == 10,  [](void* pointer, bool shouldRender) { setLedBrightness(10);  return false; } },
+        {"25 %", [=]() { bruceConfig.setLedBright(25);  }, bruceConfig.ledBright == 25,  [](void* pointer, bool shouldRender) { setLedBrightness(25);  return false; } },
+        {"50 %", [=]() { bruceConfig.setLedBright(50);  }, bruceConfig.ledBright == 50,  [](void* pointer, bool shouldRender) { setLedBrightness(50);  return false; } },
+        {"75 %", [=]() { bruceConfig.setLedBright(75);  }, bruceConfig.ledBright == 75,  [](void* pointer, bool shouldRender) { setLedBrightness(75);  return false; } },
+        {"100%", [=]() { bruceConfig.setLedBright(100); }, bruceConfig.ledBright == 100, [](void* pointer, bool shouldRender) { setLedBrightness(100); return false; } },
     };
     addOptionToMainMenu();
 

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -47,17 +47,18 @@ void MainMenu::begin(void) {
                 _menuItems[i]->getName(),
                 [=]() { _menuItems[i]->optionsMenu(); },
                 false, //selected = false
-                nullptr, // hover lambda
-                [](void *menuItem) { // render lambda
-                    drawMainBorder(false);
+                [](void *menuItem, bool shouldRender) { // render lambda
+                if (!shouldRender) return false;
+                drawMainBorder(false);
 
-                    MenuItemInterface *obj = static_cast<MenuItemInterface *>(menuItem);
-                    float scale = float((float)tftWidth / (float)240);
-                    if (bruceConfig.rotation & 0b01) scale = float((float)tftHeight / (float)135);
-                    obj->draw(scale);
+                MenuItemInterface *obj = static_cast<MenuItemInterface *>(menuItem);
+                float scale = float((float)tftWidth / (float)240);
+                if (bruceConfig.rotation & 0b01) scale = float((float)tftHeight / (float)135);
+                obj->draw(scale);
                     #if defined(HAS_TOUCH)
-                    TouchFooter();
+                TouchFooter();
                     #endif
+                return true;
                 },
                 _menuItems[i]
             });

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -36,61 +36,26 @@ MainMenu::MainMenu() {
 
 MainMenu::~MainMenu() {}
 
-/***************************************************************************************
-** Function name: previous
-** Description:   Função para selecionar o menu anterior
-***************************************************************************************/
-void MainMenu::previous(){
-    _currentIndex--;
-    if (_currentIndex < 0) _currentIndex = _totalItems - 1;
-    _checkDisabledMenus(false);
-}
-
-/***************************************************************************************
-** Function name: next
-** Description:   Função para selecionar o próximo menu
-***************************************************************************************/
-void MainMenu::next(){
-    _currentIndex++;
-    if (_currentIndex >= _totalItems) _currentIndex = 0;
-    _checkDisabledMenus(true);
-}
-
-
-/**********************************************************************
-**  Function:    openMenuOptions
-**  Description: Get main menu options
-**********************************************************************/
-void MainMenu::openMenuOptions(){
-    _menuItems[_currentIndex]->optionsMenu();
-}
-
-/***************************************************************************************
-** Function name: draw
-** Description:   Função para desenhar e mostrar o menu principal
-***************************************************************************************/
-void MainMenu::draw(float scale) {
-    MenuItemInterface* current_menu = _menuItems[_currentIndex];
-
-    drawMainBorder(false);
-    current_menu->draw(scale);
-
-    #if defined(HAS_TOUCH)
-    TouchFooter();
-    #endif
-}
-
-
-void MainMenu::_checkDisabledMenus(bool next_button) {
-    MenuItemInterface* current_menu = _menuItems[_currentIndex];
+void MainMenu::begin(void) {
+    options = {};
     std::vector<String> l = bruceConfig.disabledMenus;
-
-    String currName = current_menu->getName();
-    if( find(l.begin(), l.end(), currName)!=l.end() ) {
-        // menu disabled, skip to the next/prev one and re-check
-        if(next_button)
-            next();
-        else
-            previous();
+    for(int i = 0; i < _totalItems; i++) {
+        String itemName = _menuItems[i]->getName();
+        if( find(l.begin(), l.end(), itemName)==l.end() ) { // If menu item is not disabled
+            options.push_back({ // selected lambda
+                _menuItems[i]->getName(),
+                [=]() { _menuItems[i]->optionsMenu(); },
+                false, //selected = false
+                nullptr, // hover lambda
+                [=]() { // render lambda
+                    drawMainBorder(false);
+                    _menuItems[i]->draw();
+                    #if defined(HAS_TOUCH)
+                    TouchFooter();
+                    #endif
+                }
+            });
+        }
     }
-}
+    _currentIndex = loopOptions(options, true, "Main Menu");
+};

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -38,8 +38,6 @@ MainMenu::~MainMenu() {}
 
 void MainMenu::begin(void) {
     options = {};
-    float scale = float((float)tftWidth / (float)240);
-    if (bruceConfig.rotation & 0b01) scale = float((float)tftHeight / (float)135);
 
     std::vector<String> l = bruceConfig.disabledMenus;
     for(int i = 0; i < _totalItems; i++) {
@@ -50,14 +48,18 @@ void MainMenu::begin(void) {
                 [=]() { _menuItems[i]->optionsMenu(); },
                 false, //selected = false
                 nullptr, // hover lambda
-                [=]() { // render lambda
+                [](void *menuItem) { // render lambda
                     drawMainBorder(false);
 
-                    _menuItems[i]->draw(scale);
+                    MenuItemInterface *obj = static_cast<MenuItemInterface *>(menuItem);
+                    float scale = float((float)tftWidth / (float)240);
+                    if (bruceConfig.rotation & 0b01) scale = float((float)tftHeight / (float)135);
+                    obj->draw(scale);
                     #if defined(HAS_TOUCH)
                     TouchFooter();
                     #endif
-                }
+                },
+                _menuItems[i]
             });
         }
     }

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -38,6 +38,9 @@ MainMenu::~MainMenu() {}
 
 void MainMenu::begin(void) {
     options = {};
+    float scale = float((float)tftWidth / (float)240);
+    if (bruceConfig.rotation & 0b01) scale = float((float)tftHeight / (float)135);
+
     std::vector<String> l = bruceConfig.disabledMenus;
     for(int i = 0; i < _totalItems; i++) {
         String itemName = _menuItems[i]->getName();
@@ -49,7 +52,8 @@ void MainMenu::begin(void) {
                 nullptr, // hover lambda
                 [=]() { // render lambda
                     drawMainBorder(false);
-                    _menuItems[i]->draw();
+
+                    _menuItems[i]->draw(scale);
                     #if defined(HAS_TOUCH)
                     TouchFooter();
                     #endif

--- a/src/core/main_menu.h
+++ b/src/core/main_menu.h
@@ -38,18 +38,12 @@ public:
     MainMenu();
     ~MainMenu();
 
-    void begin(void) { _currentIndex = 0; };
-    void previous(void);
-    void next(void);
-
-    void openMenuOptions(void);
-    void draw(float scale = 1);
+    void begin(void);
 
 private:
     int _currentIndex = 0;
     int _totalItems = 0;
     std::vector<MenuItemInterface*> _menuItems;
-    void _checkDisabledMenus(bool next_button);
 };
 
 #endif

--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -33,7 +33,7 @@ void BleMenu::optionsMenu() {
     options.push_back({"Spam All", lambdaHelper(aj_adv, 4)});
     addOptionToMainMenu();
 
-    loopOptions(options, false, true, "Bluetooth");
+    loopOptions(options, true, "Bluetooth");
 }
 void BleMenu::drawIconImg() {
     if (bruceConfig.theme.ble) {

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -37,7 +37,7 @@ void ConfigMenu::optionsMenu() {
     options.push_back({"About", showDeviceInfo});
     addOptionToMainMenu();
 
-    loopOptions(options,false,true,"Config");
+    loopOptions(options,true,"Config");
 }
 
 void ConfigMenu::devMenu(){
@@ -49,7 +49,7 @@ void ConfigMenu::devMenu(){
         {"Back",          [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options,false,true,"Dev Mode");
+    loopOptions(options,true,"Dev Mode");
 }
 void ConfigMenu::drawIconImg() {
     if(bruceConfig.theme.config) {

--- a/src/core/menu_items/ConnectMenu.cpp
+++ b/src/core/menu_items/ConnectMenu.cpp
@@ -16,7 +16,7 @@ void ConnectMenu::optionsMenu() {
   };
   addOptionToMainMenu();
 
-  loopOptions(options, false, true, getName().c_str());
+  loopOptions(options, true, getName().c_str());
 }
 void ConnectMenu::drawIconImg() {
     if(bruceConfig.theme.connect) {

--- a/src/core/menu_items/FMMenu.cpp
+++ b/src/core/menu_items/FMMenu.cpp
@@ -16,7 +16,7 @@ void FMMenu::optionsMenu() {
     };
     addOptionToMainMenu();
 
-    loopOptions(options, false, true, "FM");
+    loopOptions(options, true, "FM");
 }
 void FMMenu::drawIconImg() {
     if (bruceConfig.theme.fm) {

--- a/src/core/menu_items/FileMenu.cpp
+++ b/src/core/menu_items/FileMenu.cpp
@@ -15,7 +15,7 @@ void FileMenu::optionsMenu() {
 #endif
     addOptionToMainMenu();
 
-    loopOptions(options, false, true, "Files");
+    loopOptions(options, true, "Files");
 }
 void FileMenu::drawIconImg() {
     if(bruceConfig.theme.files) {

--- a/src/core/menu_items/GpsMenu.cpp
+++ b/src/core/menu_items/GpsMenu.cpp
@@ -15,7 +15,7 @@ void GpsMenu::optionsMenu() {
     addOptionToMainMenu();
 
     String txt = "GPS (" + String(bruceConfig.gpsBaudrate) + " bps)";
-    loopOptions(options,false,true,txt.c_str());
+    loopOptions(options,true,txt.c_str());
 }
 
 void GpsMenu::configMenu() {
@@ -24,7 +24,7 @@ void GpsMenu::configMenu() {
         {"Back",     [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options,false,true,"GPS Config");
+    loopOptions(options,true,"GPS Config");
 }
 void GpsMenu::drawIconImg() {
     if(bruceConfig.theme.gps) {

--- a/src/core/menu_items/IRMenu.cpp
+++ b/src/core/menu_items/IRMenu.cpp
@@ -17,7 +17,7 @@ void IRMenu::optionsMenu() {
 
     String txt = "Infrared";
     txt+=" Tx: " + String(bruceConfig.irTx) + " Rx: " + String(bruceConfig.irRx) + " Rpts: " + String(bruceConfig.irTxRepeats);
-    loopOptions(options,false,true,txt.c_str());
+    loopOptions(options,true,txt.c_str());
 }
 
 void IRMenu::configMenu() {
@@ -28,7 +28,7 @@ void IRMenu::configMenu() {
         {"Back",          [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options,false,true,"IR Config");
+    loopOptions(options,true,"IR Config");
 }
 void IRMenu::drawIconImg() {
     if(bruceConfig.theme.ir) {

--- a/src/core/menu_items/NRF24.cpp
+++ b/src/core/menu_items/NRF24.cpp
@@ -27,7 +27,7 @@ void NRF24Menu::optionsMenu() {
 
   addOptionToMainMenu();
 
-  loopOptions(options,false,true,"NRF24");
+  loopOptions(options,true,"NRF24");
 }
 
 void NRF24Menu::configMenu() {
@@ -38,7 +38,7 @@ void NRF24Menu::configMenu() {
       {"Back",                  [=]() { optionsMenu(); }},
   };
 
-  loopOptions(options,false,true,"RF Config");
+  loopOptions(options,true,"RF Config");
   if(opt==1) {
     bruceConfig.NRF24_bus = { (gpio_num_t)NRF24_SCK_PIN,  (gpio_num_t)NRF24_MISO_PIN,  (gpio_num_t)NRF24_MOSI_PIN,  (gpio_num_t)NRF24_SS_PIN, (gpio_num_t)NRF24_CE_PIN,   GPIO_NUM_NC };
     bruceConfig.setSpiPins(bruceConfig.NRF24_bus);

--- a/src/core/menu_items/OthersMenu.cpp
+++ b/src/core/menu_items/OthersMenu.cpp
@@ -35,7 +35,7 @@ void OthersMenu::optionsMenu() {
     addOptionToMainMenu();
 
 
-    loopOptions(options,false,true,"Others");
+    loopOptions(options,true,"Others");
 }
 void OthersMenu::drawIconImg() {
     if(bruceConfig.theme.others) {

--- a/src/core/menu_items/RFIDMenu.cpp
+++ b/src/core/menu_items/RFIDMenu.cpp
@@ -29,7 +29,7 @@ void RFIDMenu::optionsMenu() {
     if(bruceConfig.rfidModule==M5_RFID2_MODULE)        txt+=" (RFID2)";
     else if(bruceConfig.rfidModule==PN532_I2C_MODULE)  txt+=" (PN532-I2C)";
     else if(bruceConfig.rfidModule==PN532_SPI_MODULE)  txt+=" (PN532-SPI)";
-    loopOptions(options,false,true,txt.c_str());
+    loopOptions(options,true,txt.c_str());
 }
 
 void RFIDMenu::configMenu() {
@@ -39,7 +39,7 @@ void RFIDMenu::configMenu() {
         {"Back",          [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options,false,true,"RFID Config");
+    loopOptions(options,true,"RFID Config");
 }
 void RFIDMenu::drawIconImg() {
     if(bruceConfig.theme.rfid) {

--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -23,7 +23,7 @@ void RFMenu::optionsMenu() {
     if(bruceConfig.rfModule==CC1101_SPI_MODULE) txt+=" (CC1101)"; // Indicates if CC1101 is connected
     else txt+=" Tx: " + String(bruceConfig.rfTx) + " Rx: " + String(bruceConfig.rfRx);
 
-    loopOptions(options,false,true,txt.c_str());
+    loopOptions(options,true,txt.c_str());
 }
 
 void RFMenu::configMenu() {
@@ -35,7 +35,7 @@ void RFMenu::configMenu() {
         {"Back",          [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options,false,true,"RF Config");
+    loopOptions(options,true,"RF Config");
 }
 void RFMenu::drawIconImg() {
     if(bruceConfig.theme.rf) {

--- a/src/core/menu_items/ScriptsMenu.cpp
+++ b/src/core/menu_items/ScriptsMenu.cpp
@@ -62,7 +62,7 @@ void ScriptsMenu::optionsMenu() {
     options.push_back({"Load...", run_bjs_script});
     addOptionToMainMenu();
 
-    loopOptions(options,false,true,"Scripts");
+    loopOptions(options,true,"Scripts");
 }
 void ScriptsMenu::drawIconImg() {
     if(bruceConfig.theme.interpreter) {

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -56,7 +56,7 @@ void WifiMenu::optionsMenu() {
     options.push_back({"Config", [=]()   { configMenu(); }});
     addOptionToMainMenu();
 
-    loopOptions(options,false,true,"WiFi");
+    loopOptions(options,true,"WiFi");
 }
 
 void WifiMenu::configMenu() {
@@ -66,7 +66,7 @@ void WifiMenu::configMenu() {
         {"Back", [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options,false,true,"WiFi Config");
+    loopOptions(options,true,"WiFi Config");
 }
 void WifiMenu::drawIconImg() {
     if(bruceConfig.theme.wifi) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -111,17 +111,15 @@ void setBrightnessMenu() {
     else if (bruceConfig.bright == 1) idx = 4;
 
     options = {
-        {"100%", [=]() { setBrightness((uint8_t)99); },  bruceConfig.bright == 99, []()  { setBrightness((uint8_t)99, false);  }},
+        {"100%", [=]() { setBrightness((uint8_t)100); }, bruceConfig.bright == 100, []() { setBrightness((uint8_t)100, false); }},
         {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , []() { setBrightness((uint8_t)75, false);  }},
         {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50, []()  { setBrightness((uint8_t)50, false);  }},
         {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25, []()  { setBrightness((uint8_t)25, false);  }},
         {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1, []()   { setBrightness((uint8_t)1, false);   }}
     };
     addOptionToMainMenu(); // this one bugs the brightness selection
-    int chosen = loopOptions(options, false, "", idx);
-    if(chosen == options.size()-1) {
-        setBrightness(bruceConfig.bright,false);
-    }
+    loopOptions(options, false, "", idx);
+    setBrightness(bruceConfig.bright,false);
 }
 
 /*********************************************************************

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -111,11 +111,11 @@ void setBrightnessMenu() {
     else if (bruceConfig.bright == 1) idx = 4;
 
     options = {
-        {"100%", [=]() { setBrightness((uint8_t)99); },  bruceConfig.bright == 99, [=]()  { setBrightness((uint8_t)99, false);  }},
-        {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , [=]() { setBrightness((uint8_t)75, false);  }},
-        {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50, [=]()  { setBrightness((uint8_t)50, false);  }},
-        {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25, [=]()  { setBrightness((uint8_t)25, false);  }},
-        {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1, [=]()   { setBrightness((uint8_t)1, false);   }}
+        {"100%", [=]() { setBrightness((uint8_t)99); },  bruceConfig.bright == 99, []()  { setBrightness((uint8_t)99, false);  }},
+        {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , []() { setBrightness((uint8_t)75, false);  }},
+        {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50, []()  { setBrightness((uint8_t)50, false);  }},
+        {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25, []()  { setBrightness((uint8_t)25, false);  }},
+        {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1, []()   { setBrightness((uint8_t)1, false);   }}
     };
     addOptionToMainMenu(); // this one bugs the brightness selection
     int chosen = loopOptions(options, false, "", idx);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -111,14 +111,17 @@ void setBrightnessMenu() {
     else if (bruceConfig.bright == 1) idx = 4;
 
     options = {
-        {"100%", [=]() { setBrightness((uint8_t)100); }, bruceConfig.bright == 100},
-        {"75 %", [=]() { setBrightness((uint8_t)75); }, bruceConfig.bright == 75},
-        {"50 %", [=]() { setBrightness((uint8_t)50); }, bruceConfig.bright == 50},
-        {"25 %", [=]() { setBrightness((uint8_t)25); }, bruceConfig.bright == 25},
-        {" 1 %", [=]() { setBrightness((uint8_t)1); }, bruceConfig.bright == 1},
+        {"100%", [=]() { setBrightness((uint8_t)99); },  bruceConfig.bright == 99, [=]()  { setBrightness((uint8_t)99, false);  }},
+        {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , [=]() { setBrightness((uint8_t)75, false);  }},
+        {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50, [=]()  { setBrightness((uint8_t)50, false);  }},
+        {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25, [=]()  { setBrightness((uint8_t)25, false);  }},
+        {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1, [=]()   { setBrightness((uint8_t)1, false);   }}
     };
     addOptionToMainMenu(); // this one bugs the brightness selection
-    loopOptions(options, true, false, "", idx);
+    int chosen = loopOptions(options, false, "", idx);
+    if(chosen == options.size()-1) {
+        setBrightness(bruceConfig.bright,false);
+    }
 }
 
 /*********************************************************************
@@ -445,7 +448,7 @@ void setClock() {
             options.push_back({tmp.c_str(), [&]() { delay(1); }});
         }
 
-        hr = loopOptions(options, false, true, "Set Hour");
+        hr = loopOptions(options, true, "Set Hour");
         options.clear();
 
         for (int i = 0; i < 60; i++) {
@@ -453,7 +456,7 @@ void setClock() {
             options.push_back({tmp.c_str(), [&]() { delay(1); }});
         }
 
-        mn = loopOptions(options, false, true, "Set Minute");
+        mn = loopOptions(options, true, "Set Minute");
         options.clear();
 
         options = {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -111,11 +111,11 @@ void setBrightnessMenu() {
     else if (bruceConfig.bright == 1) idx = 4;
 
     options = {
-        {"100%", [=]() { setBrightness((uint8_t)100); }, bruceConfig.bright == 100, []() { setBrightness((uint8_t)100, false); }},
-        {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , []() { setBrightness((uint8_t)75, false);  }},
-        {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50, []()  { setBrightness((uint8_t)50, false);  }},
-        {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25, []()  { setBrightness((uint8_t)25, false);  }},
-        {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1, []()   { setBrightness((uint8_t)1, false);   }}
+        {"100%", [=]() { setBrightness((uint8_t)100); }, bruceConfig.bright == 100, [](void* pointer, bool shouldRender) { setBrightness((uint8_t)100, false); return false; }},
+        {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , [](void* pointer, bool shouldRender) { setBrightness((uint8_t)75, false); return false;  }},
+        {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50,  [](void* pointer, bool shouldRender) { setBrightness((uint8_t)50, false); return false;  }},
+        {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25,  [](void* pointer, bool shouldRender) { setBrightness((uint8_t)25, false); return false;  }},
+        {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1,   [](void* pointer, bool shouldRender) { setBrightness((uint8_t)1, false); return false;   }}
     };
     addOptionToMainMenu(); // this one bugs the brightness selection
     loopOptions(options, false, "", idx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -390,7 +390,6 @@ void setup() {
 void loop() {
   bool redraw = true;
   long clock_update=0;
-  mainMenu.begin();
 
   // Interpreter must be ran in the loop() function, otherwise it breaks
   // called by 'stack canary watchpoint triggered (loopTask)'
@@ -415,68 +414,7 @@ void loop() {
 #endif
   tft.fillScreen(bruceConfig.bgColor);
 
-
-  while(1){
-    if(interpreter_start) break;
-    if (returnToMenu) {
-      returnToMenu = false;
-      tft.fillScreen(bruceConfig.bgColor); //fix any problem with the mainMenu screen when coming back from submenus or functions
-      redraw=true;
-    }
-
-    if (redraw) {
-      if(bruceConfig.rotation & 0b01) mainMenu.draw(float((float)tftHeight/(float)135));
-      else mainMenu.draw(float((float)tftWidth/(float)240));
-      clock_update=0; // forces clock drawing
-      redraw = false;
-    }
-
-    handleSerialCommands();
-#ifdef HAS_KEYBOARD
-    checkShortcutPress();  // shortctus to quickly start apps without navigating the menus
-#endif
-
-    if (check(PrevPress)) {
-      checkReboot();
-      mainMenu.previous();
-      redraw = true;
-    }
-    /* DW Btn to next item */
-    if (check(NextPress)) {
-      mainMenu.next();
-      redraw = true;
-    }
-
-    /* Select and run function */
-    if (check(SelPress)) {
-      mainMenu.openMenuOptions();
-      drawMainBorder(true);
-      redraw=true;
-    }
-    // update battery and clock once every 30 seconds
-    // it was added to avoid delays in btns readings from Core and improves overall performance
-    if(millis()-clock_update>30000) {
-      uint8_t bat = getBattery();
-      drawBatteryStatus(bat);
-      if (clock_set) {
-#if defined(HAS_RTC)
-        _rtc.GetTime(&_time);
-        setTftDisplay(12, 12, bruceConfig.priColor, 1, bruceConfig.bgColor);
-        snprintf(timeStr, sizeof(timeStr), "%02d:%02d", _time.Hours, _time.Minutes);
-        tft.print(timeStr);
-#else
-        updateTimeStr(rtc.getTimeStruct());
-        setTftDisplay(12, 12, bruceConfig.priColor, 1, bruceConfig.bgColor);
-        tft.print(timeStr);
-#endif
-      }
-      else {
-        setTftDisplay(12, 12, bruceConfig.priColor, 1, bruceConfig.bgColor);
-        tft.print("BRUCE " + String(BRUCE_VERSION));
-      }
-      clock_update=millis();
-    }
-  }
+  mainMenu.begin();
   delay(1);
 }
 #else

--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -950,6 +950,13 @@ static duk_ret_t native_storageRmdir(duk_context *ctx) {
   return 1;
 }
 
+duk_ret_t native_drawStatusBar(duk_context *ctx) {
+  #if defined(HAS_SCREEN)
+  drawStatusBar();
+  #endif
+  return 0;
+}
+
 static duk_ret_t native_require(duk_context *ctx) {
   duk_idx_t obj_idx = duk_push_object(ctx);
 
@@ -1005,7 +1012,7 @@ static duk_ret_t native_require(duk_context *ctx) {
                               2, 0);
     bduk_put_prop_c_lightfunc(ctx, obj_idx, "createTextViewer",
                               native_dialogCreateTextViewer, 2, 0);
-
+    bduk_put_prop_c_lightfunc(ctx, obj_idx, "drawStatusBar", native_drawStatusBar, 0, 0);
   } else if (filepath == "display") {
     putPropDisplayFunctions(ctx, obj_idx, 0);
     bduk_put_prop_c_lightfunc(ctx, obj_idx, "createSprite", native_createSprite,

--- a/src/modules/bjs_interpreter/interpreter.h
+++ b/src/modules/bjs_interpreter/interpreter.h
@@ -1,8 +1,12 @@
+#ifndef __BJS_INTERPRETER_H__
+#define __BJS_INTERPRETER_H__
+
 #include "stdio.h"
 #include <SPI.h>
 #include <SD.h>
 #include <string.h>
 #include <chrono>
+#include "core/display.h"
 
 // Credits to https://github.com/justinknight93/Doolittle
 // This functionality is dedicated to @justinknight93 for providing such a nice example! Consider yourself a part of the team!
@@ -15,3 +19,4 @@ void interpreterHandler(void * pvParameters);
 bool run_bjs_script_headless(char *code);
 bool run_bjs_script_headless(FS fs, String filename);
 
+#endif

--- a/src/modules/ble/bad_ble.cpp
+++ b/src/modules/ble/bad_ble.cpp
@@ -284,7 +284,7 @@ NewScript:
         addKeyboardOption("pl-PL",       KeyboardLayout_en_US);
         addOptionToMainMenu();
         index = loopOptions(
-            options, false, true, "Keyboard Layout", index
+            options, true, "Keyboard Layout", index
         ); // It will ask for the keyboard each time, but will save the last chosen to be faster
         options.clear();
         if (returnToMenu) return;
@@ -380,7 +380,7 @@ void ble_keyboard() {
     {"pl-PL",       [=]() { chooseKb_ble(KeyboardLayout_en_US); }},
   };
   addOptionToMainMenu();
-  loopOptions(options,false,true,"Keyboard Layout");
+  loopOptions(options,true,"Keyboard Layout");
   if(returnToMenu) return;
   if (!kbChosen_ble) Kble.begin(); // starts the KeyboardLayout_en_US as default if nothing had beed chosen (cancel selection)
   Ask_for_restart=1;

--- a/src/modules/others/bad_usb.cpp
+++ b/src/modules/others/bad_usb.cpp
@@ -284,7 +284,7 @@ NewScript:
         {"Turkish (Turkey)", createKeyboardSetter(KeyboardLayout_tr_TR)},
         {"Polish (Poland)",  createKeyboardSetter(KeyboardLayout_en_US)},
       };
-      loopOptions(options,false,true,"Keyboard Layout");
+      loopOptions(options,true,"Keyboard Layout");
 
       #if defined(USB_as_HID)
       if (!kbChosen) Kb.begin(); // starts the KeyboardLayout_en_US as default if nothing had beed chosen (cancel selection)
@@ -388,7 +388,7 @@ void usb_keyboard() {
   };
   addOptionToMainMenu();
 
-  loopOptions(options,false,true,"Keyboard Layout");
+  loopOptions(options,true,"Keyboard Layout");
   if(returnToMenu) return;
   USB.begin();
 

--- a/src/modules/rf/emit.cpp
+++ b/src/modules/rf/emit.cpp
@@ -15,12 +15,6 @@ TaskHandle_t rf_raw_emit_draw_handle = NULL;
 
 // FreeRTOS task to handle periodic updates
 void rf_raw_emit_draw(void *parameter) {
-    
-    gpio_num_t txPin = gpio_num_t(bruceConfig.rfTx);
-    #ifdef USE_CC1101_VIA_SPI
-        if (bruceConfig.rfModule == CC1101_SPI_MODULE) txPin = gpio_num_t(bruceConfig.CC1101_bus.io0);
-    #endif
-
     tft.fillScreen(bruceConfig.bgColor);
     drawMainBorder();
     tft.setCursor(20, 38);
@@ -35,7 +29,7 @@ void rf_raw_emit_draw(void *parameter) {
 
     while (1) {
         previousMillis = millis(); // Prevent screen power-saving
-        
+
         rssiCount++;
         if(rssiCount >= 200) selPressed = true; // Stop the emission after 20 seconds
 

--- a/src/modules/rfid/chameleon.cpp
+++ b/src/modules/rfid/chameleon.cpp
@@ -337,7 +337,7 @@ uint8_t Chameleon::selectSlot() {
         {"7", [&]() { slot=7; }},
         {"8", [&]() { slot=8; }},
     };
-    loopOptions(options,false,true,"Set Emulation Slot");
+    loopOptions(options,true,"Set Emulation Slot");
 
     return slot;
 }
@@ -379,7 +379,7 @@ void Chameleon::factoryReset() {
         {"No",  [&]() { proceed=false; }},
         {"Yes", [&]() { proceed=true; }},
     };
-    loopOptions(options,false,true,"Proceed with Factory Reset?");
+    loopOptions(options,true,"Proceed with Factory Reset?");
 
     displayBanner();
 


### PR DESCRIPTION
### This PR consists of:

- Adding the "hover" and "render" optional lambdas to Option instances
- Using "hover" lambdas to control brightness selection behavior, and removing this logic from loopOptions
- Refactoring MainMenu to use loopOptions, and "render" lambdas to handle the custom rendering of the options
- Add duktape method to natively draw the statusbar from JS scripts.
- Changing the maximum screen brightness to 99 instead of 100, because setting it to 100 sets it to a random brightness on the T-embed's display. Perhaps there is a better way?
