### PR TITLE
Make mainMenu handle escPress the same way it did before the refactor

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -425,7 +425,7 @@ void padprintln(double n, int digits, int16_t padx) {
 **  Function: loopOptions
 **  Where you choose among the options in menu
 **********************************************************************/
-int loopOptions(std::vector<Option> &options, bool submenu, const char *subText, int index) {
+int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subText, int index) {
     Opt_Coord coord;
     bool redraw = true;
     int menuSize = options.size();
@@ -449,7 +449,7 @@ int loopOptions(std::vector<Option> &options, bool submenu, const char *subText,
                 renderedByLambda = options[index].hover(options[index].hoverPointer, true);
 
             if (!renderedByLambda) {
-                if (submenu) drawSubmenu(index, options, subText);
+                if (menuType == MENU_TYPE_SUBMENU) drawSubmenu(index, options, subText);
                 else
                     coord =
                         drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor, firstRender);
@@ -464,12 +464,13 @@ int loopOptions(std::vector<Option> &options, bool submenu, const char *subText,
         checkShortcutPress(); // shortctus to quickly start apps without navigating the menus
 #endif
 
-        if (!submenu) {
+        if (menuType == MENU_TYPE_REGULAR) {
             String txt = options[index].label;
             displayScrollingText(txt, coord);
         }
 
         if (check(PrevPress) || check(UpPress)) {
+            if (menuType == MENU_TYPE_MAIN) checkReboot();
 #ifdef HAS_KEYBOARD
             if (index == 0) index = options.size() - 1;
             else if (index > 0) index--;
@@ -492,7 +493,6 @@ int loopOptions(std::vector<Option> &options, bool submenu, const char *subText,
             if (millis() - _tmp > 700) { // longpress detected to exit
                 break;
             } else {
-                checkReboot();
                 if (index == 0) index = options.size() - 1;
                 else if (index > 0) index--;
                 redraw = true;
@@ -529,7 +529,7 @@ int loopOptions(std::vector<Option> &options, bool submenu, const char *subText,
             redraw = true;
         }
 #elif defined(T_EMBED) || defined(HAS_TOUCH)
-        if (check(EscPress)) break;
+        if (menuType != MENU_TYPE_MAIN && check(EscPress)) break;
 #endif
     }
     while (SelPress) delay(100); // to avoid miss click due to heavy fingers

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -9,6 +9,9 @@
 #include <globals.h>
 #define BORDER_PAD_X 10
 #define BORDER_PAD_Y 28
+#define MENU_TYPE_MAIN 0
+#define MENU_TYPE_SUBMENU 1
+#define MENU_TYPE_REGULAR 2
 
 struct Opt_Coord {
     uint16_t x = 0;
@@ -143,11 +146,13 @@ void padprintln(unsigned long long n, int base = DEC, int16_t padx = 1);
 void padprintln(double n, int digits, int16_t padx = 1);
 
 // loopOptions will now return the last index used in the function
-int loopOptions(std::vector<Option> &options, bool submenu, const char *subText, int index = 0);
+int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subText, int index = 0);
 inline int loopOptions(std::vector<Option> &options, int _index) {
-    return loopOptions(options, false, "", _index);
+    return loopOptions(options, MENU_TYPE_REGULAR, "", _index);
 }
-inline int loopOptions(std::vector<Option> &options) { return loopOptions(options, false, "", 0); }
+inline int loopOptions(std::vector<Option> &options) {
+    return loopOptions(options, MENU_TYPE_REGULAR, "", 0);
+}
 
 Opt_Coord drawOptions(
     int index, std::vector<Option> &options, uint16_t fgcolor, uint16_t bgcolor, bool firstRender = true

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -65,5 +65,5 @@ void MainMenu::begin(void) {
             });
         }
     }
-    _currentIndex = loopOptions(options, true, "Main Menu", _currentIndex);
+    _currentIndex = loopOptions(options, MENU_TYPE_MAIN, "Main Menu", _currentIndex);
 };

--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -34,7 +34,7 @@ void BleMenu::optionsMenu() {
     options.push_back({"Spam Custom", lambdaHelper(aj_adv, 5)});
     addOptionToMainMenu();
 
-    loopOptions(options, true, "Bluetooth");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Bluetooth");
 }
 void BleMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -45,7 +45,7 @@ void ConfigMenu::optionsMenu() {
     options.push_back({"About", showDeviceInfo});
     addOptionToMainMenu();
 
-    loopOptions(options, true, "Config");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Config");
 }
 
 void ConfigMenu::devMenu() {
@@ -57,7 +57,7 @@ void ConfigMenu::devMenu() {
         {"Back",        [=]() { optionsMenu(); }                         },
     };
 
-    loopOptions(options, true, "Dev Mode");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Dev Mode");
 }
 void ConfigMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/ConnectMenu.cpp
+++ b/src/core/menu_items/ConnectMenu.cpp
@@ -16,7 +16,7 @@ void ConnectMenu::optionsMenu() {
     };
     addOptionToMainMenu();
 
-    loopOptions(options, true, getName().c_str());
+    loopOptions(options, MENU_TYPE_SUBMENU, getName().c_str());
 }
 void ConnectMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/FMMenu.cpp
+++ b/src/core/menu_items/FMMenu.cpp
@@ -16,7 +16,7 @@ void FMMenu::optionsMenu() {
     };
     addOptionToMainMenu();
 
-    loopOptions(options, true, "FM");
+    loopOptions(options, MENU_TYPE_SUBMENU, "FM");
 }
 void FMMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/FileMenu.cpp
+++ b/src/core/menu_items/FileMenu.cpp
@@ -15,7 +15,7 @@ void FileMenu::optionsMenu() {
 #endif
     addOptionToMainMenu();
 
-    loopOptions(options, true, "Files");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Files");
 }
 void FileMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/GpsMenu.cpp
+++ b/src/core/menu_items/GpsMenu.cpp
@@ -15,7 +15,7 @@ void GpsMenu::optionsMenu() {
     addOptionToMainMenu();
 
     String txt = "GPS (" + String(bruceConfig.gpsBaudrate) + " bps)";
-    loopOptions(options, true, txt.c_str());
+    loopOptions(options, MENU_TYPE_SUBMENU, txt.c_str());
 }
 
 void GpsMenu::configMenu() {
@@ -24,7 +24,7 @@ void GpsMenu::configMenu() {
         {"Back",     [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options, true, "GPS Config");
+    loopOptions(options, MENU_TYPE_SUBMENU, "GPS Config");
 }
 void GpsMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/IRMenu.cpp
+++ b/src/core/menu_items/IRMenu.cpp
@@ -18,7 +18,7 @@ void IRMenu::optionsMenu() {
     String txt = "Infrared";
     txt += " Tx: " + String(bruceConfig.irTx) + " Rx: " + String(bruceConfig.irRx) +
            " Rpts: " + String(bruceConfig.irTxRepeats);
-    loopOptions(options, true, txt.c_str());
+    loopOptions(options, MENU_TYPE_SUBMENU, txt.c_str());
 }
 
 void IRMenu::configMenu() {
@@ -29,7 +29,7 @@ void IRMenu::configMenu() {
         {"Back", [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options, true, "IR Config");
+    loopOptions(options, MENU_TYPE_SUBMENU, "IR Config");
 }
 void IRMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/NRF24.cpp
+++ b/src/core/menu_items/NRF24.cpp
@@ -28,7 +28,7 @@ void NRF24Menu::optionsMenu() {
 
     addOptionToMainMenu();
 
-    loopOptions(options, true, "NRF24");
+    loopOptions(options, MENU_TYPE_SUBMENU, "NRF24");
 }
 
 void NRF24Menu::configMenu() {
@@ -39,7 +39,7 @@ void NRF24Menu::configMenu() {
         {"Back",               [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options, true, "RF Config");
+    loopOptions(options, MENU_TYPE_SUBMENU, "RF Config");
     if (opt == 1) {
         bruceConfig.NRF24_bus = {
             (gpio_num_t)NRF24_SCK_PIN,

--- a/src/core/menu_items/OthersMenu.cpp
+++ b/src/core/menu_items/OthersMenu.cpp
@@ -34,7 +34,7 @@ void OthersMenu::optionsMenu() {
     };
     addOptionToMainMenu();
 
-    loopOptions(options, true, "Others");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Others");
 }
 void OthersMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/RFIDMenu.cpp
+++ b/src/core/menu_items/RFIDMenu.cpp
@@ -29,7 +29,7 @@ void RFIDMenu::optionsMenu() {
     if (bruceConfig.rfidModule == M5_RFID2_MODULE) txt += " (RFID2)";
     else if (bruceConfig.rfidModule == PN532_I2C_MODULE) txt += " (PN532-I2C)";
     else if (bruceConfig.rfidModule == PN532_SPI_MODULE) txt += " (PN532-SPI)";
-    loopOptions(options, true, txt.c_str());
+    loopOptions(options, MENU_TYPE_SUBMENU, txt.c_str());
 }
 
 void RFIDMenu::configMenu() {
@@ -39,7 +39,7 @@ void RFIDMenu::configMenu() {
         {"Back",        [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options, true, "RFID Config");
+    loopOptions(options, MENU_TYPE_SUBMENU, "RFID Config");
 }
 void RFIDMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -23,7 +23,7 @@ void RFMenu::optionsMenu() {
     if (bruceConfig.rfModule == CC1101_SPI_MODULE) txt += " (CC1101)"; // Indicates if CC1101 is connected
     else txt += " Tx: " + String(bruceConfig.rfTx) + " Rx: " + String(bruceConfig.rfRx);
 
-    loopOptions(options, true, txt.c_str());
+    loopOptions(options, MENU_TYPE_SUBMENU, txt.c_str());
 }
 
 void RFMenu::configMenu() {
@@ -35,7 +35,7 @@ void RFMenu::configMenu() {
         {"Back", [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options, true, "RF Config");
+    loopOptions(options, MENU_TYPE_SUBMENU, "RF Config");
 }
 void RFMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/ScriptsMenu.cpp
+++ b/src/core/menu_items/ScriptsMenu.cpp
@@ -57,7 +57,7 @@ void ScriptsMenu::optionsMenu() {
     options.push_back({"Load...", run_bjs_script});
     addOptionToMainMenu();
 
-    loopOptions(options, true, "Scripts");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Scripts");
 }
 void ScriptsMenu::drawIconImg() {
     drawImg(

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -34,7 +34,8 @@ void WifiMenu::optionsMenu() {
     if (!wifiConnected) {
         options = {
             {"Connect Wifi", lambdaHelper(wifiConnectMenu, WIFI_STA)},
-            {"WiFi AP", [=]() {
+            {"WiFi AP",
+             [=]() {
                  wifiConnectMenu(WIFI_AP);
                  displayInfo("pwd: " + bruceConfig.wifiAp.pwd, true);
              }},
@@ -68,7 +69,7 @@ void WifiMenu::optionsMenu() {
     options.push_back({"Config", [=]() { configMenu(); }});
     addOptionToMainMenu();
 
-    loopOptions(options, true, "WiFi");
+    loopOptions(options, MENU_TYPE_SUBMENU, "WiFi");
 }
 
 void WifiMenu::configMenu() {
@@ -78,7 +79,7 @@ void WifiMenu::configMenu() {
         {"Back",             [=]() { optionsMenu(); }},
     };
 
-    loopOptions(options, true, "WiFi Config");
+    loopOptions(options, MENU_TYPE_SUBMENU, "WiFi Config");
 }
 void WifiMenu::drawIconImg() {
     drawImg(

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1,5 +1,5 @@
 #include "settings.h"
-#include "display.h" // calling loopOptions(options, true);
+#include "display.h"
 #include "modules/others/qrcode_menu.h"
 #include "modules/rf/rf.h" // for initRfModule
 #include "mykeyboard.h"
@@ -148,7 +148,7 @@ void setBrightnessMenu() {
          }}
     };
     addOptionToMainMenu(); // this one bugs the brightness selection
-    loopOptions(options, false, "", idx);
+    loopOptions(options, MENU_TYPE_REGULAR, "", idx);
     setBrightness(bruceConfig.bright, false);
 }
 
@@ -362,8 +362,7 @@ void setRFModuleMenu() {
         if (pins_setup == 1)
             qrcode_display("https://github.com/pr3y/Bruce/blob/main/media/connections/cc1101_stick.jpg");
         if (pins_setup == 2)
-            qrcode_display(
-                "https://github.com/pr3y/Bruce/blob/main/media/connections/cc1101_stick_SDCard.jpg"
+            qrcode_display("https://github.com/pr3y/Bruce/blob/main/media/connections/cc1101_stick_SDCard.jpg"
             );
         while (!check(AnyKeyPress));
     }
@@ -504,7 +503,7 @@ void setClock() {
             options.push_back({tmp.c_str(), [&]() { delay(1); }});
         }
 
-        hr = loopOptions(options, true, "Set Hour");
+        hr = loopOptions(options, MENU_TYPE_SUBMENU, "Set Hour");
         options.clear();
 
         for (int i = 0; i < 60; i++) {
@@ -512,7 +511,7 @@ void setClock() {
             options.push_back({tmp.c_str(), [&]() { delay(1); }});
         }
 
-        mn = loopOptions(options, true, "Set Minute");
+        mn = loopOptions(options, MENU_TYPE_SUBMENU, "Set Minute");
         options.clear();
 
         options = {
@@ -632,11 +631,12 @@ void setIrTxRepeats() {
         {"None",             [&]() { chRpts = 0; } },
         {"5  (+ 1 initial)", [&]() { chRpts = 5; } },
         {"10 (+ 1 initial)", [&]() { chRpts = 10; }},
-        {"Custom",           [&]() {
+        {"Custom",
+         [&]() {
              // up to 99 repeats
              String rpt = keyboard(String(bruceConfig.irTxRepeats), 2, "Nbr of Repeats (+ 1 initial)");
              chRpts = static_cast<uint8_t>(rpt.toInt());
-         }                       },
+         }                                         },
     };
     addOptionToMainMenu();
 
@@ -767,9 +767,8 @@ void setStartupApp() {
         if (bruceConfig.startupApp == appName) idx = index++;
 
         options.push_back(
-            {appName.c_str(),
-             [=]() { bruceConfig.setStartupApp(appName); },
-             bruceConfig.startupApp == appName}
+            {appName.c_str(), [=]() { bruceConfig.setStartupApp(appName); }, bruceConfig.startupApp == appName
+            }
         );
     }
 

--- a/src/modules/badusb_ble/bad_ble.cpp
+++ b/src/modules/badusb_ble/bad_ble.cpp
@@ -814,7 +814,7 @@ void ble_keyboard() {
         {"pl-PL",       [=]() { chooseKb_ble(KeyboardLayout_en_US); }},
     };
     addOptionToMainMenu();
-    loopOptions(options, true, "Keyboard Layout");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Keyboard Layout");
     if (returnToMenu) return;
     if (!kbChosen_ble)
         Kble.begin(

--- a/src/modules/badusb_ble/bad_usb.cpp
+++ b/src/modules/badusb_ble/bad_usb.cpp
@@ -702,7 +702,7 @@ NewScript:
                 {"Turkish (Turkey)",      createKeyboardSetter(KeyboardLayout_tr_TR)},
                 {"Polish (Poland)",       createKeyboardSetter(KeyboardLayout_en_US)},
             };
-            loopOptions(options, true, "Keyboard Layout");
+            loopOptions(options, MENU_TYPE_SUBMENU, "Keyboard Layout");
 
 #if defined(USB_as_HID)
             if (!kbChosen)
@@ -806,7 +806,7 @@ void usb_keyboard() {
     };
     addOptionToMainMenu();
 
-    loopOptions(options, true, "Keyboard Layout");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Keyboard Layout");
     if (returnToMenu) return;
     USB.begin();
 

--- a/src/modules/others/clicker.cpp
+++ b/src/modules/others/clicker.cpp
@@ -26,7 +26,7 @@ void clicker_setup() {
       {"BLE", [=]() { bleClickerSetup();}},
     };
     delay(200);
-    loopOptions(options, true);
+    loopOptions(options, MENU_TYPE_SUBMENU, "");
     delay(200);
     */
 }

--- a/src/modules/rfid/chameleon.cpp
+++ b/src/modules/rfid/chameleon.cpp
@@ -246,7 +246,7 @@ uint8_t Chameleon::selectSlot() {
         {"7", [&]() { slot = 7; }},
         {"8", [&]() { slot = 8; }},
     };
-    loopOptions(options, true, "Set Emulation Slot");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Set Emulation Slot");
 
     return slot;
 }
@@ -278,7 +278,7 @@ void Chameleon::factoryReset() {
         {"No",  [&]() { proceed = false; }},
         {"Yes", [&]() { proceed = true; } },
     };
-    loopOptions(options, true, "Proceed with Factory Reset?");
+    loopOptions(options, MENU_TYPE_SUBMENU, "Proceed with Factory Reset?");
 
     displayBanner();
 


### PR DESCRIPTION
## Smal PR:

When I refactored the main menu to use loopOptions, it inherited some stuff from it (namely, quitting on escPress on the TEmbed), and loopOptions inherited some stuff from the mainMenu (running checkReboot on PrevPress). 
To avoid any issues, I have expanded the `bool submenu` parameter, and turned it into `uint8_t menuType` .
I have used defines, to unify the integer values of the three kind of submenus (and possibly more in the future):
```
#define MENU_TYPE_MAIN 0
#define MENU_TYPE_SUBMENU 1
#define MENU_TYPE_REGULAR 2
```
This way, loopOptions can now know which kind of menu it is displaying, instead of just having the choice between submenu and regular menu.

