### PR TITLE
IR Read: Fix save issue in Custom Read

### DIFF
--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -116,7 +116,7 @@ void IrRead::loop() {
             break;
         }
         if (check(NextPress)) save_signal();
-        if (button_pos == (sizeof(quickButtons) / sizeof(quickButtons[0]))) { save_device(); }
+        if (quickloop && button_pos == quickButtons.size()) save_device();
         if (check(SelPress)) save_device();
         if (check(PrevPress)) discard_signal();
 
@@ -183,8 +183,7 @@ void IrRead::read_signal() {
     String raw_signal = parse_raw_signal();
     tft.println(
         raw_signal.substring(0, 45) + (raw_signal.length() > 45 ? "..." : "")
-    );                          // Shows the RAW signal on the display
-    Serial.println(raw_signal); // Print RAW signal to serial monitor
+    ); // Shows the RAW signal on the display
 
     display_btn_options();
     delay(500);


### PR DESCRIPTION
Since https://github.com/pr3y/Bruce/commit/88f1dfc8c33f723f44f8b4cfb931ba4048a7dccf, the size was incorrectly calculated, I’ve fixed it here (this fixes #1029).
I also added a `quickloop` mode check to prevent saving the device after x signals when using the Custom Read mode.

Fix #1029 