### PR TITLE
Update bad_ble.cpp

### DIFF
--- a/src/modules/badusb_ble/bad_ble.cpp
+++ b/src/modules/badusb_ble/bad_ble.cpp
@@ -780,6 +780,14 @@ void ble_MediaCommands() {
                  Kble.press(KEY_MEDIA_MUTE);
                  Kble.releaseAll();
              }},
+
+            {"Hold volume +",
+             [=]() {
+                 Kble.press(KEY_MEDIA_VOLUME_UP);
+                 delay(1000);
+                 Kble.releaseAll();
+             }},
+            
             //{"", [=](){ Kble.press(); Kble.releaseAll(); }},
         };
         addOptionToMainMenu();


### PR DESCRIPTION
Added option to hold Volume +

#### Proposed Changes ####

I added an option in the BLE media commands sub menu topress the Volume+ button for 1 second.

#### Types of Changes ####

Feature

#### Verification ####

BadUSBBle Module, bad_ble.cpp, MediaCMDs submenu (starting at line 724)

#### Testing ####

Tested on local m5StickCplus2

#### Linked Issues ####

None

#### User-Facing Change ####
<!--
None
```release-note
Please test on other boards
```

#### Further Comments ####

