### PR TITLE
Change dialog module to gui in JS, Fix dino_game for t-embed

### DIFF
--- a/sd_files/interpreter/dino_game.js
+++ b/sd_files/interpreter/dino_game.js
@@ -302,9 +302,13 @@ function main() {
   var baseColorValue = 0;
   var baseColorInverted = Math.abs(baseColorValue - 255);
 
+  var displayWidth = display.width();
+  var displayHeight = display.height();
+
   var clouds = [
-    { x: random(240, 300), y: random(0, 50) },
-    { x: random(350, 400), y: random(0, 50) },
+    { x: random(displayWidth, displayWidth + 100), y: random(0, 50) },
+    { x: random(displayWidth + 200, displayWidth + 300), y: random(0, 50) },
+    { x: random(displayWidth + 400, displayWidth + 500), y: random(0, 50) }
   ];
   var foreground = black;
   var background = white;
@@ -327,7 +331,7 @@ function main() {
       audio.tone(494, 40, true);
     }
 
-    var nextPressed = keyboard.getNextPress(true);
+    var nextPressed = keyboard.getNextPress(true) || keyboard.getEscPress(true);
     if (nextPressed && !dinoIsJumping) {
       dinoIsDucking = true;
     }
@@ -374,7 +378,7 @@ function main() {
     obstacleX -= groundSpeed;
     // Reset obstacle
     if (obstacleX < -obstacle.width) {
-      obstacleX = 240 + random(0, 100); // Random respawn
+      obstacleX = displayWidth + random(0, 100); // Random respawn
       obstacle = obstacles[random(0, 3)];
       obstacleY = obstacle.spawnsY[random(0, obstacle.spawnsY.length)];
     }
@@ -383,7 +387,7 @@ function main() {
     for (var i = 0; i < 2; i++) {
       clouds[i].x -= groundSpeed - 2;
       if (clouds[i].x < -46) {
-        clouds[i].x = 240 + random(0, 100); // Random respawn
+        clouds[i].x = displayWidth + 50;
         clouds[i].y = random(0, 50);
       }
     }
@@ -430,6 +434,9 @@ function main() {
       sprite.drawXBitmap(clouds[i].x, clouds[i].y, cloudSprite, 46, 13, grey);
     }
     sprite.drawXBitmap(groundX, 118, groundSprite, 623, 12, foreground);
+    if ((displayWidth > 240) && ((623 + groundX) < displayWidth)) {
+      sprite.drawXBitmap(623 + groundX, 118, groundSprite, 623, 12, foreground);
+    }
     sprite.drawXBitmap(
       obstacleX,
       obstacleY,
@@ -490,7 +497,7 @@ function main() {
         delay(10);
       }
 
-      obstacleX = 300;
+      obstacleX = displayWidth + 50;
       delay(500);
       startTime = now();
     }

--- a/src/modules/bjs_interpreter/gui_js.cpp
+++ b/src/modules/bjs_interpreter/gui_js.cpp
@@ -1,4 +1,4 @@
-#include "dialog_js.h"
+#include "gui_js.h"
 #include "core/scrollableTextArea.h"
 
 #include "helpers_js.h"
@@ -315,4 +315,11 @@ duk_ret_t native_dialogCreateTextViewer(duk_context *ctx) {
     duk_set_finalizer(ctx, obj_idx);
 
     return 1;
+}
+
+duk_ret_t native_drawStatusBar(duk_context *ctx) {
+#if defined(HAS_SCREEN)
+    drawStatusBar();
+#endif
+    return 0;
 }

--- a/src/modules/bjs_interpreter/gui_js.h
+++ b/src/modules/bjs_interpreter/gui_js.h
@@ -1,5 +1,5 @@
-#ifndef __DIALOG_JS_H__
-#define __DIALOG_JS_H__
+#ifndef __GUI_JS_H__
+#define __GUI_JS_H__
 #include <duktape.h>
 
 duk_ret_t native_dialogMessage(duk_context *ctx);
@@ -9,5 +9,6 @@ duk_ret_t native_dialogChoice(duk_context *ctx);
 duk_ret_t native_dialogViewFile(duk_context *ctx);
 duk_ret_t native_dialogViewText(duk_context *ctx);
 duk_ret_t native_dialogCreateTextViewer(duk_context *ctx);
+duk_ret_t native_drawStatusBar(duk_context *ctx);
 
 #endif

--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -8,8 +8,8 @@
 
 #include <duktape.h>
 
-#include "dialog_js.h"
 #include "display_js.h"
+#include "gui_js.h"
 #include "helpers_js.h"
 #include "wifi_js.h"
 
@@ -912,13 +912,6 @@ static duk_ret_t native_storageRmdir(duk_context *ctx) {
     return 1;
 }
 
-duk_ret_t native_drawStatusBar(duk_context *ctx) {
-#if defined(HAS_SCREEN)
-    drawStatusBar();
-#endif
-    return 0;
-}
-
 static duk_ret_t native_require(duk_context *ctx) {
     duk_idx_t obj_idx = duk_push_object(ctx);
 
@@ -944,7 +937,7 @@ static duk_ret_t native_require(duk_context *ctx) {
 
     } else if (filepath == "blebeacon") {
 
-    } else if (filepath == "dialog") {
+    } else if (filepath == "dialog" || filepath == "gui") {
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "message", native_dialogMessage, 2, 0);
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "info", native_dialogNotification, 2, 0);
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "success", native_dialogNotification, 2, 1);


### PR DESCRIPTION
#### Proposed Changes ####

- Change dialog module to gui in JS (you can use `require('gui')` and `require('dialog')` for backwards compatibility)
- Fix dino_game for t-embed

#### Types of Changes ####

Bugfix

#### Verification ####

You can test dino_game.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Fix dino_game for t-embed
```

#### Further Comments ####

