### PR TITLE
Add FeliCa support

### DIFF
--- a/src/modules/rfid/PN532.h
+++ b/src/modules/rfid/PN532.h
@@ -40,10 +40,10 @@ public:
     /////////////////////////////////////////////////////////////////////////////////////
     // Operations
     /////////////////////////////////////////////////////////////////////////////////////
-    int read();
+    int read(int cardBaudRate = PN532_MIFARE_ISO14443A);
     int clone();
     int erase();
-    int write();
+    int write(int cardBaudRate = PN532_MIFARE_ISO14443A);
     int write_ndef();
     int load();
     int save(String filename);
@@ -55,6 +55,7 @@ private:
     // Converters
     /////////////////////////////////////////////////////////////////////////////////////
     void format_data();
+    void format_data_felica(uint8_t idm[8], uint8_t pmm[8], uint16_t sys_code);
     void parse_data();
     void set_uid();
 
@@ -72,6 +73,11 @@ private:
     bool write_mifare_classic_data_block(int block, String data);
     bool write_mifare_ultralight_data_block(int block, String data);
 
+    int read_felica_data();
+
     int erase_data_blocks();
     int write_ndef_blocks();
+
+    int write_felica_data_block(int block, String data);
+    String hextostr(uint8_t *data, uint8_t len, char separator = ' ');
 };

--- a/src/modules/rfid/RFID2.cpp
+++ b/src/modules/rfid/RFID2.cpp
@@ -40,7 +40,7 @@ bool RFID2::PICC_IsNewCardPresent() {
     return bl_result;
 }
 
-int RFID2::read() {
+int RFID2::read(int cardBaudRate) {
     pageReadStatus = FAILURE;
 
     if (!PICC_IsNewCardPresent() || !mfrc522.PICC_ReadCardSerial()) return TAG_NOT_PRESENT;
@@ -72,7 +72,7 @@ int RFID2::erase() {
     return result;
 }
 
-int RFID2::write() {
+int RFID2::write(int cardBaudRate) {
     if (!mfrc522.PICC_IsNewCardPresent() || !mfrc522.PICC_ReadCardSerial()) { return TAG_NOT_PRESENT; }
 
     if (mfrc522.uid.sak != uid.sak) return TAG_NOT_MATCH;

--- a/src/modules/rfid/RFID2.h
+++ b/src/modules/rfid/RFID2.h
@@ -26,10 +26,10 @@ public:
     /////////////////////////////////////////////////////////////////////////////////////
     // Operations
     /////////////////////////////////////////////////////////////////////////////////////
-    int read();
+    int read(int cardBaudRate = 0);
     int clone();
     int erase();
-    int write();
+    int write(int cardBaudRate = 0);
     int write_ndef();
     int load();
     int save(String filename);

--- a/src/modules/rfid/RFIDInterface.h
+++ b/src/modules/rfid/RFIDInterface.h
@@ -87,10 +87,10 @@ public:
     /////////////////////////////////////////////////////////////////////////////////////
     // Operations
     /////////////////////////////////////////////////////////////////////////////////////
-    virtual int read() = 0;
+    virtual int read(int cardBaudRate = 0) = 0; // cardBaudRate = 0 means MIFARE, 1 means FeliCa
     virtual int clone() = 0;
     virtual int erase() = 0;
-    virtual int write() = 0;
+    virtual int write(int cardBaudRate = 0) = 0;
     virtual int write_ndef() = 0;
     virtual int load() = 0;
     virtual int save(String filename) = 0;

--- a/src/modules/rfid/tag_o_matic.cpp
+++ b/src/modules/rfid/tag_o_matic.cpp
@@ -157,9 +157,15 @@ void TagOMatic::display_banner() {
 
 void TagOMatic::dump_card_details() {
     padprintln("Device type: " + _rfid->printableUID.picc_type);
-    padprintln("UID: " + _rfid->printableUID.uid);
-    padprintln("ATQA: " + _rfid->printableUID.atqa);
-    padprintln("SAK: " + _rfid->printableUID.sak);
+    if (_rfid->printableUID.picc_type != "FeliCa") {
+        padprintln("UID: " + _rfid->printableUID.uid);
+        padprintln("ATQA: " + _rfid->printableUID.atqa);
+        padprintln("SAK: " + _rfid->printableUID.sak);
+    } else {
+        padprintln("IDm: " + _rfid->printableUID.uid);
+        padprintln("PMm: " + _rfid->printableUID.sak);
+        padprintln("Sys code: " + _rfid->printableUID.atqa);
+    }
     if (_rfid->pageReadStatus != RFIDInterface::SUCCESS)
         padprintln("[!] " + _rfid->statusMessage(_rfid->pageReadStatus));
 }
@@ -187,7 +193,13 @@ void TagOMatic::dump_scan_results() {
 void TagOMatic::read_card() {
     if (millis() - _lastReadTime < 2000) return;
 
-    if (_rfid->read() != RFIDInterface::SUCCESS) return;
+    if (_rfid->read() != RFIDInterface::SUCCESS) {
+        if (bruceConfig.rfidModule != M5_RFID2_MODULE) { // Read felica if module is PN532
+            if (_rfid->read(1) != RFIDInterface::SUCCESS) return;
+        } else {
+            return;
+        }
+    }
 
     Serial.print("Tag read status: ");
     Serial.println(_rfid->statusMessage(_rfid->pageReadStatus));
@@ -271,7 +283,12 @@ void TagOMatic::erase_card() {
 }
 
 void TagOMatic::write_data() {
-    int result = _rfid->write();
+    int result = -1;
+    if (_rfid->printableUID.picc_type != "FeliCa") {
+        result = _rfid->write();
+    } else {
+        result = _rfid->write(1);
+    }
 
     switch (result) {
         case RFIDInterface::TAG_NOT_PRESENT: return; break;


### PR DESCRIPTION
This PR adds FeliCa supports to tag-o-matic function of Bruce. FeliCa supports works only for PN532 users, for those who use RC522 there is no difference in operation of tag-o-matic.

I also wrote a hextostr helper to reduce code repetition during the conversion between int and hex string