### PR TITLE
Update lilygo T-Watch-S3 interface. initial touch as polling mode

### DIFF
--- a/boards/lilygo-t-watch-s3/interface.cpp
+++ b/boards/lilygo-t-watch-s3/interface.cpp
@@ -83,6 +83,7 @@ void _setup_gpio() {
 
     touch.begin(Wire1, FT6X36_SLAVE_ADDRESS, 39, 40);
     touch.setSwapXY(true);
+    touch.interruptPolling();
 }
 
 /***************************************************************************************


### PR DESCRIPTION
#### Proposed Changes ####

Due to the touch chip working with trigger mode, T Watch S3 GUI cannot work properly. Set the touch chip to polling mode while setting up.

#### Types of Changes ####

Bugfix

#### Verification ####

build the firmware and test the GUI of Bruce with T-Watch-S3.

#### Testing ####

N/A. I tested it manually.

#### Linked Issues ####

None.

#### User-Facing Change ####

```release-note
T-Watch-S3 GUI cannot work properly with the default touch detection mode. (trigger mode touch)
```

#### Further Comments ####

