### PR TITLE
Add posibility to run multiple JS scripts, background scripts, run script on start, task manager

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -514,6 +514,8 @@ int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subT
             break;
         }
 
+        if (interpreter_start) { break; }
+
 #ifdef HAS_KEYBOARD
         if (check(EscPress)) break;
         int pressed_number = checkNumberShortcutPress();


### PR DESCRIPTION
Because of recent changes in loopOptions, which now include an infinite loop and no longer return to the main menu on every render, running JS scripts via serial commands doesn't work while idling in the main menu. 
You now need to manually select any option in the menu to run a script.

To fix this, I'm planning to introduce a task manager to handle multiple tasks. Scripts are already running as RTOS tasks so it should be possible.

I'll provide API  to run JS scripts from any core or task, so launching scripts from the serial interface or WebUI will work again.

Before we do this we need to remove any state from js functions, so we need to remove sprites and gifs vectors, and store them as pointers in duktape context, so there can be multiple duktape context(scripts).

#### Proposed Changes ####
 - Added functions to JS: `runtime.toBackground()`, `runtime.toForeground()` and `runtime.isForeground()` to make possible to run scripts in background.
 - Added JS script on startup function.
 - Added task manager for JS scripts.

#### Types of Changes ####

Bugfix, New Feature

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
 - Added `runtime.toBackground()`, `runtime.toForeground()` and `runtime.isForeground()` to make possible to run scripts in background.
 - Added JS script on startup function.
 - Added task manager for JS scripts.
```
