### PR TITLE
WifiFinder

### DIFF
--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -12,6 +12,7 @@
 #include "modules/wifi/scan_hosts.h"
 #include "modules/wifi/sniffer.h"
 #include "modules/wifi/wifi_atks.h"
+#include "modules/wifi/wififinder.h"
 
 #ifndef LITE_VERSION
 #include "modules/pwnagotchi/pwnagotchi.h"
@@ -34,8 +35,7 @@ void WifiMenu::optionsMenu() {
     if (!wifiConnected) {
         options = {
             {"Connect Wifi", lambdaHelper(wifiConnectMenu, WIFI_STA)},
-            {"WiFi AP",
-             [=]() {
+            {"WiFi AP", [=]() {
                  wifiConnectMenu(WIFI_AP);
                  displayInfo("pwd: " + bruceConfig.wifiAp.pwd, true);
              }},
@@ -54,6 +54,7 @@ void WifiMenu::optionsMenu() {
                            }
                            EvilPortal();
                        }});
+    options.push_back({"WifiFinder", wififindersetup});
     // options.push_back({"ReverseShell", [=]()       { ReverseShell(); }});
     options.push_back({"Listen TCP", listenTcpPort});
     options.push_back({"Client TCP", clientTCP});

--- a/src/modules/wifi/wififinder.cpp
+++ b/src/modules/wifi/wififinder.cpp
@@ -1,0 +1,162 @@
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/utils.h"
+#include "core/wifi/wifi_common.h"
+#include "globals.h"
+#include "modules/others/audio.h"
+#include <vector>
+
+std::vector<String> wifinames;
+String ssid;
+int32_t range;
+bool found = false;
+bool checkk = false;
+bool sound = false;
+
+void wififinder() {
+    tft.fillScreen(bruceConfig.bgColor);
+    tft.setCursor(0, 0);
+
+    tft.print("Finding Networks...");
+    displayInfo("Searching...");
+
+    while (true) {
+        int nets = WiFi.scanNetworks();
+        for (int i = 0; i < nets; i++) {
+            ssid = WiFi.SSID(i);
+            range = WiFi.RSSI(i);
+
+            tft.setCursor(0, 0);
+
+            if (!found) displayTextLine(String(ssid));
+
+            for (const String &name2 : wifinames) {
+                if (ssid == name2) {
+                    found = true;
+                    tft.fillScreen(bruceConfig.bgColor);
+                    tft.setCursor(0, 0);
+                    if (!sound) {
+#if defined(BUZZ_PIN)
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+                        _tone(5000, 50);
+                        delay(500);
+#else
+                        if (SD.exists("/found.mp3")) displayTextLine("Press Any Key To Skip Song!");
+                        playAudioFile(&SD, "/found.mp3");
+                        if (LittleFS.exists("/found.mp3")) displayTextLine("Press Any Key To Skip Song!");
+                        playAudioFile(&LittleFS, "/found.mp3");
+                        if (!SD.exists("/found.mp3") && !LittleFS.exists("/found.mp3"))
+                            tts("Wifi Has Been Founded Wifi Has Been Founded");
+#endif
+                    }
+                    sound = true;
+                    displayTextLine(String(name2) + " has been founded. Range: " + String(range));
+
+                    if (check(EscPress)) {
+                        sound = false;
+                        checkk = false;
+                        found = false;
+                        returnToMenu = true;
+                        return;
+                    }
+                }
+            }
+        }
+
+        if (check(EscPress)) {
+            sound = false;
+            checkk = false;
+            found = false;
+            returnToMenu = true;
+            return;
+        }
+    }
+}
+
+void wififindersetup() {
+    if (!checkk) {
+        File file;
+        FS *fs;
+        int selectedmode;
+        String ExampleFile = "";
+
+        options = {
+            {"Single Wifi",   [&]() { selectedmode = 0; }},
+            {"From The File", [&]() { selectedmode = 1; }},
+        };
+        addOptionToMainMenu();
+        loopOptions(options);
+
+        if (selectedmode == 0) {
+            String name = keyboard("", 32, "Wifi Name");
+            wifinames.push_back(name);
+
+            if (wifinames[0] == "" || wifinames[0] == " " || wifinames[0] == "  ") {
+                displayError("Wifi Name Can't be Empty.");
+                delay(2500);
+                return;
+            }
+        }
+
+        if (selectedmode == 1) {
+            if (!file) {
+                options = {};
+                fs = nullptr;
+
+                if (setupSdCard()) {
+                    options.push_back({"SD Card", [&]() { fs = &SD; }});
+                }
+                options.push_back({"LittleFS", [&]() { fs = &LittleFS; }});
+                addOptionToMainMenu();
+
+                loopOptions(options);
+                if (fs != nullptr) {
+                    ExampleFile = loopSD(*fs, true, "TXT");
+                    file = fs->open(ExampleFile, FILE_READ);
+                    ExampleFile = file.readString();
+                    ExampleFile.replace("\r\n", "\n");
+                }
+            }
+
+            int start = 0;
+            int end = ExampleFile.indexOf('\n', start);
+
+            while (end != -1) {
+                String line = ExampleFile.substring(start, end);
+                line.trim();
+
+                if (line.length() > 0) { wifinames.push_back(line); }
+
+                start = end + 1;
+                end = ExampleFile.indexOf('\n', start);
+            }
+
+            if (start < ExampleFile.length()) {
+                String line = ExampleFile.substring(start);
+                line.trim();
+                if (line.length() > 0) { wifinames.push_back(line); }
+            }
+        }
+        checkk = true;
+        tft.fillScreen(bruceConfig.bgColor);
+        tft.setCursor(0, 0);
+        wififinder();
+    }
+}

--- a/src/modules/wifi/wififinder.h
+++ b/src/modules/wifi/wififinder.h
@@ -1,0 +1,3 @@
+void wififindersetup();
+void wififinder();
+void alert();

--- a/src/modules/wifi/wififinder.h
+++ b/src/modules/wifi/wififinder.h
@@ -1,3 +1,2 @@
 void wififindersetup();
 void wififinder();
-void alert();


### PR DESCRIPTION
#### Proposed Changes ####

![p2](https://github.com/user-attachments/assets/1e6d2d28-7880-4ae0-adb4-a0bff142faae)
![p1](https://github.com/user-attachments/assets/b49fcdb6-4176-41b5-8e84-5cb13933de08)

#### Types of Changes ####

WifiFinder iThis is a new Feature that allows you to find the desired network by name. For example you collect many handshakes with brucegotchi and crack a few of them you want to connect cracked network but you dont remember where you captured handhakes or you dont have gps module so you can just type name of the wifi or wifis and walk around where you run brucegotchi and find your cracked network

#### Verification ####

idk

#### Testing ####
just try to type any wifi name and open network with this name on the phone by AP network

#### Linked Issues ####
NONE

#### User-Facing Change ####
<!--
NONE but user can change sound when wifi network finded by uploading file found.mp3 on littlefs or sd card
-->
```release-note

```

#### Further Comments ####
Added Different Detect Sounds for different devices
Added Select multiple wifi names by file
Added Custom Wifi found sound
Added RealTime Updating Range