### PR TITLE
Adjust the internal triangles to fit the same line width as other logo lines on the Bluetooth logo 

### DIFF
--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -120,7 +120,7 @@ void BleMenu::drawIcon(float scale) {
     );
 
       tft.fillTriangle(
-        iconCenterX - lineWidth,
+        iconCenterX - lineWidth / 2,
         iconCenterY - iconH / 4,
         iconCenterX - iconW / 2 + lineWidth / 2,
         iconCenterY - lineWidth,
@@ -129,7 +129,7 @@ void BleMenu::drawIcon(float scale) {
         bruceConfig.bgColor
     );
     tft.fillTriangle(
-        iconCenterX - lineWidth,
+        iconCenterX - lineWidth / 2,
         iconCenterY + iconH / 4,
         iconCenterX - iconW / 2 + lineWidth / 2,
         iconCenterY + lineWidth,

--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -120,21 +120,21 @@ void BleMenu::drawIcon(float scale) {
     );
 
       tft.fillTriangle(
-        iconCenterX - lineWidth / 4,
+        iconCenterX - lineWidth,
         iconCenterY - iconH / 4,
         iconCenterX - iconW / 2 + lineWidth / 2,
-        iconCenterY - lineWidth / 2,
+        iconCenterY - lineWidth,
         iconCenterX - iconW / 2 + lineWidth / 2,
-        iconCenterY - iconH / 2 + lineWidth / 2,
+        iconCenterY - iconH / 2 + lineWidth,
         bruceConfig.bgColor
     );
     tft.fillTriangle(
-        iconCenterX - lineWidth / 4,
+        iconCenterX - lineWidth,
         iconCenterY + iconH / 4,
         iconCenterX - iconW / 2 + lineWidth / 2,
-        iconCenterY + lineWidth / 2,
+        iconCenterY + lineWidth,
         iconCenterX - iconW / 2 + lineWidth / 2,
-        iconCenterY + iconH / 2 - lineWidth / 2,
+        iconCenterY + iconH / 2 - lineWidth,
         bruceConfig.bgColor
     );
 


### PR DESCRIPTION
#### Proposed Changes #### 
Adjust the internal triangles to fit the same line width as other logo lines. 

#### Types of Changes #### 
Aesthetic changes 

#### Verification #### 
Changes where simulated. 

#### Testing #### 
Tested on sim

 #### Further Comments #### 
I've modified my previous commit because I've tested on the Lilygo T-Embed and in the real devices the lines where too thin, so I brought the vertices close to the center to make all the lines with the same size.