### PR TITLE
Add exit menu to OpenHaystack module

### DIFF
--- a/src/modules/others/openhaystack.cpp
+++ b/src/modules/others/openhaystack.cpp
@@ -10,6 +10,7 @@
 #include "esp_gap_ble_api.h"
 #include "esp_gatt_defs.h"
 #include "esp_gattc_api.h"
+#include "freertos/FreeRTOS.h"
 
 #include "core/display.h"
 #include "core/sd_functions.h"


### PR DESCRIPTION
This PR adds an exit menu to the OpenHaystack module that appears when the ESC button is pressed. The menu gives users two options:

Continue OpenHaystack - resumes BLE advertising
Exit to Main Menu - stops BLE advertising and returns to main menu

The implementation properly handles BLE advertising state management, temporarily stopping it while the menu is displayed and restarting it if the user chooses to continue. 

This enhancement improves user experience by providing a clear way to exit or continue OpenHaystack.