### PR TITLE
Ble keyboard layout selector buggy design [designfix]

### DIFF
--- a/src/modules/badusb_ble/ducky_typer.cpp
+++ b/src/modules/badusb_ble/ducky_typer.cpp
@@ -171,7 +171,8 @@ void ducky_chooseKb(HIDInterface *&hid, bool ble) {
         {"Slovenian (Slovenia)",  createKeyboardSetter(KeyboardLayout_si_SI)}
     };
     addOptionToMainMenu();
-    loopOptions(options, true, "Keyboard Layout");
+    //loopOptions(options, true, "Keyboard Layout");
+    loopOptions(options, true);
     options.clear();
 }
 // Start badUSB or badBLE ducky runner


### PR DESCRIPTION
#### Proposed Changes ####

Changed design bug

#### Types of Changes ####
Changed design bug

#### Verification ####

Check latest build (M5 stickc plus2)

#### Testing ####

Check latest build (M5 stickc plus2)

#### Linked Issues ####

Ble connect still doesnt work ):  issue: #997 (https://github.com/pr3y/Bruce/issues/997)

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

I can only check this on M5 stickc plus2

**before:**
![before](https://github.com/user-attachments/assets/43dddf6c-18b4-45f7-a29f-8c4108766bfe)
**after:**
![after](https://github.com/user-attachments/assets/3e9befbc-cd71-40aa-8da5-12e68b324098)

