### PR TITLE
Add de-auth detector to WiFi module - IDK IF IT WORKS READ END BIT

### DIFF
--- a/src/modules/wifi/deauth_detector.cpp
+++ b/src/modules/wifi/deauth_detector.cpp
@@ -1,0 +1,36 @@
+#include "deauth_detector.h"
+#include <esp_wifi.h>
+#include <WiFi.h>
+#include <vector>
+#include <string>
+#include <iostream>
+
+std::vector<std::string> detectedDeauthPackets;
+
+void deauthSniffer(void *buf, wifi_promiscuous_pkt_type_t type) {
+    wifi_promiscuous_pkt_t *pkt = (wifi_promiscuous_pkt_t *)buf;
+    if (type == WIFI_PKT_MGMT) {
+        uint8_t *payload = pkt->payload;
+        if (payload[0] == 0xC0 || payload[0] == 0xA0) { // Deauth or Disassoc frame
+            std::string mac = "";
+            for (int i = 10; i < 16; i++) {
+                mac += String(payload[i], HEX);
+                if (i < 15) mac += ":";
+            }
+            detectedDeauthPackets.push_back(mac);
+            Serial.println("Deauth packet detected from: " + mac);
+        }
+    }
+}
+
+void startDeauthDetector() {
+    WiFi.mode(WIFI_MODE_STA);
+    esp_wifi_set_promiscuous(true);
+    esp_wifi_set_promiscuous_rx_cb(&deauthSniffer);
+    Serial.println("Deauth detector started.");
+}
+
+void stopDeauthDetector() {
+    esp_wifi_set_promiscuous(false);
+    Serial.println("Deauth detector stopped.");
+}

--- a/src/modules/wifi/deauth_detector.h
+++ b/src/modules/wifi/deauth_detector.h
@@ -1,0 +1,13 @@
+#ifndef DEAUTH_DETECTOR_H
+#define DEAUTH_DETECTOR_H
+
+#include <vector>
+#include <string>
+#include <esp_wifi.h>
+#include <WiFi.h>
+
+void deauthSniffer(void *buf, wifi_promiscuous_pkt_type_t type);
+void startDeauthDetector();
+void stopDeauthDetector();
+
+#endif // DEAUTH_DETECTOR_H

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -12,6 +12,7 @@
 #include "esp_system.h"
 #include "esp_wifi.h"
 #include "evil_portal.h"
+#include "deauth_detector.h"
 #include "vector"
 #include <Arduino.h>
 #include <globals.h>
@@ -104,6 +105,7 @@ void wifi_atk_menu() {
         {"Target Atks",  [&]() { scanAtks = true; }    },
         {"Beacon SPAM",  [=]() { beaconAttack(); }     },
         {"Deauth Flood", [=]() { deauthFloodAttack(); }},
+        {"Deauth Detector", [=]() { startDeauthDetector(); }},
     };
     addOptionToMainMenu();
     loopOptions(options);


### PR DESCRIPTION
Add de-auth detector functionality to the WiFi module.

* **New Files**:
  - `src/modules/wifi/deauth_detector.cpp`: Implements functions to initialize the WiFi sniffer, handle detected de-auth packets, and start/stop the de-auth detector.
  - `src/modules/wifi/deauth_detector.h`: Declares functions for initializing the WiFi sniffer, handling detected de-auth packets, and starting/stopping the de-auth detector.

* **Modified Files**:
  - `src/modules/wifi/wifi_atks.cpp`: Adds a menu option in `wifi_atk_menu` to start the de-auth detector.

I don't have a thing running Bruce yet, so I cannot test. I am sorry. Could someone test if this works? If it does, please pull. Otherwise, I can revise the changes if I am given the debug output.