### PR TITLE
Fix for interpreter start for serial command

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -514,6 +514,8 @@ int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subT
             break;
         }
 
+        if (interpreter_start) { break; }
+
 #ifdef HAS_KEYBOARD
         if (check(EscPress)) break;
         int pressed_number = checkNumberShortcutPress();


### PR DESCRIPTION
#### Proposed Changes ####

Because of recent changes in loopOptions, which now include an infinite loop and no longer return to the main menu on every render, running JS scripts via serial commands doesn't work while idling in the main menu.
You now need to manually select any option in the menu to run a script.
This PR fixes it.

I accidentially closed https://github.com/pr3y/Bruce/pull/1093 because of that, but I will reopen it, after this will be merged to the main.

- Fix for interpreter start for serial command

#### Types of Changes ####
Bugfix

#### Verification ####

You can start js script by serial command.

#### Linked Issues ####

https://github.com/pr3y/Bruce/pull/1093

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Fix for interpreter start for serial command
```