### PR TITLE
fixed: rf_scan menu, escpress

### DIFF
--- a/src/core/led_control.cpp
+++ b/src/core/led_control.cpp
@@ -115,8 +115,8 @@ void beginLed() {
 
     // -- Apply the configuration
     rmt_config(&rmt_tx);
-    rmt_driver_uninstall(rmt_channel_t(FASTLED_ESP32_RMT_CHANNEL_0));
-    rmt_driver_install(rmt_channel_t(FASTLED_ESP32_RMT_CHANNEL_0), 0, 0);
+    ESP_ERROR_CHECK_WITHOUT_ABORT(rmt_driver_uninstall(rmt_channel_t(FASTLED_ESP32_RMT_CHANNEL_0)));
+    ESP_ERROR_CHECK_WITHOUT_ABORT(rmt_driver_install(rmt_channel_t(FASTLED_ESP32_RMT_CHANNEL_0), 0, 0));
 
     if (bruceConfig.ledColor == LED_COLOR_WHEEL && colorWheelTaskHandle == NULL) {
         xTaskCreate(colorWheelTask, "ColorWheel", 2048, NULL, 1, &colorWheelTaskHandle);

--- a/src/modules/rf/rf_scan.cpp
+++ b/src/modules/rf/rf_scan.cpp
@@ -270,6 +270,7 @@ void RFScan::select_menu_option() {
     options.emplace_back("Main Menu", [=]() { set_option(MAIN_MENU); });
 
     loopOptions(options);
+    if (!restartScan) returnToMenu = true;
 }
 
 void RFScan::set_option(RFMenuOption option) {

--- a/src/modules/rf/rf_scan.cpp
+++ b/src/modules/rf/rf_scan.cpp
@@ -42,6 +42,7 @@ void RFScan::loop() {
         while (frequency <= 0) { // FastScan
             if (check(EscPress) || returnToMenu) return;
             if (check(NextPress)) select_menu_option();
+            if (restartScan) return setup();
 
             fast_scan();
         }

--- a/src/modules/rf/rf_scan.cpp
+++ b/src/modules/rf/rf_scan.cpp
@@ -6,7 +6,10 @@
 #include <globals.h>
 #include <sstream>
 
-RFScan::RFScan() { setup(); }
+RFScan::RFScan() {
+    setup();
+    loop();
+}
 
 RFScan::~RFScan() { deinitRfModule(); }
 
@@ -26,25 +29,26 @@ void RFScan::setup() {
     rcswitch.resetAvailable();
     returnToMenu = false;
     restartScan = false;
-
-    return loop();
 }
 
 void RFScan::loop() {
     while (1) {
-        if (check(EscPress) || returnToMenu) return;
-        if (check(NextPress)) select_menu_option();
-        if (restartScan) return setup();
-
         if (bruceConfig.rfFxdFreq) frequency = bruceConfig.rfFreq;
         if (frequency <= 0) init_freqs();
 
         while (frequency <= 0) { // FastScan
             if (check(EscPress) || returnToMenu) return;
             if (check(NextPress)) select_menu_option();
-            if (restartScan) return setup();
+            if (restartScan) break;
 
             fast_scan();
+        }
+
+        if (check(EscPress) || returnToMenu) return;
+        if (check(NextPress)) select_menu_option();
+        if (restartScan) {
+            setup();
+            continue;
         }
 
         if (rcswitch.available() && !ReadRAW) {

--- a/src/modules/rf/rf_scan.cpp
+++ b/src/modules/rf/rf_scan.cpp
@@ -274,7 +274,7 @@ void RFScan::select_menu_option() {
     options.emplace_back("Main Menu", [=]() { set_option(MAIN_MENU); });
 
     loopOptions(options);
-    if (!restartScan) returnToMenu = true;
+    if (!restartScan && !returnToMenu) set_option(CLOSE_MENU);
 }
 
 void RFScan::set_option(RFMenuOption option) {


### PR DESCRIPTION
#### Proposed Changes ####

Fixed two small bugs:
- menu operation in rf_scan fastscan mode does not work
- esc press is not properly processed after opening the menu in rf_scan

Attempted improvements:
- after blinkled turned on, rf_scan often freezes. i tried adding error handling and it improved, but it still may happen