### PR TITLE
play audio files from the webui and some fixes

### DIFF
--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -97,11 +97,11 @@ function listFilesButton(folders, fs = 'LittleFS', userRequest = false) {
             if (item.name.substring(item.name.lastIndexOf('.') + 1).toLowerCase() === "ir") {
                 tableContent += "<i class=\"gg-data\" onclick=\"sendIrFile(\'" + item.path + "\')\"></i>&nbsp&nbsp\n"
             }
-            if (item.name.substring(item.name.lastIndexOf('.') + 1).toLowerCase() === "js") {
+            if (["bjs", "js"].includes(item.name.substring(item.name.lastIndexOf('.') + 1).toLowerCase())) {
                 tableContent += "<i class=\"gg-data\" onclick=\"runJsFile(\'" + item.path + "\')\"></i>&nbsp&nbsp\n"
             }
-            if (item.name.substring(item.name.lastIndexOf('.') + 1).toLowerCase() === "bjs") {
-                tableContent += "<i class=\"gg-data\" onclick=\"runJsFile(\'" + item.path + "\')\"></i>&nbsp&nbsp\n"
+            if (["mp3", "wav", "mod", "opus", "aac", "flac"].includes(item.name.substring(item.name.lastIndexOf('.') + 1).toLowerCase())) {
+                tableContent += "<i class=\"gg-data\" onclick=\"playAudioFile(\'" + item.path + "\')\"></i>&nbsp&nbsp\n"
             }
             if (item.name.substring(item.name.lastIndexOf('.') + 1).toLowerCase() === "txt") {
                 tableContent += "<i class=\"gg-data\" onclick=\"runBadusbFile(\'" + item.path + "\')\"></i>&nbsp&nbsp\n"
@@ -244,6 +244,19 @@ function runBadusbFile(filePath) {
   const ajax5 = new XMLHttpRequest();
   const formdata5 = new FormData();
   formdata5.append("cmnd", "badusb run_from_file " + filePath);
+  ajax5.open("POST", "/cm", false);
+  ajax5.send(formdata5);
+  _("status").innerHTML = ajax5.responseText;
+  var fs = _("actualFS").value;
+  listFilesButton(actualFolder, fs, true);
+}
+
+function playAudioFile(filePath) {
+  var actualFolder = _("actualFolder").value;
+  var fs = _("actualFS").value;
+  const ajax5 = new XMLHttpRequest();
+  const formdata5 = new FormData();
+  formdata5.append("cmnd", "play " + filePath);
   ajax5.open("POST", "/cm", false);
   ajax5.send(formdata5);
   _("status").innerHTML = ajax5.responseText;

--- a/sd_files/interpreter/ir_brute.js
+++ b/sd_files/interpreter/ir_brute.js
@@ -21,7 +21,7 @@ function brute_force() {
         if(getAnyPress()) break;
             
         // example full cmd: IRSend {"Protocol":"NEC","Bits":32,"Data":"0x20DF10EF"}
-        serialCmd("IRSend {\"Protocol\":\"" + protocol + "\",\"Bits\":32,\"Data\":\"0x" + curr_val + "\"}");
+        serialCmd("ir send {\"Protocol\":\"" + protocol + "\",\"Bits\":32,\"Data\":\"0x" + curr_val + "\"}");
             
         delay(delay_ms);
         fillScreen(0);

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -16,6 +16,7 @@ JsonDocument BruceConfig::toJson() const {
     setting["bright"] = bright;
     setting["tmz"] = tmz;
     setting["soundEnabled"] = soundEnabled;
+    setting["soundVolume"] = soundVolume;
     setting["wifiAtStartup"] = wifiAtStartup;
     setting["instantBoot"] = instantBoot;
 
@@ -159,6 +160,12 @@ void BruceConfig::fromFile() {
     }
     if (!setting["soundEnabled"].isNull()) {
         soundEnabled = setting["soundEnabled"].as<int>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
+    if (!setting["soundVolume"].isNull()) {
+        soundEnabled = setting["soundVolume"].as<int>();
     } else {
         count++;
         log_e("Fail");
@@ -415,6 +422,7 @@ void BruceConfig::validateConfig() {
     validateBrightValue();
     validateTmzValue();
     validateSoundEnabledValue();
+    validateSoundVolumeValue();
     validateWifiAtStartupValue();
     validateLedBrightValue();
     validateLedColorValue();
@@ -480,8 +488,18 @@ void BruceConfig::setSoundEnabled(int value) {
     saveFile();
 }
 
+void BruceConfig::setSoundVolume(int value) {
+    soundVolume = value;
+    validateSoundVolumeValue();
+    saveFile();
+}
+
 void BruceConfig::validateSoundEnabledValue() {
     if (soundEnabled > 1) soundEnabled = 1;
+}
+
+void BruceConfig::validateSoundVolumeValue() {
+    if (soundVolume > 100) soundVolume = 100;
 }
 
 void BruceConfig::setWifiAtStartup(int value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -43,6 +43,7 @@ public:
     int bright = 100;
     int tmz = 0;
     int soundEnabled = 1;
+    int soundVolume = 100;
     int wifiAtStartup = 0;
     int instantBoot = 0;
 
@@ -126,7 +127,9 @@ public:
     void setTmz(int value);
     void validateTmzValue();
     void setSoundEnabled(int value);
+    void setSoundVolume(int value);
     void validateSoundEnabledValue();
+    void validateSoundVolumeValue();
     void setWifiAtStartup(int value);
     void validateWifiAtStartupValue();
 

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -29,6 +29,9 @@ void ConfigMenu::optionsMenu() {
         {"Led Blink On/Off", setLedBlinkConfig},
 #endif
         {"Sound On/Off", setSoundConfig},
+#if defined(HAS_NS4168_SPKR)
+        {"Sound Volume", setSoundVolume},
+#endif
         {"Startup WiFi", setWifiStartupConfig},
         {"Startup App", setStartupApp},
         {"Network Creds", setNetworkCredsMenu},

--- a/src/core/menu_items/ScriptsMenu.cpp
+++ b/src/core/menu_items/ScriptsMenu.cpp
@@ -31,9 +31,9 @@ std::vector<Option> getScriptsOptionsList() {
 
     File root = fs->open(folder);
     if (!root || !root.isDirectory()) return opt; // not a dir
-    File file2 = root.openNextFile();
+    File file2;
 
-    while (file2) {
+    while (file2 = root.openNextFile()) {
         if (file2.isDirectory()) continue;
 
         String fileName = String(file2.name());
@@ -42,9 +42,8 @@ std::vector<Option> getScriptsOptionsList() {
         String entry_title = String(file2.name());
         entry_title = entry_title.substring(0, entry_title.lastIndexOf(".")); // remove the extension
         opt.push_back({entry_title.c_str(), [=]() { run_bjs_script_headless(*fs, file2.path()); }});
-
-        file2 = root.openNextFile();
     }
+    
     file2.close();
     root.close();
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -244,6 +244,26 @@ void setSoundConfig() {
 }
 
 /*********************************************************************
+**  Function: setSoundVolume
+**  Set sound volume
+**********************************************************************/
+void setSoundVolume() {
+    options = {
+        {"10%", [=]() { bruceConfig.setSoundVolume(10); }, bruceConfig.soundVolume == 10},
+        {"20%", [=]() { bruceConfig.setSoundVolume(20); }, bruceConfig.soundVolume == 20},
+        {"30%", [=]() { bruceConfig.setSoundVolume(30); }, bruceConfig.soundVolume == 30},
+        {"40%", [=]() { bruceConfig.setSoundVolume(40); }, bruceConfig.soundVolume == 40},
+        {"50%", [=]() { bruceConfig.setSoundVolume(50); }, bruceConfig.soundVolume == 50},
+        {"60%", [=]() { bruceConfig.setSoundVolume(60); }, bruceConfig.soundVolume == 60},
+        {"70%", [=]() { bruceConfig.setSoundVolume(70); }, bruceConfig.soundVolume == 70},
+        {"80%", [=]() { bruceConfig.setSoundVolume(80); }, bruceConfig.soundVolume == 80},
+        {"90%", [=]() { bruceConfig.setSoundVolume(90); }, bruceConfig.soundVolume == 90},
+        {"100%", [=]() { bruceConfig.setSoundVolume(100); }, bruceConfig.soundVolume == 100},
+    };
+    loopOptions(options, bruceConfig.soundVolume);
+}
+
+/*********************************************************************
 **  Function: setLedBlinkConfig
 **  Enable or disable led blink
 **********************************************************************/

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -51,6 +51,8 @@ void runClockLoop();
 
 void setSoundConfig();
 
+void setSoundVolume();
+
 void setLedBlinkConfig();
 
 void setWifiStartupConfig();

--- a/src/modules/others/audio.cpp
+++ b/src/modules/others/audio.cpp
@@ -2,6 +2,8 @@
 #include "AudioFileSourceFunction.h"
 #include "AudioGeneratorMIDI.h"
 #include "AudioGeneratorWAV.h"
+#include "AudioGeneratorAAC.h"
+#include "AudioGeneratorFLAC.h"
 #include "AudioOutputI2SNoDAC.h"
 #include "core/mykeyboard.h"
 #include <ESP8266Audio.h>
@@ -27,6 +29,9 @@ bool playAudioFile(FS *fs, String filepath) {
     if (filepath.endsWith(".wav")) generator = new AudioGeneratorWAV();
     if (filepath.endsWith(".mod")) generator = new AudioGeneratorMOD();
     if (filepath.endsWith(".opus")) generator = new AudioGeneratorOpus();
+    if (filepath.endsWith(".aac")) generator = new AudioGeneratorAAC();
+    if (filepath.endsWith(".flac")) generator = new AudioGeneratorFLAC();
+    // OGG Vorbis is not supported https://github.com/earlephilhower/ESP8266Audio/issues/84
     if (filepath.endsWith(".mp3")) {
         generator = new AudioGeneratorMP3();
         source = new AudioFileSourceID3(source);

--- a/src/modules/others/audio.cpp
+++ b/src/modules/others/audio.cpp
@@ -20,6 +20,9 @@ bool playAudioFile(FS *fs, String filepath) {
     AudioOutputI2S *audioout = new AudioOutputI2S(
     ); // https://github.com/earlephilhower/ESP8266Audio/blob/master/src/AudioOutputI2S.cpp#L32
     audioout->SetPinout(BCLK, WCLK, DOUT, MCLK);
+    
+    // set volume, derived from https://github.com/earlephilhower/ESP8266Audio/blob/master/examples/WebRadio/WebRadio.ino
+    audioout->SetGain(((float)bruceConfig.soundVolume) / 100.0);
 
     AudioGenerator *generator = NULL;
 


### PR DESCRIPTION
- remotely play audio files from the webui 
   - later TODO: async play to avoid freezing the webui for long files
- added aac and flac audio files support
- fix for JS Interpreter menu infinite loop with non-js files in script dir
- fixed ir_brute js script (#1168)
- added audio volume adjustment setting (#1174)
