### PR TITLE
Improve energy consumption during DeepSleep for T-Embed CC1101

### DIFF
--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -30,6 +30,7 @@ BQ27220 bq;
 #endif
 
 #include "core/i2c_finder.h"
+#include "modules/rf/rf_utils.h"
 #include <Adafruit_PN532.h>
 
 /***************************************************************************************
@@ -228,6 +229,12 @@ void powerDownNFC() {
     }
 }
 
+void powerDownCC1101() {
+    if (!initRfModule("rx", bruceConfig.rfFreq)) { Serial.println("Can't init CC1101"); }
+
+    ELECHOUSE_cc1101.goSleep();
+}
+
 void checkReboot() {
 #ifdef T_EMBED_1101
     int countDown;
@@ -247,6 +254,7 @@ void checkReboot() {
                     while (digitalRead(BK_BTN) == BTN_ACT);
                     delay(200);
                     powerDownNFC();
+                    powerDownCC1101();
                     digitalWrite(PIN_POWER_ON, LOW);
                     esp_sleep_enable_ext0_wakeup(GPIO_NUM_6, LOW);
                     esp_deep_sleep_start();

--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -255,6 +255,7 @@ void checkReboot() {
                     delay(200);
                     powerDownNFC();
                     powerDownCC1101();
+                    tft.sleep(true);
                     digitalWrite(PIN_POWER_ON, LOW);
                     esp_sleep_enable_ext0_wakeup(GPIO_NUM_6, LOW);
                     esp_deep_sleep_start();

--- a/lib/TFT_eSPI/TFT_eSPI.cpp
+++ b/lib/TFT_eSPI/TFT_eSPI.cpp
@@ -799,6 +799,23 @@ void TFT_eSPI::init(uint8_t tc)
 #endif
 }
 
+/***************************************************************************************
+** Function name:           sleep
+** Description:             Allows the display to be put to sleep then awake again
+***************************************************************************************/
+void TFT_eSPI::sleep(bool value)
+{
+    if (value)
+    {
+        writecommand(0x10);         // Send command to put the display to sleep.
+        delay(5);                   // Delay for shutdown time before another command can be sent.
+    }
+    else
+    {
+        writecommand(0x11);         // Send command to wakeup the display.
+        delay(120);                 // Wait for the display power supplies to stabilise.
+    }
+}
 
 /***************************************************************************************
 ** Function name:           setRotation

--- a/lib/TFT_eSPI/TFT_eSPI.h
+++ b/lib/TFT_eSPI/TFT_eSPI.h
@@ -434,7 +434,9 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
   // init() and begin() are equivalent, begin() included for backwards compatibility
   // Sketch defined tab colour option is for ST7735 displays only
   void     init(uint8_t tc = TAB_COLOUR), begin(uint8_t tc = TAB_COLOUR);
-
+  
+  void sleep(bool value);
+  
   // These are virtual so the TFT_eSprite class can override them with sprite specific functions
   virtual void     drawPixel(int32_t x, int32_t y, uint32_t color),
                    drawChar(int32_t x, int32_t y, uint16_t c, uint32_t color, uint32_t bg, uint8_t size),


### PR DESCRIPTION
This PR resolves issue #1136 and improve energy consumption during deepsleep by powering down PN532 and CC1101.

https://github.com/rennancockles/PN532/pull/2 must be accepted in order to build firmware with this changes