### PR TITLE
loopOptions() handles escpress

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -421,6 +421,7 @@ void padprintln(double n, int digits, int16_t padx) {
     tft.println(n, digits);
 }
 
+bool escInMenu = false;
 /*********************************************************************
 **  Function: loopOptions
 **  Where you choose among the options in menu
@@ -431,7 +432,6 @@ int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subT
     bool exit = false;
     int menuSize = options.size();
     static unsigned long _clock_bat_timer = millis();
-    escInMenu = false;
     if (options.size() > MAX_MENU_SIZE) { menuSize = MAX_MENU_SIZE; }
     if (index > 0)
         tft.fillRoundRect(

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -431,6 +431,7 @@ int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subT
     bool exit = false;
     int menuSize = options.size();
     static unsigned long _clock_bat_timer = millis();
+    escInMenu = false;
     if (options.size() > MAX_MENU_SIZE) { menuSize = MAX_MENU_SIZE; }
     if (index > 0)
         tft.fillRoundRect(
@@ -539,7 +540,10 @@ int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subT
         if (interpreter_start) { break; }
 
 #ifdef HAS_KEYBOARD
-        if (check(EscPress)) break;
+        if (check(EscPress)) {
+            escInMenu = true;
+            break;
+        }
         int pressed_number = checkNumberShortcutPress();
         if (pressed_number >= 0) {
             if (index == pressed_number) {
@@ -553,7 +557,10 @@ int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subT
             redraw = true;
         }
 #elif defined(T_EMBED) || defined(HAS_TOUCH)
-        if (menuType != MENU_TYPE_MAIN && check(EscPress)) break;
+        if (menuType != MENU_TYPE_MAIN && check(EscPress)) {
+            escInMenu = true;
+            break;
+        }
 #endif
     }
     while (SelPress) delay(100); // to avoid miss click due to heavy fingers

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -432,6 +432,7 @@ int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subT
     bool exit = false;
     int menuSize = options.size();
     static unsigned long _clock_bat_timer = millis();
+    escInMenu = false;
     if (options.size() > MAX_MENU_SIZE) { menuSize = MAX_MENU_SIZE; }
     if (index > 0)
         tft.fillRoundRect(

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -145,7 +145,7 @@ void padprintln(long long n, int base = DEC, int16_t padx = 1);
 void padprintln(unsigned long long n, int base = DEC, int16_t padx = 1);
 void padprintln(double n, int digits, int16_t padx = 1);
 
-bool escInMenu = false;
+extern bool escInMenu;
 // loopOptions will now return the last index used in the function
 int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subText, int index = 0);
 inline int loopOptions(std::vector<Option> &options, int _index) {

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -145,6 +145,7 @@ void padprintln(long long n, int base = DEC, int16_t padx = 1);
 void padprintln(unsigned long long n, int base = DEC, int16_t padx = 1);
 void padprintln(double n, int digits, int16_t padx = 1);
 
+bool escInMenu = false;
 // loopOptions will now return the last index used in the function
 int loopOptions(std::vector<Option> &options, uint8_t menuType, const char *subText, int index = 0);
 inline int loopOptions(std::vector<Option> &options, int _index) {

--- a/src/core/wifi/wg.cpp
+++ b/src/core/wifi/wg.cpp
@@ -116,6 +116,7 @@ void read_and_parse_file() {
 **********************************************************************/
 void wg_setup() {
     if (!wifiConnected) wifiConnectMenu();
+    if (returnToMenu) return;
 
     read_and_parse_file();
 

--- a/src/core/wifi/wifi_common.cpp
+++ b/src/core/wifi/wifi_common.cpp
@@ -137,7 +137,7 @@ bool wifiConnectMenu(wifi_mode_t mode) {
                 loopOptions(options);
                 options.clear();
 
-                if (check(EscPress)) {
+                if (escInMenu) {
                     refresh_scan = true;
                 } else {
                     refresh_scan = false;

--- a/src/modules/badusb_ble/ducky_typer.cpp
+++ b/src/modules/badusb_ble/ducky_typer.cpp
@@ -172,6 +172,7 @@ void ducky_chooseKb(HIDInterface *&hid, bool ble) {
     };
     addOptionToMainMenu();
     loopOptions(options, true, "Keyboard Layout");
+    if (escInMenu) returnToMenu = true;
     options.clear();
 }
 // Start badUSB or badBLE ducky runner

--- a/src/modules/ble/ble_ninebot.cpp
+++ b/src/modules/ble/ble_ninebot.cpp
@@ -114,7 +114,8 @@ void BLENinebot::redrawMainBorder() {
 void BLENinebot::loop() {
     std::vector<Option> deviceSelection;
 
-    while (!check(EscPress)) {
+    escInMenu = false;
+    while (!escInMenu) {
         redrawMainBorder();
         displayTextLine("Scanning...");
 

--- a/src/modules/rf/rf_scan.cpp
+++ b/src/modules/rf/rf_scan.cpp
@@ -269,6 +269,10 @@ void RFScan::select_menu_option() {
     options.emplace_back("Main Menu", [=]() { set_option(MAIN_MENU); });
 
     loopOptions(options);
+    if (escInMenu) {
+        escInMenu = false;
+        set_option(CLOSE_MENU);
+    }
 }
 
 void RFScan::set_option(RFMenuOption option) {

--- a/src/modules/rf/rf_scan.cpp
+++ b/src/modules/rf/rf_scan.cpp
@@ -269,10 +269,7 @@ void RFScan::select_menu_option() {
     options.emplace_back("Main Menu", [=]() { set_option(MAIN_MENU); });
 
     loopOptions(options);
-    if (escInMenu) {
-        escInMenu = false;
-        set_option(CLOSE_MENU);
-    }
+    if (escInMenu) set_option(CLOSE_MENU);
 }
 
 void RFScan::set_option(RFMenuOption option) {

--- a/src/modules/wifi/clients.cpp
+++ b/src/modules/wifi/clients.cpp
@@ -54,6 +54,7 @@ bool filterAnsiSequences = true; // Set to false to disable ANSI sequence filter
 
 void ssh_setup(String host) {
     if (!wifiConnected) wifiConnectMenu();
+    if (returnToMenu) return;
 
     tft.fillScreen(bruceConfig.bgColor);
     tft.setCursor(0, 0);
@@ -376,6 +377,7 @@ if (buffer[0] == 0xFF) {
 
 void telnet_setup() {
     if (!wifiConnected) wifiConnectMenu();
+    if (returnToMenu) return;
 
     tft.fillScreen(bruceConfig.bgColor);
     tft.setCursor(0, 0);

--- a/src/modules/wifi/evil_portal.cpp
+++ b/src/modules/wifi/evil_portal.cpp
@@ -41,6 +41,7 @@ void EvilPortal::CaptiveRequestHandler::handleRequest(AsyncWebServerRequest *req
 }
 bool EvilPortal::setup() {
     bool returnToMain = false;
+ChooseHtml:
     options = {
         {"Custom Html", [=]() { loadCustomHtml(); }}
     };
@@ -55,8 +56,7 @@ bool EvilPortal::setup() {
 
     loopOptions(options);
 
-    if (returnToMain) return false;
-
+    if (returnToMain || escInMenu) return false;
     memcpy(deauth_frame, deauth_frame_default, sizeof(deauth_frame_default));
     wsl_bypasser_send_raw_frame(&ap_record, _channel); // writes the buffer with the information
 
@@ -73,6 +73,7 @@ bool EvilPortal::setup() {
             }
 
             loopOptions(options);
+            if (escInMenu) goto ChooseHtml;
         }
     }
 
@@ -82,6 +83,7 @@ bool EvilPortal::setup() {
     };
 
     loopOptions(options);
+    if (escInMenu) goto ChooseHtml;
 
     Serial.println("Evil Portal output file: " + outputFile);
     return true;

--- a/src/modules/wifi/tcp_utils.cpp
+++ b/src/modules/wifi/tcp_utils.cpp
@@ -7,6 +7,7 @@ bool inputMode;
 
 void listenTcpPort() {
     if (!wifiConnected) wifiConnectMenu();
+    if (returnToMenu) return;
 
     WiFiClient tcpClient;
     tft.fillScreen(TFT_BLACK);
@@ -81,6 +82,7 @@ void listenTcpPort() {
 
 void clientTCP() {
     if (!wifiConnected) wifiConnectMenu();
+    if (returnToMenu) return;
 
     String serverIP = keyboard("", 15, "Enter server IP");
     String portString = keyboard("", 5, "Enter server Port");


### PR DESCRIPTION
#### Proposed Changes ####

In loopOptions(), press esc executes break. It is difficult for the caller to distinguish whether the esc key is pressed, Therefore, a flag is added

fixed: not redraw when escpress in rf_scan menu