### PR TITLE
Added spectogram to subghz

### DIFF
--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -16,7 +16,7 @@ void RFMenu::optionsMenu() {
         {"Custom SubGhz",   sendCustomRF              },
         {"Spectrum",        rf_spectrum               },
         {"SquareWave Spec", rf_SquareWave             }, // @Pirata
-        {"Waterfall Spectrum", rf_waterfall           }, // dev_eclipse
+        {"Spectogram", rf_waterfall           }, // dev_eclipse
         {"Jammer Itmt",     [=]() { RFJammer(false); }},
         {"Jammer Full",     [=]() { RFJammer(true); } },
         {"Config",          [=]() { configMenu(); }   },

--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -7,6 +7,7 @@
 #include "modules/rf/rf_scan.h"
 #include "modules/rf/rf_send.h"
 #include "modules/rf/rf_spectrum.h"
+#include "modules/rf/rf_waterfall.h"
 
 void RFMenu::optionsMenu() {
     options = {
@@ -15,6 +16,7 @@ void RFMenu::optionsMenu() {
         {"Custom SubGhz",   sendCustomRF              },
         {"Spectrum",        rf_spectrum               },
         {"SquareWave Spec", rf_SquareWave             }, // @Pirata
+        {"Waterfall Spectrum", rf_waterfall           }, // dev_eclipse
         {"Jammer Itmt",     [=]() { RFJammer(false); }},
         {"Jammer Full",     [=]() { RFJammer(true); } },
         {"Config",          [=]() { configMenu(); }   },

--- a/src/modules/rf/rf_waterfall.cpp
+++ b/src/modules/rf/rf_waterfall.cpp
@@ -1,0 +1,211 @@
+#include "rf_waterfall.h"
+
+float m_rf_waterfall_start_freq = 433.0;
+float m_rf_waterfall_end_freq = 434.0;
+
+void rf_waterfall() {
+    if (bruceConfig.rfModule != CC1101_SPI_MODULE) {
+        displayError("Waterfall needs a CC1101!", true);
+        return;
+    }
+    if (!initRfModule("rx", m_rf_waterfall_start_freq)) {
+        displayError("CC1101 not found!", true);
+        return;
+    }
+
+    ELECHOUSE_cc1101.setRxBW(200);
+
+select:
+
+    int option = 0;
+    options = {
+        {"Start Freq.", [&]() { option = 1; }},
+        {"End Freq.",   [&]() { option = 2; }},
+        {"Start",       [&]() { option = 3; }},
+        {"Main Menu",   [&]() { option = 4; }},
+    };
+    loopOptions(options);
+
+    tft.fillScreen(0x0);
+
+    if (option == 4) {
+        return;
+    } else if (option == 3) {
+        rf_waterfall_run();
+        goto select;
+    } else if (option == 1) {
+        rf_waterfall_start_freq();
+        goto select;
+    } else if (option == 2) {
+        rf_waterfall_end_freq();
+        goto select;
+    }
+}
+
+void rf_waterfall_start_freq() {
+    options = {};
+    int ind = 0;
+    int arraySize = sizeof(subghz_frequency_list) / sizeof(subghz_frequency_list[0]);
+    for (int i = 0; i < arraySize; i++) {
+        String tmp = String(subghz_frequency_list[i], 2) + "Mhz";
+        options.push_back({tmp.c_str(), [=]() { m_rf_waterfall_start_freq = subghz_frequency_list[i]; }});
+    }
+    loopOptions(options, ind);
+    options.clear();
+}
+
+void rf_waterfall_end_freq() {
+    options = {};
+    int ind = 0;
+    int arraySize = sizeof(subghz_frequency_list) / sizeof(subghz_frequency_list[0]);
+    for (int i = 0; i < arraySize; i++) {
+        String tmp = String(subghz_frequency_list[i], 2) + "Mhz";
+        options.push_back({tmp.c_str(), [=]() { m_rf_waterfall_end_freq = subghz_frequency_list[i]; }});
+    }
+    loopOptions(options, ind);
+    options.clear();
+}
+
+void rf_waterfall_run() {
+    float f_start = m_rf_waterfall_start_freq;
+    float f_end = m_rf_waterfall_end_freq;
+    const int screen_width = tft.width();
+    const int screen_height = tft.height();
+    const int display_top = screen_height / 5;
+    float f_freq_step;
+
+    int current_line = display_top;
+    initRfModule("rx", f_start);
+
+    float max_freq = f_start;
+    int max_rssi = -100;
+    unsigned long lastMaxUpdate = millis();
+
+    tft.fillRect(0, 0, screen_width, display_top, TFT_BLACK);
+
+    int selected_item = 0;
+    bool exitting = false;
+    unsigned long exit_time = 0;
+
+    while (1) {
+        for (int i = 0; i < 4; i++) {
+            int x = i * (screen_width / 4);
+            float f_freq = f_start + (f_end - f_start) * i / 4.0;
+            tft.setCursor(x, 0);
+            tft.setTextSize(1);
+
+            if (i == 0 && selected_item == 0) {
+                tft.setTextColor(TFT_PINK, TFT_BLACK);
+            } else if (i == 3 && selected_item == 1) {
+                tft.setTextColor(TFT_PINK, TFT_BLACK);
+            } else {
+                tft.setTextColor(TFT_WHITE, TFT_BLACK);
+            }
+
+            tft.drawFastVLine(x, 0, tft.height(), TFT_DARKGREY);
+            tft.print(String(f_freq, 1));
+        }
+
+        f_freq_step = (f_end - f_start) / screen_width;
+
+        float temp_max_freq = f_start;
+        int temp_max_rssi = -100;
+
+        float range = abs(f_end - f_start);
+        float step;
+
+        if (range > 100) step = 10;
+        else if (range > 10) step = 1;
+        else if (range > 1) step = 0.1;
+        else if (range > 0.1) step = 0.01;
+        else step = 0.001;
+
+        for (int i = 0; i < screen_width; ++i) {
+            float f_freq = f_start + i * f_freq_step;
+            setMHZ(f_freq);
+            delayMicroseconds(100);
+            int i_rssi = ELECHOUSE_cc1101.getRssi();
+            if (i_rssi > temp_max_rssi) {
+                temp_max_rssi = i_rssi;
+                temp_max_freq = f_freq;
+            }
+
+            int rawLevel = map(i_rssi, -100, -30, 0, 255);
+            int level = 255 - constrain(rawLevel, 0, 255);
+
+            uint8_t r = 0, g = 0, b = 0;
+            if (level <= 63) {
+                b = map(level, 0, 63, 64, 255);
+            } else if (level <= 127) {
+                g = map(level, 64, 127, 0, 255);
+                b = map(level, 64, 127, 255, 0);
+            } else if (level <= 191) {
+                r = map(level, 128, 191, 0, 255);
+                g = 255;
+            } else {
+                r = 255;
+                g = map(level, 192, 255, 255, 0);
+            }
+
+            uint16_t color = tft.color565(r, g, b);
+            tft.drawPixel(i, current_line, color);
+
+            if (check(SelPress)) {
+                selected_item++;
+                if (selected_item > 2) selected_item = 0;
+            }
+
+            if (check(UpPress) || check(NextPress)) {
+                switch (selected_item) {
+                    case 0: f_start += step; break;
+                    case 1: f_end += step; break;
+                    case 2: return;
+                }
+                delay(100);
+            } else if (check(DownPress) || check(PrevPress)) {
+                switch (selected_item) {
+                    case 0: f_start -= step; break;
+                    case 1: f_end -= step; break;
+                    case 2: return;
+                }
+                delay(100);
+            }
+        }
+
+        if (millis() - lastMaxUpdate >= 5000) {
+            max_rssi = temp_max_rssi;
+            max_freq = temp_max_freq;
+            tft.fillRect(0, 10, screen_width, 10, TFT_BLACK);
+            tft.setCursor(3, 10);
+            tft.setTextSize(1);
+            tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+            tft.print(max_rssi);
+            tft.print(" dBm @ ");
+            tft.print(max_freq, 3);
+            tft.print(" MHz ");
+
+            lastMaxUpdate = millis();
+        }
+
+        tft.setCursor(3, 20);
+        tft.setTextColor(TFT_DARKCYAN);
+        tft.print("[OK] Item [PREV/NEXT] Value ");
+
+        if (selected_item == 2) {
+            tft.setTextColor(TFT_RED);
+            tft.print("EXIT");
+        } else {
+            tft.setTextColor(TFT_WHITE);
+            tft.print("EXIT");
+        }
+
+        current_line++;
+        if (current_line >= screen_height) current_line = display_top;
+    }
+
+    returnToMenu = true;
+    rmt_rx_stop(RMT_RX_CHANNEL);
+    deinitRMT();
+    deinitRfModule();
+    delay(10);
+}

--- a/src/modules/rf/rf_waterfall.h
+++ b/src/modules/rf/rf_waterfall.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "rf_utils.h"
+
+void rf_waterfall_start_freq();
+void rf_waterfall_end_freq();
+void rf_waterfall_run();
+
+extern float m_rf_waterfall_start_freq;
+extern float m_rf_waterfall_end_freq;
+
+void rf_waterfall();


### PR DESCRIPTION
#### Proposed Changes ####

i have added a spectogram to the subghz menu, you can select frequencies, it shows it in nice colors and such
#### Types of Changes ####

i have added a menu item to the subghz menu and added files to the RF module
#### Verification ####

rf_waterfall.cpp

#### Testing ####

tested on my diy board, 170x320 display, but should work fine on any other display, i made sure its compatible
#### Linked Issues ####

no issues or pull requests was just bored so ive added it

#### User-Facing Change ####

action required

```release-note
Added a subghz spectogram (waterfall)
```

#### Further Comments ####
the -xx dbm @ xxx MHz shows the frequency that has the highest dbm on it
![IMG_3990](https://github.com/user-attachments/assets/56058205-ea2a-4ab2-9df7-8dce0ed5f96d)

