### PR TITLE
Added listening to rf signals

### DIFF
--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -16,7 +16,10 @@ void RFMenu::optionsMenu() {
         {"Custom SubGhz",   sendCustomRF              },
         {"Spectrum",        rf_spectrum               },
         {"SquareWave Spec", rf_SquareWave             }, // @Pirata
-        {"Spectogram", rf_waterfall           }, // dev_eclipse
+        {"Spectogram", rf_waterfall                   }, // dev_eclipse
+        #if defined(BUZZ_PIN) or defined(HAS_NS4168_SPKR)
+            {"Listen",          rf_listen                 }, // dev_eclipse
+        #endif
         {"Jammer Itmt",     [=]() { RFJammer(false); }},
         {"Jammer Full",     [=]() { RFJammer(true); } },
         {"Config",          [=]() { configMenu(); }   },

--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -4,6 +4,7 @@
 #include "core/utils.h"
 #include "modules/rf/record.h"
 #include "modules/rf/rf_jammer.h"
+#include "modules/rf/rf_listen.h"
 #include "modules/rf/rf_scan.h"
 #include "modules/rf/rf_send.h"
 #include "modules/rf/rf_spectrum.h"
@@ -16,10 +17,10 @@ void RFMenu::optionsMenu() {
         {"Custom SubGhz",   sendCustomRF              },
         {"Spectrum",        rf_spectrum               },
         {"SquareWave Spec", rf_SquareWave             }, // @Pirata
-        {"Spectogram", rf_waterfall                   }, // dev_eclipse
-        #if defined(BUZZ_PIN) or defined(HAS_NS4168_SPKR)
-            {"Listen",          rf_listen                 }, // dev_eclipse
-        #endif
+        {"Spectogram",      rf_waterfall              }, // dev_eclipse
+#if defined(BUZZ_PIN) or defined(HAS_NS4168_SPKR) and defined(RF_LISTEN_H)
+        {"Listen",          rf_listen                 }, // dev_eclipse
+#endif
         {"Jammer Itmt",     [=]() { RFJammer(false); }},
         {"Jammer Full",     [=]() { RFJammer(true); } },
         {"Config",          [=]() { configMenu(); }   },

--- a/src/modules/rf/rf_listen.cpp
+++ b/src/modules/rf/rf_listen.cpp
@@ -12,7 +12,7 @@ void IRAM_ATTR onPulse() {
     static bool wasHigh = false;
     unsigned long now = micros();
 
-    if (digitalRead(CC1101_GDO0_PIN)) {
+    if (digitalRead(bruceConfigPins.CC1101_bus.io0)) {
         pulseDuration = now - lastMicros;
         ___frequency = 1000000.0 / pulseDuration;
         newPulse = true;

--- a/src/modules/rf/rf_listen.cpp
+++ b/src/modules/rf/rf_listen.cpp
@@ -1,0 +1,98 @@
+#include "rf_listen.h"
+
+#include "../others/audio.h"
+
+volatile unsigned long lastMicros = 0;
+volatile unsigned long pulseMicros = 0;
+volatile float ___frequency = 0;
+volatile unsigned long pulseDuration = 0;
+volatile bool newPulse = false;
+
+void IRAM_ATTR onPulse() {
+    static bool wasHigh = false;
+    unsigned long now = micros();
+
+    if (digitalRead(CC1101_GDO0_PIN)) {
+        pulseDuration = now - lastMicros;
+        ___frequency = 1000000.0 / pulseDuration;
+        newPulse = true;
+        wasHigh = true;
+    } else if (wasHigh) {
+        lastMicros = now;
+        wasHigh = false;
+    }
+}
+
+void rf_listen() {
+    float freq = 433.92;
+    float last_freq = -1;
+    bool redraw = false;
+    while (!check(SelPress) && !check(EscPress)) {
+        if (check(PrevPress)) { freq -= 0.1f; }
+        if (check(NextPress)) { freq += 0.1f; }
+
+        freq = constrain(freq, 300.0f, 928.0f);
+        if (freq != last_freq) {
+            redraw = true;
+            last_freq = freq;
+        } else {
+            redraw = false;
+        }
+
+        if (redraw) {
+            String text = String("Frequency: ") + String(freq, 2) + String("MHz");
+            displayRedStripe(text, getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+        }
+
+        if (check(EscPress)) break;
+        if (check(SelPress)) break;
+    }
+
+    if (bruceConfig.rfModule != CC1101_SPI_MODULE) {
+        displayError("Listener needs a CC1101!", true);
+        return;
+    }
+    if (!initRfModule("rx", freq)) {
+        displayError("CC1101 not found!", true);
+        return;
+    }
+
+    ELECHOUSE_cc1101.setRxBW(58);
+    ELECHOUSE_cc1101.setModulation(2);
+    ELECHOUSE_cc1101.setDcFilterOff(true);
+    attachInterrupt(digitalPinToInterrupt(CC1101_GDO0_PIN), onPulse, CHANGE);
+    displayRedStripe("Listening...", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+
+    unsigned long lastPulseTime = millis();
+    bool pulseActive = false;
+
+    while (check(EscPress)) { delay(10); }
+
+    while (!check(EscPress)) {
+        displayRedStripe(
+            "Waiting for a pulse", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor
+        );
+        if (newPulse) {
+            newPulse = false;
+            lastPulseTime = millis();
+            pulseActive = true;
+            String pulseText = String("Freq: ") + String(___frequency, 2) + String(" Hz");
+            displayRedStripe(pulseText, getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+#if defined(BUZZ_PIN)
+            tone(BUZZ_PIN, ___frequency, pulseDuration);
+#elif defined(HAS_NS4168_SPKR)
+            playTone(___frequency, pulseDuration, 0);
+#endif
+        }
+
+        if (pulseActive && millis() - lastPulseTime > 3000) {
+            pulseActive = false;
+            displayRedStripe("No signal", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+        }
+
+        if (check(EscPress)) break;
+        if (check(SelPress)) break;
+    }
+
+    detachInterrupt(digitalPinToInterrupt(CC1101_GDO0_PIN));
+}

--- a/src/modules/rf/rf_listen.cpp
+++ b/src/modules/rf/rf_listen.cpp
@@ -94,5 +94,5 @@ void rf_listen() {
         if (check(SelPress)) break;
     }
 
-    detachInterrupt(digitalPinToInterrupt(CC1101_GDO0_PIN));
+    detachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0));
 }

--- a/src/modules/rf/rf_listen.cpp
+++ b/src/modules/rf/rf_listen.cpp
@@ -60,7 +60,7 @@ void rf_listen() {
     ELECHOUSE_cc1101.setRxBW(58);
     ELECHOUSE_cc1101.setModulation(2);
     ELECHOUSE_cc1101.setDcFilterOff(true);
-    attachInterrupt(digitalPinToInterrupt(CC1101_GDO0_PIN), onPulse, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0), onPulse, CHANGE);
     displayRedStripe("Listening...", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
 
     unsigned long lastPulseTime = millis();

--- a/src/modules/rf/rf_listen.h
+++ b/src/modules/rf/rf_listen.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "rf_utils.h"
+
+void rf_listen();

--- a/src/modules/rf/rf_listen.h
+++ b/src/modules/rf/rf_listen.h
@@ -1,5 +1,8 @@
-#pragma once
+#ifndef RF_LISTEN_H
+#define RF_LISTEN_H
 
 #include "rf_utils.h"
 
 void rf_listen();
+
+#endif


### PR DESCRIPTION
#### Proposed Changes ####

you can basically listen to the digital signals/pulses on a frequency you set, it plays those in a speaker or a buzzer

#### Types of Changes ####

new feature

#### Verification ####

rf_listener.cpp

#### Testing ####

tested on a tembed, works fine, but did not test it on a SDR because i dont have one, so i cant know if the frequency/duration it plays at are valid

#### Linked Issues ####

no issues, was bored yet again

#### User-Facing Change ####

action required

```release-note
Added listening to RF signals to subghz
```

#### Further Comments ####

https://github.com/user-attachments/assets/1848f800-612d-4071-9910-9658115655e2


