### PR TITLE
🔥 tweak webui for save and run

### DIFF
--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -211,8 +211,7 @@
       <textarea class="dialog-body file-content" style="resize: none;"></textarea>
       <div class="dialog-footer">
         <button class="btn-action act-save-edit-file" title="CTRL + S">Save</button>
-        <button class="btn-action act-save-and-run-edit-file" title="CTRL + SHIFT + S">Save & Run</button>
-        <button class="btn-action act-run-edit-file">Run</button>
+        <button class="btn-action act-run-edit-file" title="ALT + ENTER">Run</button>
         <button class="btn-action act-dialog-close">Close</button>
       </div>
     </div>

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -598,7 +598,7 @@ window.addEventListener("keydown", async (e) => {
   }
 
   if (key === "escape") {
-    if ($(".dialog-background:not(.hidden)") && $(".dialog.loading.hidden,.dialog.upload.hidden")) {
+    if ($(".dialog-background:not(.hidden)") && !$(".dialog.loading:not(.hidden),.dialog.upload:not(.hidden)")) {
       Dialog.hide();
       return;
     }

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -589,7 +589,7 @@ window.addEventListener("keydown", async (e) => {
       e.stopImmediatePropagation();
 
       await saveEditorFile();
-    } else if ((e.altKey || e.metaKey) && key === "enter") {
+    } else if (e.altKey && key === "enter") {
       e.preventDefault();
       e.stopImmediatePropagation();
 

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -380,7 +380,10 @@ $(".upload-area").ondrop = async (e) => {
     await appendDroppedFiles(entry);
   }
 
-  if (!_runningUpload) setTimeout(uploadFile, 100);
+  if (!_runningUpload) setTimeout(() =>  {
+    if (_queueUpload.length === 0) return;
+    uploadFile();
+  }, 100);
 };
 
 document.querySelectorAll(".inp-uploader").forEach((el) => {
@@ -599,6 +602,17 @@ window.addEventListener("keydown", async (e) => {
 
   if (key === "escape") {
     if ($(".dialog-background:not(.hidden)") && !$(".dialog.loading:not(.hidden),.dialog.upload:not(.hidden)")) {
+      if ($(".dialog.editor:not(.hidden)")) {
+        let ide = $(".dialog.editor .file-content");
+        let newHash = calcHash(ide.value);
+        let oldHash = ide.getAttribute("data-hash");
+        if (newHash !== oldHash) {
+          if (!confirm("You have unsaved changes. Do you want to discard them?")) {
+            return;
+          }
+        }
+      }
+
       Dialog.hide();
       return;
     }


### PR DESCRIPTION
Follow up for tweak that @emericklaw has done.
- change editor button to "Save" and "Run" instead "Save", "Run" and "Save and Run" to reduce confusion.
- saving and running combination key can be done as long as editor window open. (Previously when you focus on textarea)
- doing hash calculation to decide either file content is changed or not for saving file
- Change combination Save and Run from CTRL SHIFT S to ALT ENTER
- handle accident escape when you made some changes in editor