### PR TITLE
WebUI Dialog Improvements and Bugfix for renaming folders

### DIFF
--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -129,6 +129,12 @@ svg > g, svg > path {
     width: 100%;
     border: 0px;
     border-collapse: collapse;
+    table-layout: fixed;
+}
+.container .content .table .col-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .container .content .table .col-size {
     width: 90px;
@@ -276,4 +282,12 @@ svg > g, svg > path {
     vertical-align: center;
     display: flex;
     align-items: center;
+}
+.oinput-file-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 250px;
+    display: block;
+    float: right;
 }

--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -154,7 +154,7 @@ svg > g, svg > path {
 .table .col-action.executable .act-play {
     display: inherit;
 }
-.dialog-background {
+.dialog-foreground, .dialog-background {
     position: fixed;
     top: 0;
     left: 0;
@@ -164,6 +164,12 @@ svg > g, svg > path {
     display: flex;
     justify-content: center;
     align-items: center;
+}
+.dialog-foreground {
+    z-index: 1000;
+}
+.dialog-background {
+    z-index: 500;
 }
 .dialog {
     border: 1px solid var(--color);
@@ -194,7 +200,7 @@ svg > g, svg > path {
     border-top: 1px solid var(--color);
     text-align: right;
 }
-.dialog.loading .dialog-body {
+.dialog.status .dialog-body {
     padding: 10px 0;
     text-align: center;
 }

--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -31,10 +31,14 @@ body {
     padding: 2px 7px;
     text-decoration: none;
 }
-.btn-action:hover,
+.btn-action:hover:not(:disabled),
 .btn-action.active {
     background-color: var(--color);
     color: var(--background);
+}
+.btn-action:disabled  {
+    filter: brightness(50%);
+    cursor: not-allowed;
 }
 .icon-action {
     border: 0;

--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -151,14 +151,8 @@
       <div class="bar"></div>
     </div>
   </template>
-  <div class="dialog-background hidden">
-    <div class="dialog loading">
-      <div class="dialog-body">
-        Loading...
-      </div>
-    </div>
-    <div class="dialog upload">
-      <div class="dialog-head">Uploading</div>
+  <div class="dialog-foreground hidden">
+    <div class="dialog status">
       <div class="dialog-body"></div>
     </div>
     <div class="dialog info">
@@ -204,6 +198,8 @@
         <button class="btn-action act-dialog-close">Close</button>
       </div>
     </div>
+  </div>
+  <div class="dialog-background hidden">
     <div class="dialog editor">
       <div class="dialog-head">
         Edit: <span class="editor-file-name"></span>

--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -103,7 +103,7 @@
   <template id="t">
     <table>
       <tr class="path-row">
-        <td colspan="3">...</td>
+        <td colspan="3">..</td>
       </tr>
       <tr class="file-row">
         <td class="col-name"></td>

--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -158,12 +158,12 @@
     <div class="dialog info">
       <div class="dialog-head">Info</div>
       <div class="dialog-body">
-        Firmware for offensive pranks and pentest studies and analysis. For educational purposes only. Don't use in
-        environments where you are not allowed. All responsibilities for irresponsible usage of this firmware rest on
-        your
-        fin, sharky. Sincerely, Bruce. <br><br>
-        You can also develop page like this using my template in <a href="https://github.com/lshaf/bruce-web-interface"
-          target="_blank">https://github.com/lshaf/bruce-web-interface</a>
+        <p>Firmware for offensive pranks and pentest studies and analysis. For educational purposes only. Don't use in
+          environments where you are not allowed. All responsibilities for irresponsible usage of this firmware rest on
+          your fin, sharky.</p>
+          <p>Sincerely, Bruce.</p>
+        <p>You can also help develop the WebUI interface using <a href="https://github.com/lshaf/bruce-web-interface"
+            target="_blank">Bruce WebUI Interface</a> by <a href="https://github.com/lshaf" target="_blank">lshaf</a>.</p>
       </div>
       <div class="dialog-footer">
         <button class="btn-action act-dialog-close">Close</button>

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -311,6 +311,7 @@ function renderFileRow(fileList) {
       e.querySelector('[data-action="rename"]').setAttribute("data-action", "renameFile");
       e.querySelector(".col-name").classList.add("act-edit-file");
       e.querySelector(".col-name").textContent = name;
+      e.querySelector(".col-name").setAttribute("title", name);
       e.querySelector(".col-size").textContent = size;
       e.querySelector(".col-action").classList.add("type-file");
 
@@ -330,6 +331,7 @@ function renderFileRow(fileList) {
       e.querySelector('.file-row').setAttribute("data-path", dPath);
       e.querySelector('[data-action="rename"]').setAttribute("data-action", "renameFolder");
       e.querySelector(".col-name").textContent = name;
+      e.querySelector(".col-name").setAttribute("title", name);
       e.querySelector(".col-action").classList.add("type-folder");
     }
     $("table.explorer tbody").appendChild(e);
@@ -490,7 +492,10 @@ $(".container").addEventListener("click", async (e) => {
 
     d.setAttribute("data-cache", `${action}|${filePath}`);
     if (filePath != "") {
-      d.querySelector(".oinput-file-name").textContent = ": " + filePath.substring(filePath.lastIndexOf("/") + 1);
+      let fName = filePath.substring(filePath.lastIndexOf("/") + 1);
+      let fNameSpan = d.querySelector(".oinput-file-name");
+      fNameSpan.textContent = ": " + fName;
+      fNameSpan.setAttribute("title", fName);
     }
 
     return;

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -490,7 +490,7 @@ $(".container").addEventListener("click", async (e) => {
 
     d.setAttribute("data-cache", `${action}|${filePath}`);
     if (filePath != "") {
-      d.querySelector(".oinput-file-name").textContent = ": " + filePath;
+      d.querySelector(".oinput-file-name").textContent = ": " + filePath.substring(filePath.lastIndexOf("/") + 1);
     }
 
     return;

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -66,19 +66,23 @@ const Dialog = {
     const dbForm = {
       rename: {
         title: "Rename",
-        label: `New Filename:`
+        label: `New Filename:`,
+        action: "Rename"
       },
       createFolder: {
         title: "Create Folder",
-        label: `Folder Name:`
+        label: `Folder Name:`,
+        action: "Create Folder"
       },
       createFile: {
         title: "Create File",
-        label: `File Name:`
+        label: `File Name:`,
+        action: "Create File"
       },
       serial: {
         title: "Serial Command",
-        label: `Enter command:`
+        label: `Command:`,
+        action: "Run"
       }
     };
 
@@ -93,6 +97,7 @@ const Dialog = {
     dialog.querySelector(".oinput-title").textContent = config.title;
     dialog.querySelector(".oinput-label").textContent = config.label;
     dialog.querySelector(".oinput-file-name").textContent = "";
+    dialog.querySelector(".act-save-oinput-file").textContent = config.action;
     this.show('oinput');
     dialog.querySelector("#oinput-input").value = "";
     dialog.querySelector("#oinput-input").focus();


### PR DESCRIPTION
#### Proposed Changes ####

I have split the dialogs into foreground/background so foreground dialogs can show over the top of ones in the background like the editor. This started off with me fixing an issue where saving a file would loose the focus in the textarea, something I only noticed when making some real edits to a interpreter file.
This allows more custom status messages rather then them all saying 'loading'.

The helper function for showing a dialog with one input `showOneInput` has been modified so it uses a dialog specific action button text rather than always showing 'Save'.

To give some visual feed back the save button is now disabled/enabled depending on if any changes have been made to the file.

Fixed the renaming of folders since it was not working after the recent changes.

When renaming a file/folder the rename dialog now only shows the file/folder name rather than the full path.

Updated the info dialog to mention @lshaf rather than using 'my'.

#### Types of Changes ####

New feature and bugfix

#### Verification ####

##### Example of status message
![image](https://github.com/user-attachments/assets/4cb7e0a1-ba3f-4e10-ab28-829d72476b77)
![2025-06-12_04-02-53](https://github.com/user-attachments/assets/fab7fdfa-c0b1-46cb-aa6c-47c7d1956f5a)


##### Some of the updated one input dialogs
![image](https://github.com/user-attachments/assets/336ede1c-e5bf-4ae9-8a37-921bdc31c45c)
![image](https://github.com/user-attachments/assets/1bed3fc1-ee47-4416-89b9-766e5992e6e8)


##### Enabled/disabled save button
![image](https://github.com/user-attachments/assets/185577b9-7262-460e-aa63-7e3ff56a9a4b)
![image](https://github.com/user-attachments/assets/83ea0033-c043-4c8f-b9a7-d9c636c19d15)


##### Long file names
**Before**
![image](https://github.com/user-attachments/assets/19373ffd-0dca-46d8-921e-21a709f33a44)
![image](https://github.com/user-attachments/assets/5768bdb1-d4ab-496b-a52b-a7f8951426a6)

**After**
![image](https://github.com/user-attachments/assets/54fd6f42-a875-4891-af11-48b35da3e05f)
![image](https://github.com/user-attachments/assets/f4cb374a-c491-4f0d-a466-422dca8421b6)

#### Testing ####

Not covered.

#### Linked Issues ####

None

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Clearer status messages and dialogs
Fixed the renaming of folders
```
