### PR TITLE
FIX: sometimes CC1101 deinitialization crashes

### DIFF
--- a/src/modules/rf/rf_utils.cpp
+++ b/src/modules/rf/rf_utils.cpp
@@ -80,6 +80,7 @@ const float subghz_frequency_list[] = {
 RfCodes recent_rfcodes[16];       // TODO: save/load in EEPROM
 int recent_rfcodes_last_used = 0; // TODO: save/load in EEPROM
 bool rmtInstalled = true;
+static bool cc1101_spi_ready = false;
 
 bool initRfModule(String mode, float frequency) {
 
@@ -174,7 +175,7 @@ bool initRfModule(String mode, float frequency) {
             Serial.println("cc1101 SetRx();");
         }
         // else if mode is unspecified wont start TX/RX mode here -> done by the caller
-
+        cc1101_spi_ready = true;
     } else {
         // single-pinned module
         if (frequency != bruceConfig.rfFreq) {
@@ -199,7 +200,10 @@ bool initRfModule(String mode, float frequency) {
 
 void deinitRfModule() {
     if (bruceConfig.rfModule == CC1101_SPI_MODULE) {
-        ELECHOUSE_cc1101.setSidle();
+        if (cc1101_spi_ready) {
+            ELECHOUSE_cc1101.setSidle();
+            cc1101_spi_ready = false;
+        }
         ioExpander.turnPinOnOff(IO_EXP_CC_RX, LOW);
         ioExpander.turnPinOnOff(IO_EXP_CC_TX, LOW);
     } else digitalWrite(bruceConfig.rfTx, LED_OFF);


### PR DESCRIPTION
#### Proposed Changes ####

ive noticed that when i like spam my .sub files, or sometimes after record raw after the end, it crashes

#### Types of Changes ####

bugfix

#### Verification ####

try to send as much stuff as possible (subghz of course), and maybe try some other stuff that definetly deinitializes the cc1101 quick

#### Testing ####

tested on a tembed cc1101, dont get the crashing issue now

#### Linked Issues ####

https://github.com/pr3y/Bruce/issues/1404
also was irritated by it myself

#### User-Facing Change ####
action required
```release-note
Fixed subghz crashing issues
```

#### Further Comments ####

