### PR TITLE
📺 Navigator Screen with Canvas

### DIFF
--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -145,7 +145,7 @@ svg > g, svg > path {
     text-align: right;
 }
 .container .content .table .col-action {
-    width: 220px;
+    width: 130px;
     text-align: right;
 }
 .container .content .table tbody tr td {
@@ -178,6 +178,7 @@ svg > g, svg > path {
     display: flex;
     justify-content: center;
     align-items: center;
+    padding:  10px;
 }
 .dialog {
     border: 1px solid var(--color);
@@ -218,57 +219,56 @@ svg > g, svg > path {
     text-align: right;
 }
 .dialog.navigator {
-    width: 352px;
+    max-width: 500px;
+}
+.dialog.navigator .dialog-head {
+    display: flex;
+    justify-content: space-between;
+    padding-right: 5px;
+}
+.dialog.navigator .dialog-head select {
+    background-color: var(--background);
+    padding: 1px;
+    border: 1px solid var(--color);
+}
+.dialog.navigator .dialog-body {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap:  10px;
+}
+.dialog.navigator #navigator-screen {
+    border: 1px solid var(--color);
+    border-radius: 3px;
 }
 .dialog.navigator .navigator-canvas {
     position: relative;
     display: flex;
-    width: 100%;
-    margin-bottom: 25px;
+    flex-direction: column;
+    gap: 1px;
+    border: 1px solid var(--color);
+    border-radius: 3px;
+    /* background-color: var(--color); */
 }
 .dialog.navigator .navigator-canvas > div {
     display: flex;
-    flex-direction: column;
-    height: 90px;
-    justify-content: space-between;
+    flex-direction: row;
+    justify-content: center;
+    gap: 1px;
 }
 .dialog.navigator .navigator-canvas .nav {
-    text-align: center;
-    border: 1px solid var(--color);
-    padding: 6px 8px;
-    width: 90px;
-    cursor: pointer;
-}
-.dialog.navigator .navigator-canvas .nav:hover {
-    color: var(--background);
-    background: var(--color);
-}
-.dialog.navigator .navigator-canvas .b-center {
-    flex: 2;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-}
-.dialog.navigator .navigator-canvas .b-center .nav {
-    width: 28px;
-    height: 28px;
+    width: 38px;
+    height: 38px;
     border-radius: 3px;
     padding: 0;
     display: flex;
     align-items: center;
     justify-content: center;
+    cursor: pointer;
+    background: var(--background);
 }
-.dialog.navigator .navigator-canvas .b-center > div {
-    display: flex;
-    justify-content: center;
-}
-.dialog.navigator .navigator-canvas .b-center .p-mid {
-    justify-content: center;
-    gap: 5px;
-    margin: auto;
-}
-.dialog.navigator .navigator-canvas .b-center .nav.nav-ok:before {
+.dialog.navigator .navigator-canvas .nav.nav-ok:before {
     content: "";
     width: 16px;
     height: 16px;
@@ -276,19 +276,34 @@ svg > g, svg > path {
     background-color: var(--color);
     border-radius: 100%;
 }
-.dialog.navigator .navigator-canvas .b-center .nav.nav-down svg {
-    transform: rotate(180deg);
-}
-.dialog.navigator .navigator-canvas .b-center .nav.nav-left svg {
+.dialog.navigator .navigator-canvas .nav.nav-page-up svg {
     transform: rotate(-90deg);
 }
-.dialog.navigator .navigator-canvas .b-center .nav.nav-right svg {
+.dialog.navigator .navigator-canvas .nav.nav-page-down svg {
     transform: rotate(90deg);
 }
-.dialog.navigator .navigator-canvas .b-center .nav:hover svg path {
+.dialog.navigator .navigator-canvas .nav.nav-down svg {
+    transform: rotate(180deg);
+}
+.dialog.navigator .navigator-canvas .nav.nav-left svg {
+    transform: rotate(-90deg);
+}
+.dialog.navigator .navigator-canvas .nav.nav-right svg {
+    transform: rotate(90deg);
+}
+.dialog.navigator .navigator-canvas .nav:hover {
+    color: var(--background);
+    background: var(--color);
+}
+.dialog.navigator .navigator-canvas .nav:hover svg path,
+.dialog.navigator .navigator-canvas .nav:hover svg line {
+    color: var(--background);
     fill: var(--background);
 }
-.dialog.navigator .navigator-canvas .b-center .nav.nav-ok:hover:before {
+.dialog.navigator .navigator-canvas .nav:hover svg circle {
+    stroke: var(--background);
+}
+.dialog.navigator .navigator-canvas .nav.nav-ok:hover:before {
     background-color: var(--background);
 }
 .dialog.status .dialog-body {
@@ -387,104 +402,32 @@ svg > g, svg > path {
     text-overflow: ellipsis;
     max-width: 250px;
 }
-.navigator-screen {
-    height: 130px;
-    border: 1px solid var(--color);
-    margin-bottom: 15px;
-    position: relative;
-}
-.navigator-screen .nav-main_menu {
-    width: 100%;
-    height: 100%;
-    position: relative;
+.dialog.navigator .dialog-head div {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    gap: 5px;
 }
-.navigator-screen .nav-main_menu > div {
-    font-size: 20px;
-    font-weight: bold;
-    color: var(--sec-color);
-}
-.navigator-screen .nav-main_menu > div:nth-child(2) {
-    font-size: 28px;
-    color: var(--color);
-    position: initial;
-    text-align: center;
-    max-width: 200px;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-}
-.navigator-screen .nav-sub_menu {
-    position: relative;
-    height: 100%;
-}
-.navigator-screen .nav-sub_menu .title {
-    position: absolute;
-    left: 8px;
-    top: 5px;
-}
-.navigator-screen .nav-sub_menu .menu {
+#force-reload {
+    padding: 0;
+    height: 21px;
     display: flex;
-    flex-direction: column;
+    width: 21px;
     justify-content: center;
     align-items: center;
-    height: 100%;
-    gap: 10px;
+    border:  0;
 }
-.navigator-screen .nav-sub_menu .menu div {
-    font-size: 18px;
-    color: var(--sec-color);
+#force-reload svg path{
+    fill: var(--background);
 }
-.navigator-screen .nav-sub_menu .menu div:nth-child(2) {
-    font-size: 24px;
-    font-weight: bold;
-    color: var(--color);
+#force-reload:hover svg path{
+    fill: var(--color);
+    stroke: var(--background);
 }
-.navigator-screen .nav-regular_menu {
-    padding: 15px;
-    position: relative;
-    height: 100%;
+#force-reload.reloading svg path {
+  animation: rotation 1s linear infinite;
+  transform-origin: 50% 50%;
 }
-.navigator-screen .nav-regular_menu .box {
-    content: "";
-    border: 1px solid var(--color);
-    width: 100%;
-    height: 100%;
-    padding: 5px;
-}
-.navigator-screen .nav-regular_menu div {
-    font-size: 14px;
-    padding-left: 15px;
-    position: relative;
-}
-.navigator-screen .nav-regular_menu div.active:before {
-    content: "";
-    background-color: var(--color);
-    width: 10px;
-    height: 10px;
-    display: inline-block;
-    position: absolute;
-    border-radius: 100%;
-    top: 3px;
-    left: 0px;
-}
-.navigator-screen .loading {
-    position: absolute;
-    background-color: rgba(0,0,0,.9);
-    width: 100%;
-    height: 100%;
-    top: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-.navigator-screen .loading:before {
-    content: "Navigating....";
-}
-
-canvas {
-    border: 1px solid var(--color);
-    image-rendering: auto;
+@keyframes rotation {
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -180,6 +180,7 @@
           <li>Page Up = Page Up</li>
           <li>Page Down = Page Down</li>
           <li>Close Navigator = Escape</li>
+          <li>Reload Screen = R</li>
         </ul>
       </div>
       <div class="dialog-footer">

--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -187,67 +187,84 @@
       </div>
     </div>
     <div class="dialog navigator">
-      <div class="dialog-head">Device Navigator</div>
-      <div class="dialog-body" align="center">
-        <canvas id="display_screen"></canvas>
-        <div class="navigator-screen">
-          <div class="screen hidden nav-main_menu">
-          </div>
-          <div class="screen hidden nav-sub_menu">
-            <div class="title"></div>
-            <div class="menu"></div>
-          </div>
-          <div class="screen hidden nav-regular_menu">
-            <div class="box"></div>
-          </div>
-          <div class="screen loading hidden"></div>
+      <div class="dialog-head">
+        <span>Device Navigator</span>
+        <div>
+          <button id="force-reload" class="btn-action">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24">
+              <path d="M21 12C21 16.9706 16.9706 21 12 21C9.69494 21 7.59227 20.1334 6 18.7083L3 16M3 12C3 7.02944 7.02944 3 12 3C14.3051 3 16.4077 3.86656 18 5.29168L21 8M3 21V16M3 16H8M21 3V8M21 8H16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
+          <select id="navigator-auto-reload">
+            <option value="0">Reload After Navigate</option>
+            <option value="1000">Auto Reload: 1s</option>
+            <option value="2000">Auto Reload: 2s</option>
+            <option value="5000">Auto Reload: 5s</option>
+            <option value="10000">Auto Reload: 10s</option>
+          </select>
         </div>
+      </div>
+      <div class="dialog-body">
+        <canvas id="navigator-screen"></canvas>
         <div class="navigator-canvas">
-          <div class="b-left">
-            <div class="nav" data-direction="NextPage">Page Up</div>
-            <div class="nav" data-direction="PrevPage">Page Down</div>
-          </div>
-          <div class="b-center">
-            <div class="p-up">
-              <div class="nav nav-up" data-direction="Up">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 512 512">
-                  <path fill="currentColor" d="M256 63.6L0 319.6l69.8 69.8L256 203.2l186.2 186.2l69.8-69.8z" />
-                </svg>
-              </div>
+          <div class="p-up">
+            <div class="nav nav-page-up" data-direction="NextPage" title="Next Page">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M15.5 12L5.72222 19.1111L5.72222 4.88889L15.5 12Z" stroke="currentColor" stroke-width="1.77778" stroke-linecap="round" stroke-linejoin="round"/>
+                <line x1="18.1667" y1="4.88889" x2="18.1667" y2="19.1111" stroke="currentColor" stroke-width="1.77778" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
             </div>
-            <div class="p-mid">
-              <div class="nav nav-left" data-direction="Prev">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 512 512">
-                  <path fill="currentColor" d="M256 63.6L0 319.6l69.8 69.8L256 203.2l186.2 186.2l69.8-69.8z" />
-                </svg>
-              </div>
-              <div class="nav nav-ok" data-direction="Sel"></div>
-              <div class="nav nav-right" data-direction="Next">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 512 512">
-                  <path fill="currentColor" d="M256 63.6L0 319.6l69.8 69.8L256 203.2l186.2 186.2l69.8-69.8z" />
-                </svg>
-              </div>
+            <div class="nav nav-up" data-direction="Up" title="Up">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 52 52">
+                <path fill="currentColor" d="M43.7,38H8.3c-1,0-1.7-1.3-0.9-2.2l17.3-21.2c0.6-0.8,1.9-0.8,2.5,0l17.5,21.2C45.4,36.7,44.8,38,43.7,38z" />
+              </svg>
             </div>
-            <div class="p-bot">
-              <div class="nav nav-down" data-direction="Down">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 512 512">
-                  <path fill="currentColor" d="M256 63.6L0 319.6l69.8 69.8L256 203.2l186.2 186.2l69.8-69.8z" />
-                </svg>
-              </div>
+            <div class="nav nav-menu" data-direction="Menu" title="Long Press">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 256 256">
+                <circle stroke="currentColor" style="fill:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path822" cx="128" cy="128" r="40"/>
+                <circle stroke="currentColor" style="fill:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path823" cx="128" cy="128" r="112"/>
+              </svg>
             </div>
           </div>
-          <div class="b-right">
-            <div class="nav" data-direction="Menu">Long Press</div>
-            <div class="nav" data-direction="Esc">Back</div>
+          <div class="p-mid">
+            <div class="nav nav-left" data-direction="Prev" title="Left">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 52 52">
+                <path fill="currentColor" d="M43.7,38H8.3c-1,0-1.7-1.3-0.9-2.2l17.3-21.2c0.6-0.8,1.9-0.8,2.5,0l17.5,21.2C45.4,36.7,44.8,38,43.7,38z" />
+              </svg>
+            </div>
+            <div class="nav nav-ok" data-direction="Sel" title="Select/OK"></div>
+            <div class="nav nav-right" data-direction="Next" title="Right">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 52 52">
+                <path fill="currentColor" d="M43.7,38H8.3c-1,0-1.7-1.3-0.9-2.2l17.3-21.2c0.6-0.8,1.9-0.8,2.5,0l17.5,21.2C45.4,36.7,44.8,38,43.7,38z" />
+              </svg>
+            </div>
+          </div>
+          <div class="p-bot">
+            <div class="nav nav-page-down" data-direction="PrevPage" title="Previous Page">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M15.5 12L5.72222 19.1111L5.72222 4.88889L15.5 12Z" stroke="currentColor" stroke-width="1.77778" stroke-linecap="round" stroke-linejoin="round"/>
+                <line x1="18.1667" y1="4.88889" x2="18.1667" y2="19.1111" stroke="currentColor" stroke-width="1.77778" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+            <div class="nav nav-down" data-direction="Down" title="Down">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 52 52">
+                <path fill="currentColor" d="M43.7,38H8.3c-1,0-1.7-1.3-0.9-2.2l17.3-21.2c0.6-0.8,1.9-0.8,2.5,0l17.5,21.2C45.4,36.7,44.8,38,43.7,38z" />
+              </svg>
+            </div>
+            <div class="nav" data-direction="Esc" title="Back">
+              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18"
+                height="18" viewBox="0 0 24 24" version="1.1">
+                <path d="M3.07615,5.61732 C3.23093,5.24364 3.59557,5 4.00003,5 L13.9999996,5 C17.866,5 20.9999996,8.13401 20.9999996,12 C20.9999996,15.866 17.866,19 13.9999996,19 L5.00003,19 C4.44774,19 4.00003,18.5523 4.00003,18 C4.00003,17.4477 4.44774,17 5.00003,17 L13.9999996,17 C16.7615,17 18.9999996,14.7614 18.9999996,12 C18.9999996,9.23858 16.7615,7 13.9999996,7 L6.41424,7 L8.20714,8.79289 C8.59766,9.18342 8.59766,9.81658 8.20714,10.2071 C7.81661,10.5976 7.18345,10.5976 6.79292,10.2071 L3.29292,6.70711 C3.00692,6.42111 2.92137,5.99099 3.07615,5.61732 Z"
+                  fill="currentColor">
+                </path>
+              </svg>
+            </div>
           </div>
         </div>
-        <p class="info">
-          You can control your device screen using the navigator.
-        </p>
       </div>
       <div class="dialog-footer">
         <button class="btn-action" onclick="Dialog.show('navigator-shortcut')">Shortcut</button>
-        <button class="btn-action act-dialog-close act-escape act-stop-screen">Close</button>
+        <button class="btn-action act-dialog-close act-escape">Close</button>
       </div>
     </div>
     <div class="dialog info">

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -1,5 +1,4 @@
 function $(s) { return document.querySelector(s) }
-function _(e) { return document.getElementById(e); }
 const IS_DEV = (window.location.host === "127.0.0.1:8080");
 const T = {
   master: $('#t'),
@@ -394,71 +393,314 @@ function isModified(target) {
   return oldHash !== newHash;
 }
 
+async function openNavigator() {
+  Dialog.show('navigator');
+  await reloadScreen();
+  autoReloadScreen();
+}
+
+let SCREEN_NAVIGATING = false;
 async function runNavigation(direction) {
-  const screen = $(".navigator-screen");
-
-  screen.querySelector(".loading").classList.remove("hidden");
+  if (SCREEN_NAVIGATING) return;
+  SCREEN_NAVIGATING = true;
   try {
-    let r = await requestPost("/cm", { cmnd: `nav ${direction.toLowerCase()}` });
-    let d = JSON.parse(r);
-
-    screen.querySelector(".screen:not(.hidden)").classList.add("hidden");
-    let navScreen = screen.querySelector(`.nav-${d.menu}`);
-    navScreen.classList.remove("hidden");
-
-    let prevIndex = d.active - 1;
-    if (prevIndex < 0) prevIndex = d.options.length - 1;
-    let nextIndex = d.active + 1;
-    if (nextIndex >= d.options.length) nextIndex = 0;
-
-    if (d.menu === "main_menu") {
-      navScreen.innerHTML = "";
-      for (let i of [prevIndex, d.active, nextIndex]) {
-        let item = d.options[i];
-        let label = item.label;
-        if (i === prevIndex) label = label.substring(label.length - 3);
-        if (i === nextIndex) label = label.substring(0, 3);
-        let itemEl = document.createElement("div");
-        itemEl.textContent = label;
-        navScreen.appendChild(itemEl);
-      }
-    } else if (d.menu === "sub_menu") {
-      navScreen.querySelector(".title").textContent = d.menu_title;
-      navScreen.querySelector(".menu").innerHTML = "";
-      for (let i of [prevIndex, d.active, nextIndex]) {
-        let item = d.options[i];
-        let itemEl = document.createElement("div");
-        itemEl.textContent = item.label;
-        navScreen.querySelector(".menu").appendChild(itemEl);
-      }
-    } else if (d.menu === "regular_menu") {
-      let startIndex = 0;
-      if (d.active > 4) startIndex = d.active - 4;
-      navScreen.querySelector(".box").innerHTML = "";
-      for (let i = startIndex; i < d.options.length && i < startIndex + 5; i++) {
-        let item = d.options[i];
-        let itemEl = document.createElement("div");
-        itemEl.textContent = item.label;
-        if (i == d.active) itemEl.classList.add("active");
-        navScreen.querySelector(".box").appendChild(itemEl);
-      }
-    }
+    drawCanvasLoading();
+    await requestPost("/cm", { cmnd: `nav ${direction.toLowerCase()}` });
+    await reloadScreen();
   } catch (error) {
     alert("Failed to run command: " + error.message);
     console.error(error)
   } finally {
-    screen.querySelector(".loading").classList.add("hidden");
+    SCREEN_NAVIGATING = false;
   }
-  getScreen();
 }
 
-async function openNavigator() {
-  Dialog.show('navigator');
-  control = 1;
-  await runNavigation("Esc");
-  // Start Screen update
-  screenInterval = setInterval(getScreen, 1000);
+const btnForceReload = $("#force-reload");
+let SCREEN_RELOAD = false;
+async function reloadScreen() {
+  if (SCREEN_RELOAD) return;
+  SCREEN_RELOAD = true;
+  btnForceReload.classList.add("reloading");
+  try {
+    let screenReq = await requestGet("/getscreen");
+    let screenData = JSON.parse(screenReq);
+    await renderTFT(screenData);
+  } catch (error) {
+    console.error("Failed to reload screen:", error);
+    alert("Failed to reload screen: " + error.message);
+  } finally {
+    btnForceReload.classList.remove("reloading");
+    SCREEN_RELOAD = false;
+  }
 }
+
+const eConfigAutoReload = $("#navigator-auto-reload");
+let AUTO_RELOAD_SCREEN = null;
+async function taskReloader() {
+  let timer = parseInt(eConfigAutoReload.value);
+  let navigatorOpen = $(".dialog.navigator:not(.hidden)");
+  if (timer <= 0 || !navigatorOpen) {
+    if (AUTO_RELOAD_SCREEN) {
+      clearTimeout(AUTO_RELOAD_SCREEN);
+      AUTO_RELOAD_SCREEN = null;
+    }
+
+    return;
+  }
+
+
+  await reloadScreen();
+  setTimeout(taskReloader, timer);
+  // better use setTimeout instead of setInterval to avoid overlapping calls
+}
+async function autoReloadScreen() {
+  let timer = parseInt(eConfigAutoReload.value);
+
+  if (AUTO_RELOAD_SCREEN) {
+    clearTimeout(AUTO_RELOAD_SCREEN);
+    AUTO_RELOAD_SCREEN = null;
+  }
+
+  if (timer > 0) taskReloader();
+}
+
+/// TFT RENDER
+let loadingDrawn = false;
+const imageCache = {}; // global
+async function renderTFT(data) {
+  loadingDrawn = false;
+  const canvas = $("#navigator-screen");
+  const ctx = canvas.getContext("2d");
+
+  const loadImage = async (url) => {
+    if (imageCache[url]) return imageCache[url];
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => {
+        imageCache[url] = img;
+        resolve(img);
+      };
+      img.onerror = (err) => reject(err);
+      img.src = url;
+    });
+  }
+
+  const drawImageCached = async (img_url, input) => {
+    let img = await loadImage(img_url);
+    let drawX = input.x;
+    let drawY = input.y;
+
+    if (input.center === 1) {
+      drawX += (canvas.width-img.width) / 2;
+      drawY += (canvas.height-img.height) / 2;
+    }
+    ctx.drawImage(img, drawX, drawY);
+  }
+
+  const color565toCSS = (color565) => {
+    const r = ((color565 >> 11) & 0x1F) * 255 / 31;
+    const g = ((color565 >> 5) & 0x3F) * 255 / 63;
+    const b = (color565 & 0x1F) * 255 / 31;
+    return `rgb(${r},${g},${b})`;
+  };
+
+  const drawRoundRect = (ctx, input, fill) => {
+    const { x, y, w, h, r } = input;
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+    if (fill) ctx.fill(); else ctx.stroke();
+  };
+
+  for (const { fn, in: input } of data) {
+    ctx.beginPath();
+
+    switch (fn) {
+      case 99: // SCREEN_INFO
+        canvas.width=input.width;
+        canvas.height=input.height;
+      case 0: // FILLSCREEN
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        break;
+
+      case 1: // DRAWRECT
+        ctx.strokeStyle = color565toCSS(input.fg);
+        ctx.strokeRect(input.x, input.y, input.w, input.h);
+        break;
+
+      case 2: // FILLRECT
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.fillRect(input.x, input.y, input.w, input.h);
+        break;
+
+      case 3: // DRAWROUNDRECT
+        ctx.strokeStyle = color565toCSS(input.fg);
+        drawRoundRect(ctx, input, false);
+        break;
+
+      case 4: // FILLROUNDRECT
+        ctx.fillStyle = color565toCSS(input.fg);
+        drawRoundRect(ctx, input, true);
+        break;
+
+      case 5: // DRAWCIRCLE
+        ctx.strokeStyle = color565toCSS(input.fg);
+        ctx.arc(input.x, input.y, input.r, 0, Math.PI * 2);
+        ctx.stroke();
+        break;
+
+      case 6: // FILLCIRCLE
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.arc(input.x, input.y, input.r, 0, Math.PI * 2);
+        ctx.fill();
+        break;
+      case 7: // DRAWTRIANGLE
+        ctx.strokeStyle = color565toCSS(input.fg);
+        ctx.beginPath();
+        ctx.moveTo(input.x, input.y);
+        ctx.lineTo(input.x2, input.y2);
+        ctx.lineTo(input.x3, input.y3);
+        ctx.closePath();
+        ctx.stroke();
+        break;
+
+      case 8: // FILLTRIANGLE
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.beginPath();
+        ctx.moveTo(input.x, input.y);
+        ctx.lineTo(input.x2, input.y2);
+        ctx.lineTo(input.x3, input.y3);
+        ctx.closePath();
+        ctx.fill();
+        break;
+      case 9: // DRAWELLIPSE
+        ctx.strokeStyle = color565toCSS(input.fg);
+        ctx.beginPath();
+        ctx.ellipse(input.x, input.y, input.rx, input.ry, 0, 0, Math.PI * 2);
+        ctx.stroke();
+        break;
+
+      case 10: // FILLELLIPSE
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.beginPath();
+        ctx.ellipse(input.x, input.y, input.rx, input.ry, 0, 0, Math.PI * 2);
+        ctx.fill();
+        break;
+
+      case 11: // DRAWLINE
+        ctx.strokeStyle = color565toCSS(input.fg);
+        ctx.moveTo(input.x, input.y);
+        ctx.lineTo(input.x1, input.y1);
+        ctx.stroke();
+        break;
+
+      case 12: // DRAWARC
+        ctx.strokeStyle = color565toCSS(input.fg);
+        ctx.lineWidth = (input.r - input.ir) || 1;
+        const sa = (input.startAngle + 90 || 0) * Math.PI / 180;
+        const ea = (input.endAngle + 90 || 0) * Math.PI / 180;
+        const radius = (input.r + input.ir) / 2;
+        ctx.beginPath();
+        ctx.arc(input.x, input.y, radius, sa, ea);
+        ctx.stroke();
+        break;
+
+      case 13: // DRAWWIDELINE
+        ctx.strokeStyle = color565toCSS(input.fg);
+        ctx.lineWidth = input.wd || 1;
+        ctx.moveTo(input.x, input.y);
+        ctx.lineTo(input.bx, input.by);
+        ctx.stroke();
+        break;
+
+      case 14: // DRAWCENTRESTRING
+      case 15: // DRAWRIGHTSTRING
+      case 16: // DRAWSTRING
+      case 17: // PRINT
+        // This must be enhanced to make font width be multiple of 6px, the font used here is multiple of 4.5px,
+        // "\n" are not treated, and long lines do not split into multi lines..
+        if(input.bg == input.fg) { input.bg = 0; }
+        ctx.fillStyle = color565toCSS(input.bg);
+
+        input.txt = input.txt.replaceAll("\\n", ""); // remove new lines
+        var fw = input.size===3 ? 13.5 : input.size===2 ? 9 : 4.5;
+        var o = 0;
+        if(fn === 15) o = input.txt.length * fw;
+        if(fn === 14) o = input.txt.length * fw/2;
+        // draw a rectangle at the text area, to avoid overlapping texts
+        ctx.fillRect(input.x-o, input.y, input.txt.length * fw, input.size * 8);
+
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.font = `${input.size * 8}px monospace`;
+        ctx.textBaseline = "top";
+        ctx.textAlign = fn === 14 ? "center" : fn === 15 ? "right" : "left";
+        ctx.fillText(input.txt, input.x, input.y);
+      break;
+
+      case 18: // DRAWIMAGE
+        let url = `/file?fs=${input.fs}&name=${encodeURIComponent(input.file)}&action=image`;
+        if (IS_DEV) url = "/bruce" + url;
+        await drawImageCached(url, input);
+      break;
+
+      case 19: // DRAWPIXEL
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.fillRect(input.x, input.y, 1, 1);
+        break;
+      case 20: // DRAWFASTVLINE
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.fillRect(input.x, input.y, 1, input.h);
+        break;
+
+      case 21: // DRAWFASTHLINE
+        ctx.fillStyle = color565toCSS(input.fg);
+        ctx.fillRect(input.x, input.y, input.w, 1);
+        break;
+    }
+  }
+}
+function drawCanvasLoading() {
+  if (loadingDrawn) return;
+  loadingDrawn = true;
+  const canvas = $("#navigator-screen");
+  const ctx = canvas.getContext("2d");
+  const width = canvas.width;
+  const height = canvas.height;
+
+  // Draw semi-transparent black background
+  ctx.save();
+  ctx.globalAlpha = 0.8;
+  ctx.fillStyle = "#000";
+  ctx.fillRect(0, 0, width, height);
+  ctx.globalAlpha = 1.0;
+
+  // Draw "Loading" text in the center
+  ctx.fillStyle = "#fff";
+  ctx.font = "bold 14px 'DejaVu Sans Mono', Consolas, Menlo";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("Navigating...", width / 2, height / 2);
+  ctx.restore();
+}
+
+let oldTimerSession = sessionStorage.getItem("autoReload") || "0";
+eConfigAutoReload.querySelector(`option[value="${oldTimerSession}"]`).selected = true;
+eConfigAutoReload.addEventListener("change", async (e) => {
+  e.preventDefault();
+  autoReloadScreen();
+  sessionStorage.setItem("autoReload", eConfigAutoReload.value);
+});
+
+btnForceReload.addEventListener("click", async (e) => {
+  e.preventDefault();
+  drawCanvasLoading();
+  await reloadScreen();
+});
 
 window.ondragenter = () => $(".upload-area").classList.remove("hidden");
 $(".upload-area").ondragleave = () => $(".upload-area").classList.add("hidden");
@@ -697,7 +939,7 @@ $(".navigator-canvas").addEventListener("click", async (e) => {
 
   let direction = nav.getAttribute("data-direction");
   if (direction === "Menu") {
-    direction = "Sel 820";
+    direction = "Sel 500";
   }
 
   await runNavigation(direction.toLowerCase());
@@ -786,302 +1028,4 @@ $(".file-content").addEventListener("keyup", function (e) {
 (async function () {
   await fetchSystemInfo();
   await fetchFiles("LittleFS", "/");
-  await fetchAndCacheTheme();
 })();
-
-var control = 0;
-$(".act-stop-screen").addEventListener("click", async (e) => {
-    // Stops loop interval
-    if (screenInterval !== null) {
-      clearInterval(screenInterval);
-      screenInterval = null;
-    }
-    control = 0;
-});
-
-/// TFT RENDER
-const imageCache = {}; // global
-
-function renderTFT(data, canvasId) {
-  console.log("drawing...");
-  const canvas = _(canvasId);
-  const ctx = canvas.getContext("2d");
-
-  const drawImageCached = (img, input) => {
-    let drawX = input.x;
-    let drawY = input.y;
-
-    if (input.center === 1) {
-      drawX += (_("display_screen").width-img.width) / 2;
-      drawY += (_("display_screen").height-img.height) / 2;
-    }
-    ctx.drawImage(img, drawX, drawY);
-  }
-
-  const color565toCSS = (color565) => {
-    const r = ((color565 >> 11) & 0x1F) * 255 / 31;
-    const g = ((color565 >> 5) & 0x3F) * 255 / 63;
-    const b = (color565 & 0x1F) * 255 / 31;
-    return `rgb(${r},${g},${b})`;
-  };
-
-  const drawRoundRect = (ctx, input, fill) => {
-    const { x, y, w, h, r } = input;
-    ctx.beginPath();
-    ctx.moveTo(x + r, y);
-    ctx.arcTo(x + w, y, x + w, y + h, r);
-    ctx.arcTo(x + w, y + h, x, y + h, r);
-    ctx.arcTo(x, y + h, x, y, r);
-    ctx.arcTo(x, y, x + w, y, r);
-    ctx.closePath();
-    if (fill) ctx.fill(); else ctx.stroke();
-  };
-
-  for (const { fn, in: input } of data) {
-    ctx.beginPath();
-
-    switch (fn) {
-      case 99: // SCREEN_INFO
-        if (control === 1) {
-          // {"fn":99, "in":{"width":240,"height":135,"rotation":1}
-          _("display_screen").width=input.width;
-          _("display_screen").height=input.height;
-          control = 2;
-        }
-      case 0: // FILLSCREEN
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        break;
-
-      case 1: // DRAWRECT
-        ctx.strokeStyle = color565toCSS(input.fg);
-        ctx.strokeRect(input.x, input.y, input.w, input.h);
-        break;
-
-      case 2: // FILLRECT
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.fillRect(input.x, input.y, input.w, input.h);
-        break;
-
-      case 3: // DRAWROUNDRECT
-        ctx.strokeStyle = color565toCSS(input.fg);
-        drawRoundRect(ctx, input, false);
-        break;
-
-      case 4: // FILLROUNDRECT
-        ctx.fillStyle = color565toCSS(input.fg);
-        drawRoundRect(ctx, input, true);
-        break;
-
-      case 5: // DRAWCIRCLE
-        ctx.strokeStyle = color565toCSS(input.fg);
-        ctx.arc(input.x, input.y, input.r, 0, Math.PI * 2);
-        ctx.stroke();
-        break;
-
-      case 6: // FILLCIRCLE
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.arc(input.x, input.y, input.r, 0, Math.PI * 2);
-        ctx.fill();
-        break;
-      case 7: // DRAWTRIANGLE
-        ctx.strokeStyle = color565toCSS(input.fg);
-        ctx.beginPath();
-        ctx.moveTo(input.x, input.y);
-        ctx.lineTo(input.x2, input.y2);
-        ctx.lineTo(input.x3, input.y3);
-        ctx.closePath();
-        ctx.stroke();
-        break;
-
-      case 8: // FILLTRIANGLE
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.beginPath();
-        ctx.moveTo(input.x, input.y);
-        ctx.lineTo(input.x2, input.y2);
-        ctx.lineTo(input.x3, input.y3);
-        ctx.closePath();
-        ctx.fill();
-        break;
-      case 9: // DRAWELLIPSE
-        ctx.strokeStyle = color565toCSS(input.fg);
-        ctx.beginPath();
-        ctx.ellipse(input.x, input.y, input.rx, input.ry, 0, 0, Math.PI * 2);
-        ctx.stroke();
-        break;
-
-      case 10: // FILLELLIPSE
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.beginPath();
-        ctx.ellipse(input.x, input.y, input.rx, input.ry, 0, 0, Math.PI * 2);
-        ctx.fill();
-        break;
-
-      case 11: // DRAWLINE
-        ctx.strokeStyle = color565toCSS(input.fg);
-        ctx.moveTo(input.x, input.y);
-        ctx.lineTo(input.x1, input.y1);
-        ctx.stroke();
-        break;
-
-      case 12: // DRAWARC
-        ctx.strokeStyle = color565toCSS(input.fg);
-        ctx.lineWidth = (input.r - input.ir) || 1;
-        const sa = (input.startAngle + 90 || 0) * Math.PI / 180;
-        const ea = (input.endAngle + 90 || 0) * Math.PI / 180;
-        const radius = (input.r + input.ir) / 2;
-        ctx.beginPath();
-        ctx.arc(input.x, input.y, radius, sa, ea);
-        ctx.stroke();
-        break;
-
-      case 13: // DRAWWIDELINE
-        ctx.strokeStyle = color565toCSS(input.fg);
-        ctx.lineWidth = input.wd || 1;
-        ctx.moveTo(input.x, input.y);
-        ctx.lineTo(input.bx, input.by);
-        ctx.stroke();
-        break;
-
-      case 14: // DRAWCENTRESTRING
-      case 15: // DRAWRIGHTSTRING
-      case 16: // DRAWSTRING
-      case 17: // PRINT
-        // This must be enhanced to make font width be multiple of 6px, the font used here is multiple of 4.5px,
-        // "\n" are not treated, and long lines do not split into multi lines..
-        if(input.bg == input.fg) { input.bg = 0; }
-        ctx.fillStyle = color565toCSS(input.bg);
-
-        var fw = input.size===3 ? 13.5 : input.size===2 ? 9 : 4.5;
-        var o = 0;
-        if(fn === 15) o = input.txt.length * fw;
-        if(fn === 14) o = input.txt.length * fw/2;
-        // draw a rectangle at the text area, to avoid overlapping texts
-        ctx.fillRect(input.x-o, input.y, input.txt.length * fw, input.size * 8);
-
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.font = `${input.size * 8}px monospace`;
-        ctx.textBaseline = "top";
-        ctx.textAlign = fn === 14 ? "center" : fn === 15 ? "right" : "left";
-        ctx.fillText(input.txt, input.x, input.y);
-      break;
-
-      case 18: // DRAWIMAGE
-        const baseUrl = "/file/" + input.fs;
-        const url = `${baseUrl}${input.file}`;
-        console.log(url);
-
-        // já está no cache?
-        if (imageCache[url]) {
-          drawImageCached(imageCache[url], input);
-            console.log("Img from Cache");
-        } else {
-          const img = new Image();
-          img.onload = () => {
-            imageCache[url] = img;
-            drawImageCached(img, input);
-          };
-          img.onerror = (e) => console.warn("Erro ao carregar imagem:", url, e);
-          img.src = url;
-            console.log("Downladed image");
-        }
-      break;
-
-      case 19: // DRAWPIXEL
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.fillRect(input.x, input.y, 1, 1);
-        break;
-      case 20: // DRAWFASTVLINE
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.fillRect(input.x, input.y, 1, input.h);
-        break;
-
-      case 21: // DRAWFASTHLINE
-        ctx.fillStyle = color565toCSS(input.fg);
-        ctx.fillRect(input.x, input.y, input.w, 1);
-        break;
-      }
-    }
-}
-var _screen;
-function getScreen() {
-  if (control === 0) return;
-  let realUrl = "/getscreen";
-  let req = new XMLHttpRequest();
-  req.open("GET", realUrl, true);
-
-  req.onload = () => {
-    if (req.status >= 200 && req.status < 300) {
-      try {
-        const screen_data = JSON.parse(req.responseText);
-        const newScreenStr = JSON.stringify(screen_data);
-        if (_screen === newScreenStr) return;
-        _screen = newScreenStr;
-        renderTFT(screen_data, "display_screen");
-      } catch (err) {
-      console.warn("Erro ao interpretar JSON:", err);
-      }
-    }
-  };
-
-  req.onerror = () => {
-    console.warn("Erro de rede.");
-  };
-  req.send();
-}
-
-async function fetchAndCacheTheme() {
-  try {
-    const res = await fetch("/gettheme");
-
-    if (!res.ok || res.status === 204) {
-      console.log("Theme not available.");
-      return;
-    }
-
-    const theme = await res.json();
-
-    // Read _fs and _path fields
-    const fs = theme._fs;
-    const path = theme._path;
-
-    if (!fs || !path) {
-      console.warn("_fs or _path not available.");
-      return;
-    }
-
-    const validExtensions = [".png", ".jpg", ".bmp"];
-
-    const entries = Object.entries(theme);
-    for (const [key, value] of entries) {
-      if (typeof value === "string" && validExtensions.some(ext => value.endsWith(ext))) {
-        const url = `/file/${fs}${path}${value}`;
-        console.log(url);
-
-        if (imageCache[url]) continue; // already cached
-
-        const img = new Image();
-        img.src = url;
-
-        // awaits loading into cache
-        await new Promise((resolve, reject) => {
-          img.onload = () => {
-            imageCache[url] = img;
-            resolve();
-          };
-          img.onerror = () => {
-            console.warn("Error loading image:", url);
-            resolve(); // ignores error and continue
-          };
-        });
-      }
-    }
-
-    console.log("Images loaded to cache successfully.");
-
-  } catch (err) {
-    console.error("Error fetching theme:", err);
-  }
-}
-
-

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -971,8 +971,15 @@ window.addEventListener("keydown", async (e) => {
       "backspace": "Esc",
       "m": "Menu",
       "pageup": "NextPage",
-      "pagedown": "PrevPage"
+      "pagedown": "PrevPage",
     };
+
+    if (key === 'r') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      reloadScreen();
+      return;
+    }
 
     if (key in map_navigator) {
       e.preventDefault();


### PR DESCRIPTION
- comment getoptions (merged with cm when doing nav command)
- comment file/lfs, file/sd (instead giving static to all folder, I add action image on /file endpoint)
- gettheme endpoint (it's not necessary when you load image on the fly, upon access menu and cached in frontend)
- add "image" action in /file endpoint to get the image for canvas (explained above)
- adjust code navigator screen to canvas
- add auto reload interval option (saved interval in browser session)
- Overhaul the buttons (I will try overhaul this again, adding select box for main-menu and sub-menu)