### PR TITLE
Configurable keyboard shortcuts from main menu (#924), loader serial cmd and some fixes

### DIFF
--- a/sd_files/interpreter/ir_brute.js
+++ b/sd_files/interpreter/ir_brute.js
@@ -24,10 +24,11 @@ function brute_force() {
         // example full cmd: IRSend {"Protocol":"NEC","Bits":32,"Data":"0x20DF10EF"}
         //serialCmd("IRSend {'Protocol':'" + protocol + "','Bits':32,'Data':'" + curr_val + "'}");
 
-        irTransmit(curr_val, protocol, 32);
-
+        
+        var r = irTransmit(curr_val, protocol, 32);
+        if(!r) drawString("ERROR: check serial log", 3 , 64);
+        
         delay(delay_ms);
-        fillScreen(0);
     }
 }
 

--- a/sd_files/interpreter/rf_brute.js
+++ b/sd_files/interpreter/rf_brute.js
@@ -26,9 +26,12 @@ function brute_force() {
         // example full cmd: "subghz tx 445533 433920000 174 10"
         //serialCmd("subghz tx " + curr_val + " " + freq + " 174 10");
 
-        subghzTransmit(curr_val, freq, 174, 10);
+        
+        var r = subghzTransmit(curr_val, freq, 174, 10);
         // TODO: customize te=174  count=10
 
+        if(!r) drawString("ERROR: check serial log", 3 , 64);
+        
         delay(delay_ms);
     }
 }

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -584,6 +584,7 @@ int loopOptions(
             index = -1;
             break;
         }
+        /* DISABLED: may conflict with custom shortcuts
         int pressed_number = checkNumberShortcutPress();
         if (pressed_number >= 0) {
             if (index == pressed_number) {
@@ -595,7 +596,7 @@ int loopOptions(
             index = pressed_number;
             if ((index + 1) > options.size()) index = options.size() - 1;
             redraw = true;
-        }
+        }*/
 
 #elif defined(T_EMBED) || defined(HAS_TOUCH) || !defined(HAS_SCREEN)
         if (menuType != MENU_TYPE_MAIN && check(EscPress)) break;

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -1,11 +1,11 @@
 #include "mykeyboard.h"
 #include "core/wifi/webInterface.h"
-#include "modules/badusb_ble/ducky_typer.h"
 #include "modules/ir/TV-B-Gone.h"
 #include "modules/ir/custom_ir.h"
 #include "modules/rf/rf_send.h"
 #include "powerSave.h"
 #include "sd_functions.h"
+#include <ArduinoJson.h>
 
 #if defined(HAS_TOUCH)
 struct box_t {
@@ -56,45 +56,57 @@ keyStroke _getKeyPress() {
 #endif
 } // must return something that the keyboards won´t recognize by default
 
+
 /*********************************************************************
 ** Function: checkShortcutPress
 ** location: mykeyboard.cpp
 ** runs a function called by the shortcut action
 **********************************************************************/
 void checkShortcutPress() {
-    // shortctus to quickly starts apps
+    static StaticJsonDocument<512> shortcutsJson;  // parsed only once
+    
+    // lazy init
+    if(shortcutsJson.size() == 0) {
+        FS *fs;
+        if (!getFsStorage(fs)) return;
+        File file = fs->open("/shortcuts.json", FILE_READ);
+		if (!file) {
+			log_e("Shortcuts Config file not found. Using default values");
+            JsonObject shortcuts = shortcutsJson.to<JsonObject>();  // root
+            shortcuts["i"] = "loader open ir";
+            shortcuts["r"] = "loader open rf";
+            shortcuts["s"] = "loader open rf";
+            shortcuts["b"] = "loader open badusb";
+            shortcuts["w"] = "loader open webui";
+            shortcuts["f"] = "loader open files";
+			return;
+		}
+		// else
+		if (deserializeJson(shortcutsJson, file)) {
+			log_e("Failed to parse shortcuts.json");
+            file.close();
+			return;
+		}
+		file.close();
+    }
+    
     keyStroke key = _getKeyPress();
-    if (key.pressed) {
+    
+    // parse shortcutsJson and check the keys
+    for (JsonPair kv : shortcutsJson.as<JsonObject>()) {
+        const char* shortcut_key = kv.key().c_str();
+        const char* shortcut_value = kv.value().as<const char*>();
+        
+        // check for matching keys
         for (auto i : key.word) {
-            if (i == 'i') {
-                otherIRcodes();
-                returnToMenu = true;
-            }
-            if (i == 'r' || i == 's') {
-                sendCustomRF();
-                returnToMenu = true;
-            }
-            if (i == 'b') {
-                ducky_setup(hid_usb, false);
-                returnToMenu = true;
-            } // badusb
-            if (i == 'w') {
-                loopOptionsWebUi();
-                returnToMenu = true;
-            }
-            if (i == 'f') {
-                setupSdCard() ? loopSD(SD) : loopSD(LittleFS);
-                returnToMenu = true;
-            }
-            if (i == 'l') {
-                loopSD(LittleFS);
-                returnToMenu = true;
+            if(i == *shortcut_key) {  // compare the 1st char of the key string
+                // execute the associated action
+                serialCli.parse(String(shortcut_value));
             }
         }
     }
-    // TODO: other boards?
-    // TODO: user-configurable
 }
+
 
 /*********************************************************************
 ** Function: checkNumberShortcutPress

--- a/src/core/serial_commands/rf_commands.cpp
+++ b/src/core/serial_commands/rf_commands.cpp
@@ -19,8 +19,8 @@ uint32_t rfRxCallback(cmd *c) {
     float frequency = strFreq.toFloat();
     frequency /= 1000000; // passed as a long int (e.g. 433920000)
 
-    Serial.print("frequency: ");
-    Serial.println(frequency);
+    //Serial.print("frequency: ");
+    //Serial.println(frequency);
 
     String r = "";
     if (raw) {

--- a/src/core/serial_commands/util_commands.cpp
+++ b/src/core/serial_commands/util_commands.cpp
@@ -3,7 +3,7 @@
 #include "core/wifi/wifi_common.h" //to return MAC addr
 #include "modules/badusb_ble/ducky_typer.h"
 #include "core/wifi/webInterface.h"
-#include "sd_functions.h"
+#include "core/sd_functions.h"
 #include "core/main_menu.h"
 #include <Wire.h>
 #include <globals.h>

--- a/src/core/serial_commands/util_commands.cpp
+++ b/src/core/serial_commands/util_commands.cpp
@@ -1,6 +1,10 @@
 #include "util_commands.h"
 #include "core/utils.h"            // to return optionsJSON
 #include "core/wifi/wifi_common.h" //to return MAC addr
+#include "modules/badusb_ble/ducky_typer.h"
+#include "core/wifi/webInterface.h"
+#include "sd_functions.h"
+#include "core/main_menu.h"
 #include <Wire.h>
 #include <globals.h>
 
@@ -264,12 +268,71 @@ uint32_t displayCallback(cmd *c) {
     return true;
 }
 
+uint32_t loaderCallback(cmd *c) {
+    Command cmd(c);
+    String arg = cmd.getArgument("cmd").getValue();
+    String appname = cmd.getArgument("appname").getValue();
+    
+    std::vector<MenuItemInterface *> _menuItems = mainMenu.getItems();
+    int _totalItems = _menuItems.size();    
+    
+    if (arg == "list") {
+        for (int i = 0; i < _totalItems; i++) {
+            Serial.println( _menuItems[i]->getName() );
+        }
+        Serial.println("BadUSB");
+        Serial.println("WebUI");
+        Serial.println("LittleFS");
+        return true;
+        
+    } else if (arg == "open") {
+        if(!appname.isEmpty()) {
+            // look for a matching name
+            for (int i = 0; i < _totalItems; i++) {
+                if(appname.equalsIgnoreCase(_menuItems[i]->getName())) {
+                    // open the associated app
+                    _menuItems[i]->optionsMenu();
+                    return true;
+                }
+            }
+            // additional shortcuts
+            if(appname.equalsIgnoreCase("badusb")) {
+                ducky_setup(hid_usb, false);
+                return true;
+            }
+            else if(appname.equalsIgnoreCase("webui")) {
+                loopOptionsWebUi();
+                return true;
+            }
+            else if(appname.equalsIgnoreCase("littlefs")) {
+                loopSD(LittleFS);
+                return true;
+            }
+            // else no matching app name found
+            Serial.println("app not found: " + appname);
+            return false;
+        }
+        
+    } else {
+        Serial.println(
+            "Loader command accept:\n"
+            "loader list : Lists available applications\n"
+            "loader open appname  : Runs the entered application.\n"
+        );
+        return false;
+    }
+    
+    // TODO: close: Closes the running application.
+    // TODO: info: Displays the loader’s state.
+    return false;
+}
+        
 void createUtilCommands(SimpleCLI *cli) {
     cli->addCommand("uptime", uptimeCallback);
     cli->addCommand("date", dateCallback);
     cli->addCommand("i2c", i2cCallback);
     cli->addCommand("free", freeCallback);
-    cli->addCommand("info,!", infoCallback);
+    cli->addCommand("info,!,device_info", infoCallback);
     cli->addCommand("optionsJSON", optionsJsonCallback);
     Command display = cli->addCommand("display", displayCallback);
     display.addPosArg("option", "dump");
@@ -280,4 +343,8 @@ void createUtilCommands(SimpleCLI *cli) {
 
     Command opt = cli->addCommand("options,option", optionsCallback);
     opt.addPosArg("run", "-1");
+    
+    Command loader = cli->addCommand("loader", loaderCallback);
+    loader.addPosArg("cmd");
+    loader.addPosArg("appname", "none");  // optional
 }

--- a/src/modules/rf/rf_utils.cpp
+++ b/src/modules/rf/rf_utils.cpp
@@ -178,9 +178,9 @@ bool initRfModule(String mode, float frequency) {
         cc1101_spi_ready = true;
     } else {
         // single-pinned module
-        if (frequency != bruceConfig.rfFreq) {
-            Serial.println("unsupported frequency");
-            return false;
+        if (abs(frequency - bruceConfig.rfFreq)>1) {
+            Serial.print("warn: unsupported frequency, trying anyway...");
+            //return false;
         }
 
         if (mode == "tx") {


### PR DESCRIPTION
 - fixed RF frequency validation on single-pinned modules ([float comparison error](https://stackoverflow.com/questions/10334688/how-dangerous-is-it-to-compare-floating-point-values))
 - fixed `js run_from_file` serial cmd buffering
 - added `loader` serial cmd: list and launch apps ([flipper0-compat](https://docs.flipper.net/development/cli/#wVlXI))
 - added customizable keyboard shortcuts (via a "/shortcuts.json" file, only for devices with a keyboard like the Cardputer)


example of  `shortcuts.json`:

````
{
    "f": "loader open files",
    "i": "loader open ir",
    "r": "loader open rf",
    "b": "loader open badusb",
    "w": "loader open webui",
    "c": "loader open config",
    "1": "rf tx_from_file BruceRF/plug1_on.sub",
    "2": "rf tx_from_file BruceRF/plug2_on.sub",
    "t": "ir tx_from_file BruceIR/tv_telefunken_power.ir",
    "l": "ir tx_from_file BruceIR/desklamp_on.ir",
} 

````

Related: 
https://github.com/pr3y/Bruce/wiki/Interface
https://github.com/pr3y/Bruce/issues/64

