### PR TITLE
Remove _rtc.setWire(&Wire) from boards/m5stack-core2/interface.cpp

### DIFF
--- a/boards/m5stack-core2/interface.cpp
+++ b/boards/m5stack-core2/interface.cpp
@@ -9,8 +9,6 @@
 ** Description:   initial setup for the device
 ***************************************************************************************/
 void _setup_gpio() {
-    _rtc.setWire(&Wire); // Cplus uses Wire1 default, the lib had been changed to accept setting I2C bus
-                         // StickCPlus uses BM8563 that is the same as PCF8536
     M5.begin();          // Need to test if SDCard inits with the new setup
     pinMode(GPIO_NUM_0, OUTPUT);
 }


### PR DESCRIPTION
Resolve issue where RFID is unable to read on M5Stack Core2 due to the line in `boards/m5stack-core2/interface.cpp` where the line `_rtc.setWire(&Wire)` is added and shouldn't be there as Wire is used for the I2C port and Wire1.

#### Proposed Changes ####

Remove the line added `_rtc.setWire(&Wire)` as part of commit https://github.com/pr3y/Bruce/commit/d9ac1e2231dea0a6a1b4a64c78f9f66a960d3c5a

#### Types of Changes ####

Fix bug on Core2 that prevents the RTC and RFID reader on I2C from working.

#### Verification ####

- Build main for M5Stack Core2 and RFID2 reader

#### Testing ####

- RFID2 reader not works on M5Stack Core2 

#### Linked Issues ####

https://github.com/pr3y/Bruce/issues/1518

#### User-Facing Change ####

None

#### Further Comments ####

