### PR TITLE
CYD devices fix

### DIFF
--- a/boards/CYD-2432S028/CYD-2432S028.ini
+++ b/boards/CYD-2432S028/CYD-2432S028.ini
@@ -48,10 +48,10 @@ build_flags =
 	;-DHAS_RTC=1
 
 	;Speaker to run music, compatible with NS4168
-	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
+	-DHAS_NS4168_SPKR=1 ;uncomment to enable
 	-DBCLK=-1
 	-DWCLK=-1
-	-DDOUT=-1
+	-DDOUT=26
 
 	;Can run USB as HID
 	;-DUSB_as_HID=1 ;uncomment to enable
@@ -73,8 +73,8 @@ build_flags =
 	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
 
 	;Infrared Led default pin and state
-	-DIR_TX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}}'
-	-DIR_RX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}, {"Pin 35", 35}}'
+	-DIR_TX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}}, {"Pin 35", 35}, {"Pin 1", 1}, {"Pin 3", 3}'
+	-DIR_RX_PINS='{{"Pin 22", 22}, {"Pin 27", 27}, {"Pin 35", 35}}, {"Pin 1", 1}, {"Pin 3", 3}'
 	-DLED=22		;NEED TO SET SOMETHING HERE, at least -1
 	-DLED_ON=HIGH
 	-DLED_OFF=LOW
@@ -177,7 +177,6 @@ build_flags =
 extends=env:CYD-2432S028
 build_flags =
 	${env:CYD-2432S028.build_flags}
-	-DTFT_INVERSION_ON
 	-DDEVICE_NAME='"CYD-2USB"'
 
 [env:LAUNCHER_CYD-2USB]
@@ -185,7 +184,6 @@ extends=env:CYD-2432S028
 build_flags =
 	${env:CYD-2432S028.build_flags}
 	-DCONFIG_ESP32_JTAG_SUPPORT_DISABLE=1
-	-DTFT_INVERSION_ON
 	-DLITE_VERSION=1
 	-DDEVICE_NAME='"LAUNCHER_CYD-2USB"'
 
@@ -193,7 +191,6 @@ build_flags =
 extends = CYD_base
 build_flags =
 	${CYD_base.build_flags}
-	-DTFT_INVERSION_ON
 	-DTFT_BL=27
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
@@ -213,7 +210,6 @@ build_flags =
 [env:CYD-2432W328C_2] # commom to CYD-2432S024 Capacitive board
 extends = env:CYD-2432W328C
 build_unflags =
-	-DTFT_INVERSION_ON
 	-DDEVICE_NAME='"CYD-2432W328C_2"'
 
 [env:LAUNCHER_CYD-2432W328C]


### PR DESCRIPTION


#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
i added speaker support for a CYD-2432s028r and CYD-2USB and removed inverted color by default and added pin 1, 3 and 35 for IR TX and pin 1, 3 for IR RX
#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
I tried to check cyd-2432s028r but my project doesn't compile
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->
#1546 #1438 
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
--> NONE
```release-note
NONE
```

#### Further Comments ####
Sorry I couldn't check because of a build error
let someone check this change and write that it works
