### PR TITLE
Keyboard code refactoring + HEX and Numpad keyboards + BACK button

### DIFF
--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -697,135 +697,96 @@ String generalKeyboard(
 #endif
 
 #if defined(HAS_3_BUTTONS) // StickCs and Core
-            if (check(SelPress)) { selection_made = true; }
-            /* Down Btn to move in X axis (to the right) */
-            if (longNextPress || NextPress) {
-                unsigned long now = millis();
-                if (!longNextPress) {
-                    longNextPress = 1;
-                    LongPress = true;
-                    LongPressTmp = now;
-                }
-                delay(1); // does not work without it
-                // Check if the button is held long enough (long press)
-                if (now - LongPressTmp > 300) {
-                    x--; // Long press action
-                    longNextPress = 2;
+            if (check(SelPress)) {
+                selection_made = true;
+            } else {
+                /* Down Btn to move in X axis (to the right) */
+                if (longNextPress || NextPress) {
+                    unsigned long now = millis();
+                    if (!longNextPress) {
+                        longNextPress = 1;
+                        LongPress = true;
+                        LongPressTmp = now;
+                    }
+                    delay(1); // does not work without it
+                    // Check if the button is held long enough (long press)
+                    if (now - LongPressTmp > 300) {
+                        x--; // Long press action
+                        longNextPress = 2;
+                        LongPress = false;
+                        check(NextPress);
+                        LongPressTmp = now;
+                    } else if (!NextPress) {
+                        if (longNextPress != 2) x++; // Short press action
+                        longNextPress = 0;
+                    } else {
+                        continue;
+                    }
                     LongPress = false;
-                    check(NextPress);
-                    LongPressTmp = now;
-                } else if (!NextPress) {
-                    if (longNextPress != 2) x++; // Short press action
-                    longNextPress = 0;
-                } else {
-                    continue;
+                    // delay(10);
+                    if (y < 0 && x >= buttons_number) x = 0;
+                    if (x >= KeyboardWidth) x = 0;
+                    else if (x < 0) x = KeyboardWidth - 1;
+                    redraw = true;
                 }
-                LongPress = false;
-                // delay(10);
-                if (y < 0 && x >= buttons_number) x = 0;
-                if (x >= KeyboardWidth) x = 0;
-                else if (x < 0) x = KeyboardWidth - 1;
-                redraw = true;
-            }
-            /* UP Btn to move in Y axis (Downwards) */
-            if (longPrevPress || PrevPress) {
-                unsigned long now = millis();
-                if (!longPrevPress) {
-                    longPrevPress = 1;
-                    LongPress = true;
-                    LongPressTmp = now;
-                }
-                delay(1); // does not work without it
-                // Check if the button is held long enough (long press)
-                if (now - LongPressTmp > 300) {
-                    y--; // Long press action
-                    longPrevPress = 2;
+                /* UP Btn to move in Y axis (Downwards) */
+                if (longPrevPress || PrevPress) {
+                    unsigned long now = millis();
+                    if (!longPrevPress) {
+                        longPrevPress = 1;
+                        LongPress = true;
+                        LongPressTmp = now;
+                    }
+                    delay(1); // does not work without it
+                    // Check if the button is held long enough (long press)
+                    if (now - LongPressTmp > 300) {
+                        y--; // Long press action
+                        longPrevPress = 2;
+                        LongPress = false;
+                        check(PrevPress);
+                        LongPressTmp = now;
+                    } else if (!PrevPress) {
+                        if (longPrevPress != 2) y++; // Short press action
+                        longPrevPress = 0;
+                    } else {
+                        continue;
+                    }
                     LongPress = false;
-                    check(PrevPress);
-                    LongPressTmp = now;
-                } else if (!PrevPress) {
-                    if (longPrevPress != 2) y++; // Short press action
-                    longPrevPress = 0;
-                } else {
-                    continue;
+                    if (y >= KeyboardHeight) {
+                        y = -1;
+                    } else if (y < -1) y = KeyboardHeight - 1;
+                    redraw = true;
                 }
-                LongPress = false;
-                if (y >= KeyboardHeight) {
-                    y = -1;
-                } else if (y < -1) y = KeyboardHeight - 1;
-                redraw = true;
             }
 #elif defined(HAS_5_BUTTONS) // Smoochie and Marauder-Mini
-            if (check(SelPress)) { selection_made = true; }
-            /* Down Btn to move in X axis (to the right) */
-            if (check(NextPress)) {
-                x++;
-                if ((y < 0 && x >= buttons_number) || x >= KeyboardWidth) x = 0;
-                redraw = true;
-            }
-            if (check(PrevPress)) {
-                x--;
-                if (y < 0 && x >= buttons_number) x = buttons_number - 1;
-                else if (x < 0) x = KeyboardWidth - 1;
-                redraw = true;
-            }
-            /* UP Btn to move in Y axis (Downwards) */
-            if (check(DownPress)) {
-                y++;
-                if (y > KeyboardHeight - 1) { y = -1; }
-                redraw = true;
-            }
-            if (check(UpPress)) {
-                y--;
-                if (y < -1) y = KeyboardHeight - 1;
-                redraw = true;
-            }
-
-#elif defined(HAS_ENCODER) // T-Embed
-            if (check(SelPress)) { selection_made = true; }
-            /* NEXT "Btn" to move forward on th X axis (to the right) */
-            // if ESC is pressed while NEXT or PREV is received, then we navigate on the Y axis instead
-            if (check(NextPress)) {
-                if (check(EscPress)) {
-                    y++;
-                } else if ((x >= buttons_number - 1 && y <= -1) || (x >= KeyboardWidth - 1 && y >= 0)) {
-                    // if we are at the end of the current line
-                    y++;   // next line
-                    x = 0; // reset to first key
-                } else x++;
-
-                if (y >= KeyboardHeight)
-                    y = -1; // if we are at the end of the keyboard, then return to the top
-
-                // If we move to a new line using the ESC-press navigation and the previous x coordinate is
-                // greater than the number of available buttons_strings on the new line, reset x to avoid
-                // out-of-bounds behavior, this can only happen when switching to the first line, as the
-                // others have all the same number of keys
-                if (y == -1 && x >= buttons_number) x = 0;
-
-                redraw = true;
-            }
-            /* PREV "Btn" to move backwards on th X axis (to the left) */
-            if (check(PrevPress)) {
-                if (check(EscPress)) {
-                    y--;
-                } else if (x <= 0) {
-                    y--;
-                    if (y == -1) x = buttons_number - 1;
-                    else x = KeyboardWidth - 1;
-                } else x--;
-
-                if (y < -1) { // go back to the bottom right of the keyboard
-                    y = KeyboardHeight - 1;
-                    x = KeyboardWidth - 1;
+            if (check(SelPress)) {
+                selection_made = true;
+            } else {
+                /* Down Btn to move in X axis (to the right) */
+                if (check(NextPress)) {
+                    x++;
+                    if ((y < 0 && x >= buttons_number) || x >= KeyboardWidth) x = 0;
+                    redraw = true;
                 }
-                // else if (y == -1 && x >= buttons_number) x = buttons_number - 1;
-                // else if (x < 0) x = KeyboardWidth - 1;
-
-                redraw = true;
+                if (check(PrevPress)) {
+                    x--;
+                    if (y < 0 && x >= buttons_number) x = buttons_number - 1;
+                    else if (x < 0) x = KeyboardWidth - 1;
+                    redraw = true;
+                }
+                /* UP Btn to move in Y axis (Downwards) */
+                if (check(DownPress)) {
+                    y++;
+                    if (y > KeyboardHeight - 1) { y = -1; }
+                    redraw = true;
+                }
+                if (check(UpPress)) {
+                    y--;
+                    if (y < -1) y = KeyboardHeight - 1;
+                    redraw = true;
+                }
             }
-
-#elif defined(HAS_KEYBOARD) // Cardputer and T-Deck
+#elif defined(HAS_KEYBOARD)  // Cardputer, T-Deck and T-LoRa-Pager
             if (KeyStroke.pressed) {
                 wakeUpScreen();
                 tft.setCursor(cursor_x, cursor_y);
@@ -869,35 +830,88 @@ String generalKeyboard(
                 if (KeyStroke.enter) { break; }
                 KeyStroke.Clear();
             }
+#if !defined(T_LORA_PAGER)   // T-LoRa-Pager does not have a select button
             if (check(SelPress)) break;
+#endif
+#endif
 
+#if defined(HAS_ENCODER) // T-Embed and T-LoRa-Pager
+            if (check(SelPress) || selection_made) {
+                selection_made = true;
+            } else {
+                /* NEXT "Btn" to move forward on th X axis (to the right) */
+                // if ESC is pressed while NEXT or PREV is received, then we navigate on the Y axis instead
+                if (check(NextPress)) {
+                    if (check(EscPress)) {
+                        y++;
+                    } else if ((x >= buttons_number - 1 && y <= -1) || (x >= KeyboardWidth - 1 && y >= 0)) {
+                        // if we are at the end of the current line
+                        y++;   // next line
+                        x = 0; // reset to first key
+                    } else x++;
+
+                    if (y >= KeyboardHeight)
+                        y = -1; // if we are at the end of the keyboard, then return to the top
+
+                    // If we move to a new line using the ESC-press navigation and the previous x coordinate
+                    // is greater than the number of available buttons_strings on the new line, reset x to
+                    // avoid out-of-bounds behavior, this can only happen when switching to the first line, as
+                    // the others have all the same number of keys
+                    if (y == -1 && x >= buttons_number) x = 0;
+
+                    redraw = true;
+                }
+                /* PREV "Btn" to move backwards on th X axis (to the left) */
+                if (check(PrevPress)) {
+                    if (check(EscPress)) {
+                        y--;
+                    } else if (x <= 0) {
+                        y--;
+                        if (y == -1) x = buttons_number - 1;
+                        else x = KeyboardWidth - 1;
+                    } else x--;
+
+                    if (y < -1) { // go back to the bottom right of the keyboard
+                        y = KeyboardHeight - 1;
+                        x = KeyboardWidth - 1;
+                    }
+                    // else if (y == -1 && x >= buttons_number) x = buttons_number - 1;
+                    // else if (x < 0) x = KeyboardWidth - 1;
+
+                    redraw = true;
+                }
+            }
 #endif
         } // end of physical input detection
 
         if (SerialCmdPress) { // only for Remote Control, if no type of input was detected on device
-            if (check(SelPress)) { selection_made = true; }
-            /* Next-Prev Btns to move in X axis (right-left) */
-            if (check(NextPress)) {
-                x++;
-                if ((y < 0 && x >= buttons_number) || x >= KeyboardWidth) x = 0;
-                redraw = true;
-            }
-            if (check(PrevPress)) {
-                x--;
-                if (y < 0 && x >= buttons_number) x = buttons_number - 1;
-                else if (x < 0) x = KeyboardWidth - 1;
-                redraw = true;
-            }
-            /* Down-Up Btns to move in Y axis */
-            if (check(DownPress)) {
-                y++;
-                if (y >= KeyboardHeight) { y = -1; }
-                redraw = true;
-            }
-            if (check(UpPress)) {
-                y--;
-                if (y < -1) y = KeyboardHeight - 1;
-                redraw = true;
+            if (check(SelPress)) {
+                selection_made = true;
+            } else {
+                /* Next-Prev Btns to move in X axis (right-left) */
+                if (check(NextPress)) {
+                    x++;
+                    if ((y < 0 && x >= buttons_number) || x >= KeyboardWidth) x = 0;
+                    redraw = true;
+                }
+                /* Down-Up Btns to move in Y axis */
+                if (check(PrevPress)) {
+                    x--;
+                    if (y < 0 && x >= buttons_number) x = buttons_number - 1;
+                    else if (x < 0) x = KeyboardWidth - 1;
+                    redraw = true;
+                }
+                /* Down-Up Btns to move in Y axis */
+                if (check(DownPress)) {
+                    y++;
+                    if (y >= KeyboardHeight) { y = -1; }
+                    redraw = true;
+                }
+                if (check(UpPress)) {
+                    y--;
+                    if (y < -1) y = KeyboardHeight - 1;
+                    redraw = true;
+                }
             }
         }
 

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -536,7 +536,7 @@ String generalKeyboard(
 
             // Prints the chars counter
             tft.setTextSize(FP);
-            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor, true);
+            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
             String chars_counter = String(current_text.length()) + "/" + String(max_size);
             tft.fillRect(
                 tftWidth - ((chars_counter.length() * 6) + 20), // 5px per char + 1 padding

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -56,57 +56,55 @@ keyStroke _getKeyPress() {
 #endif
 } // must return something that the keyboards won´t recognize by default
 
-
 /*********************************************************************
 ** Function: checkShortcutPress
 ** location: mykeyboard.cpp
 ** runs a function called by the shortcut action
 **********************************************************************/
 void checkShortcutPress() {
-    static StaticJsonDocument<512> shortcutsJson;  // parsed only once
-    
+    static StaticJsonDocument<512> shortcutsJson; // parsed only once
+
     // lazy init
-    if(shortcutsJson.size() == 0) {
+    if (shortcutsJson.size() == 0) {
         FS *fs;
         if (!getFsStorage(fs)) return;
         File file = fs->open("/shortcuts.json", FILE_READ);
-		if (!file) {
-			log_e("Shortcuts Config file not found. Using default values");
-            JsonObject shortcuts = shortcutsJson.to<JsonObject>();  // root
+        if (!file) {
+            log_e("Shortcuts Config file not found. Using default values");
+            JsonObject shortcuts = shortcutsJson.to<JsonObject>(); // root
             shortcuts["i"] = "loader open ir";
             shortcuts["r"] = "loader open rf";
             shortcuts["s"] = "loader open rf";
             shortcuts["b"] = "loader open badusb";
             shortcuts["w"] = "loader open webui";
             shortcuts["f"] = "loader open files";
-			return;
-		}
-		// else
-		if (deserializeJson(shortcutsJson, file)) {
-			log_e("Failed to parse shortcuts.json");
+            return;
+        }
+        // else
+        if (deserializeJson(shortcutsJson, file)) {
+            log_e("Failed to parse shortcuts.json");
             file.close();
-			return;
-		}
-		file.close();
+            return;
+        }
+        file.close();
     }
-    
+
     keyStroke key = _getKeyPress();
-    
+
     // parse shortcutsJson and check the keys
     for (JsonPair kv : shortcutsJson.as<JsonObject>()) {
-        const char* shortcut_key = kv.key().c_str();
-        const char* shortcut_value = kv.value().as<const char*>();
-        
+        const char *shortcut_key = kv.key().c_str();
+        const char *shortcut_value = kv.value().as<const char *>();
+
         // check for matching keys
         for (auto i : key.word) {
-            if(i == *shortcut_key) {  // compare the 1st char of the key string
+            if (i == *shortcut_key) { // compare the 1st char of the key string
                 // execute the associated action
                 serialCli.parse(String(shortcut_value));
             }
         }
     }
 }
-
 
 /*********************************************************************
 ** Function: checkNumberShortcutPress
@@ -145,6 +143,117 @@ char checkLetterShortcutPress() {
 }
 
 /*********************************************************************
+** Shared keyboard helper functions
+**********************************************************************/
+
+// Handles character deletion from the text string and screen
+bool handleDelete(String &mytext, int &cX, int &cY, const int maxFPSize) {
+    if (mytext.length() == 0) return false;
+
+    // remove from string
+    mytext.remove(mytext.length() - 1);
+    // delete from screen:
+    int fontSize = FM;
+    if (mytext.length() > maxFPSize) {
+        tft.setTextSize(FP);
+        fontSize = FP;
+    } else tft.setTextSize(FM);
+    tft.setCursor((cX - fontSize * LW), cY);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    tft.print(" ");
+    tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
+    tft.setCursor(cX - fontSize * LW, cY);
+    cX = tft.getCursorX();
+    cY = tft.getCursorY();
+    return true;
+}
+
+// Handles adding a character to the text string
+bool handleCharacterAdd(
+    String &mytext, char character, int &cX, int &cY, const int maxSize, const int maxFMSize
+) {
+    if (mytext.length() >= maxSize) return false;
+
+    mytext += character;
+    if (mytext.length() != (maxFMSize + 1) && mytext.length() != (maxFMSize + 1)) tft.print(character);
+    cX = tft.getCursorX();
+    cY = tft.getCursorY();
+    return true;
+}
+
+// Handles adding space to the text string
+bool handleSpaceAdd(String &mytext, const int maxSize) {
+    if (mytext.length() >= maxSize) return false;
+    mytext += " ";
+    return true;
+}
+
+// Enum for keyboard action results
+enum KeyboardAction { KEYBOARD_CONTINUE, KEYBOARD_OK, KEYBOARD_CANCEL, KEYBOARD_REDRAW };
+
+// Handles keyboard selection logic for regular keyboard
+KeyboardAction handleRegularKeyboardSelection(
+    int x, int y, String &mytext, bool &caps, int &cX, int &cY, const int maxSize, const int maxFMSize,
+    const int maxFPSize, char keys[4][12][2]
+) {
+    tft.setCursor(cX, cY);
+    int z = caps ? 1 : 0;
+
+    if (x == 0 && y == -1) {
+        return KEYBOARD_OK; // OK button
+    } else if (x == 1 && y == -1) {
+        caps = !caps; // CAP button
+        return KEYBOARD_REDRAW;
+    } else if (x == 2 && y == -1 && mytext.length() > 0) {
+        handleDelete(mytext, cX, cY, maxFPSize); // DEL button
+        return KEYBOARD_REDRAW;
+    } else if (x == 3 && y == -1 && mytext.length() < maxSize) {
+        handleSpaceAdd(mytext, maxSize); // SPACE button
+        return KEYBOARD_REDRAW;
+    } else if (x == 4 && y == -1) {
+        mytext = ""; // BACK button - return empty string to cancel
+        return KEYBOARD_CANCEL;
+    } else if (y > -1 && mytext.length() < maxSize) {
+        handleCharacterAdd(mytext, keys[y][x][z], cX, cY, maxSize, maxFMSize); // add letters to mytext
+        if (mytext.length() >= maxSize) {
+            // Put the Cursor at "Ok" when max size reached
+            // This would need to be handled by the caller
+        }
+        return KEYBOARD_REDRAW;
+    }
+    return KEYBOARD_CONTINUE;
+}
+
+// Handles keyboard selection logic for hex keyboard
+KeyboardAction handleHexKeyboardSelection(
+    int x, int y, String &mytext, int &cX, int &cY, const int maxSize, const int maxFMSize,
+    const int maxFPSize, char keys[4][4]
+) {
+    tft.setCursor(cX, cY);
+
+    if (x == 0 && y == -1) {
+        return KEYBOARD_OK; // OK button
+    } else if (x == 1 && y == -1 && mytext.length() > 0) {
+        handleDelete(mytext, cX, cY, maxFPSize); // DEL button
+        return KEYBOARD_REDRAW;
+    } else if (x == 2 && y == -1 && mytext.length() < maxSize) {
+        handleSpaceAdd(mytext, maxSize); // SPACE button
+        return KEYBOARD_REDRAW;
+    } else if (x == 3 && y == -1) {
+        mytext = "\x1B"; // BACK button - return ESC to cancel
+        return KEYBOARD_CANCEL;
+    } else if (y > -1 && mytext.length() < maxSize) {
+        handleCharacterAdd(mytext, keys[y][x], cX, cY, maxSize, maxFMSize); // add hex letters to mytext
+        if (mytext.length() >= maxSize) {
+            // Put the Cursor at "Ok" when max size reached
+            // This would need to be handled by the caller
+        }
+        return KEYBOARD_REDRAW;
+    }
+    return KEYBOARD_CONTINUE;
+}
+
+/*********************************************************************
 ** Function: keyboard
 ** location: mykeyboard.cpp
 ** keyboard interface.
@@ -171,12 +280,12 @@ String keyboard(String mytext, int maxSize, String msg) {
     char keys[4][12][2] = {
         //  4 lines, with 12 characteres, low and high caps
         {
-         {'1', '!'},  //             1
-            {'2', '@'},  //             2
-            {'3', '#'},  //             3
-            {'4', '$'},  //                       4
-            {'5', '%'},  //                       5
-            {'6', '^'},  //             6
+         {'1', '!'},  // 1
+            {'2', '@'},  // 2
+            {'3', '#'},  // 3
+            {'4', '$'},  // 4
+            {'5', '%'},  // 5
+            {'6', '^'},  // 6
             {'7', '&'},  // 7
             {'8', '*'},  // 8
             {'9', '('},  // 9
@@ -188,8 +297,8 @@ String keyboard(String mytext, int maxSize, String msg) {
          {'q', 'Q'},  // 1
             {'w', 'W'},  // 2
             {'e', 'E'},  // 3
-            {'r', 'R'},  //           4
-            {'t', 'T'},  //           5
+            {'r', 'R'},  // 4
+            {'t', 'T'},  // 5
             {'y', 'Y'},  // 6
             {'u', 'U'},  // 7
             {'i', 'I'},  // 8
@@ -227,28 +336,31 @@ String keyboard(String mytext, int maxSize, String msg) {
             {'/', '/'}   // 12
         }
     };
-#if FM > 1 // Normal keyboard size
-#define KBLH 20
-    int ofs[4][3] = {
-        {7,   46, 18 },
-        {55,  50, 64 },
-        {107, 50, 115},
-        {159, 74, 168},
+#if FM > 1      // Normal keyboard size
+#define KBLH 20 // Keyboard Buttons Line Height
+    // { x coord of btn border, btn width, x coord of the inside text }
+    int ofs[5][3] = {
+        {7,   46, 18 }, // OK button
+        {55,  50, 64 }, // CAP button
+        {107, 50, 115}, // DEL button
+        {159, 74, 168}, // SPACE button
+        {235, 62, 244}, // BACK button
     };
 #else // small keyboard size, for small letters (smaller screen, like Marauder Mini and others ;) )
 #define KBLH 10
-    int ofs[4][3] = {
-        {7,  20, 10},
-        {27, 25, 30},
-        {52, 25, 55},
-        {77, 50, 80},
+    int ofs[5][3] = {
+        {7,   20, 10 }, // OK button
+        {27,  25, 30 }, // CAP button
+        {52,  25, 55 }, // DEL button
+        {77,  50, 80 }, // SPACE button
+        {127, 40, 130}, // BACK button
     };
 #endif
     const int _x = tftWidth / 12;
     const int _y = (tftHeight - (2 * KBLH + 14)) / 4;
     const int _xo = _x / 2 - 3;
 
-#if defined(HAS_TOUCH)
+#if defined(HAS_TOUCH) // filling touch box list
     int k = 0;
     for (x2 = 0; x2 < 12; x2++) {
         for (y2 = 0; y2 < 4; y2++) {
@@ -310,35 +422,45 @@ String keyboard(String mytext, int maxSize, String msg) {
     uint8_t longPrevPress = 0;
     unsigned long LongPressTmp = millis();
 #endif
+
     while (1) {
         if (redraw) {
             tft.setCursor(0, 0);
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
             tft.setTextSize(FM);
 
-            // Draw the rectangles
+            // Draw the top row buttons
             if (y < 0 || y2 < 0) {
                 tft.fillRect(0, 1, tftWidth, 22, bruceConfig.bgColor);
+                // Draw the borders
                 tft.drawRect(
                     ofs[0][0], 2, ofs[0][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                ); // Ok Rectangle
+                ); // OK btn border
                 tft.drawRect(
                     ofs[1][0], 2, ofs[1][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                ); // CAP Rectangle
+                ); // CAP btn border
                 tft.drawRect(
                     ofs[2][0], 2, ofs[2][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                ); // DEL Rectangle
+                ); // DEL btn border
                 tft.drawRect(
                     ofs[3][0], 2, ofs[3][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                );                                                                    // SPACE Rectangle
-                tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // mystring Rectangle
+                ); // SPACE btn border
+                tft.drawRect(
+                    ofs[4][0], 2, ofs[4][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+                ); // BACK btn border
 
+                tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
+
+                // Highlight the corresponding button when the user cursor is over it
+
+                // OK
                 if (x == 0 && y == -1) {
                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
                     tft.fillRect(ofs[0][0], 2, ofs[0][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
                 tft.drawString("OK", ofs[0][2], 4);
 
+                // CAP
                 if (x == 1 && y == -1) {
                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
                     tft.fillRect(ofs[1][0], 2, ofs[1][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
@@ -348,77 +470,89 @@ String keyboard(String mytext, int maxSize, String msg) {
                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
                 tft.drawString("CAP", ofs[1][2], 4);
 
+                // DEL
                 if (x == 2 && y == -1) {
                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
                     tft.fillRect(ofs[2][0], 2, ofs[2][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
                 tft.drawString("DEL", ofs[2][2], 4);
 
-                if (x > 2 && y == -1) {
+                // SPACE
+                if (x == 3 && y == -1) {
                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
                     tft.fillRect(ofs[3][0], 2, ofs[3][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
                 tft.drawString("SPACE", ofs[3][2], 4);
+
+                // BACK
+                if (x > 3 && y == -1) {
+                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+                    tft.fillRect(ofs[4][0], 2, ofs[4][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
+                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+                tft.drawString("BACK", ofs[4][2], 4);
             }
 
+            // prints the title of the textbox, it should report what the user has to write in it
             tft.setTextSize(FP);
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
             tft.drawString(msg.substring(0, maxFPSize), 3, KBLH + 4);
 
+            // drawing the textbox and the currently typed string
             tft.setTextSize(FM);
-
-            // reseta o quadrado do texto
+            // reset the text box
             if (mytext.length() == (maxFMSize) || mytext.length() == (maxFMSize + 1) ||
                 mytext.length() == (maxFPSize) || mytext.length() == (maxFPSize + 1))
-                tft.fillRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.bgColor); // mystring Rectangle
-            // escreve o texto
+                tft.fillRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.bgColor);
+            // write the text
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor));
-            if (mytext.length() > maxFMSize) {
+            if (mytext.length() > maxFMSize) { // if the text is too long, we try to set the smaller font
                 tft.setTextSize(FP);
-                if (mytext.length() > maxFPSize) {
+                if (mytext.length() > maxFPSize) { // if its still too long, we divide it into two lines
                     tft.drawString(mytext.substring(0, maxFPSize), 5, KBLH + LH + 6);
                     tft.drawString(mytext.substring(maxFPSize, mytext.length()), 5, KBLH + 2 * LH + 6);
                 } else {
                     tft.drawString(mytext, 5, KBLH + 14);
                 }
             } else {
+                // else if it fits, just draw the text
                 tft.drawString(mytext, 5, KBLH + 14);
             }
-            // desenha o retangulo colorido
-            tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // mystring Rectangle
+            // Draw the textbox border again(?)
+            tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
 
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
             tft.setTextSize(FM);
 
+            // Draw the actual keyboard
             for (int i = 0; i < 4; i++) {
                 for (int j = 0; j < 12; j++) {
-                    // use last coordenate to paint only this letter
+                    // Use the previous coordinates to repaint only the previous letter
                     if (x2 == j && y2 == i) {
                         tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor);
                         tft.fillRect(j * _x, i * _y + KBLH * 2 + 14, _x, _y, bruceConfig.bgColor);
                     }
-                    /* If selected, change font color and draw Rectangle*/
+                    // If selected, highlight it by changing font color and filling the back rectangle
                     if (x == j && y == i) {
                         tft.setTextColor(bruceConfig.bgColor, ~bruceConfig.bgColor);
                         tft.fillRect(j * _x, i * _y + KBLH * 2 + 14, _x, _y, ~bruceConfig.bgColor);
                     }
 
-                    /* Print the letters */
+                    // Print the letters
                     if (!caps)
                         tft.drawString(String(keys[i][j][0]), (j * _x + _xo), (i * _y + KBLH * 2 + 16));
                     else tft.drawString(String(keys[i][j][1]), (j * _x + _xo), (i * _y + KBLH * 2 + 16));
 
-                    /* Return colors to normal to print the other letters */
+                    // Return colors to normal to print the other letters
                     if (x == j && y == i) { tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor); }
                 }
             }
-            // save actual key coordenate
+            // Save actual key coordinates
             x2 = x;
             y2 = y;
             redraw = false;
         }
 
-        // cursor handler
+        // Cursor Handler
         if (mytext.length() > maxFMSize) {
             tft.setTextSize(FP);
             if (mytext.length() > (maxFPSize)) {
@@ -450,27 +584,43 @@ String keyboard(String mytext, int maxSize, String msg) {
                 DownPress = false;
                 x = 0;
                 y = -1;
-                if (box_list[48].contain(touchPoint.x, touchPoint.y)) { break; } // Ok
+
+                bool touchHandled = false;
+
+                if (box_list[48].contain(touchPoint.x, touchPoint.y)) {
+                    break; // Ok
+                }
                 if (box_list[49].contain(touchPoint.x, touchPoint.y)) {
                     caps = !caps;
                     tft.fillRect(0, 54, tftWidth, tftHeight - 54, bruceConfig.bgColor);
-                    goto THIS_END;
-                } // CAP
-                if (box_list[50].contain(touchPoint.x, touchPoint.y)) goto DEL; // DEL
-                if (box_list[51].contain(touchPoint.x, touchPoint.y)) {
-                    if (mytext.length() < maxSize) mytext += box_list[51].key;
-                    goto THIS_END;
-                } // SPACE
-                for (k = 0; k < 48; k++) {
-                    if (box_list[k].contain(touchPoint.x, touchPoint.y)) {
-                        if (caps) mytext += box_list[k].key_sh;
-                        else mytext += box_list[k].key;
+                    touchHandled = true;
+                }
+                if (box_list[50].contain(touchPoint.x, touchPoint.y)) {
+                    if (mytext.length() > 0) {
+                        handleDelete(mytext, cX, cY, maxFPSize);
+                        touchHandled = true;
                     }
                 }
-                wakeUpScreen();
-            THIS_END:
-                touchPoint.Clear();
-                redraw = true;
+                if (box_list[51].contain(touchPoint.x, touchPoint.y)) {
+                    if (mytext.length() < maxSize) {
+                        handleSpaceAdd(mytext, maxSize);
+                        touchHandled = true;
+                    }
+                }
+                for (k = 0; k < 48; k++) {
+                    if (box_list[k].contain(touchPoint.x, touchPoint.y)) {
+                        if (caps) handleCharacterAdd(mytext, box_list[k].key_sh, cX, cY, maxSize, maxFMSize);
+                        else handleCharacterAdd(mytext, box_list[k].key, cX, cY, maxSize, maxFMSize);
+                        touchHandled = true;
+                        break;
+                    }
+                }
+
+                if (touchHandled) {
+                    wakeUpScreen();
+                    touchPoint.Clear();
+                    redraw = true;
+                }
             }
 #endif
 
@@ -500,7 +650,7 @@ String keyboard(String mytext, int maxSize, String msg) {
                 }
                 LongPress = false;
                 // delay(10);
-                if (y < 0 && x > 3) x = 0;
+                if (y < 0 && x > 4) x = 0; // Changed from 3 to 4 to include BACK button
                 if (x > 11) x = 0;
                 else if (x < 0) x = 11;
                 redraw = true;
@@ -538,12 +688,12 @@ String keyboard(String mytext, int maxSize, String msg) {
             /* Down Btn to move in X axis (to the right) */
             if (check(NextPress)) {
                 x++;
-                if ((y < 0 && x > 3) || x > 11) x = 0;
+                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
                 redraw = true;
             }
             if (check(PrevPress)) {
                 x--;
-                if (y < 0 && x > 3) x = 3;
+                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
                 else if (x < 0) x = 11;
                 redraw = true;
             }
@@ -561,17 +711,17 @@ String keyboard(String mytext, int maxSize, String msg) {
 
 #elif defined(HAS_ENCODER) // T-Embed
             if (check(SelPress)) { goto SELECT; }
-            /* Down Btn to move in X axis (to the right) */
+            /* DOWN Btn to move in X axis (to the right) */
             if (check(NextPress)) {
                 if (check(EscPress)) {
                     y++;
-                } else if ((x >= 3 && y < 0) || x == 11) {
+                } else if ((x >= 4 && y < 0) || x == 11) {
                     y++;
                     x = 0;
                 } else x++;
 
                 if (y > 3) y = -1;
-                if (y == -1 && x > 3) x = 0;
+                if (y == -1 && x > 4) x = 0;
 
                 redraw = true;
             }
@@ -579,7 +729,7 @@ String keyboard(String mytext, int maxSize, String msg) {
             if (check(PrevPress)) {
                 if (check(EscPress)) {
                     y--;
-                    if (y == -1 && x > 3) x = 3;
+                    if (y == -1 && x > 4) x = 4;
                 } else if (x == 0) {
                     y--;
                     x--;
@@ -588,7 +738,7 @@ String keyboard(String mytext, int maxSize, String msg) {
                 if (y < -1) {
                     y = 3;
                     x = 11;
-                } else if (y < 0 && x < 0) x = 3;
+                } else if (y < 0 && x < 0) x = 4;
                 else if (x < 0) x = 11;
 
                 redraw = true;
@@ -619,16 +769,16 @@ String keyboard(String mytext, int maxSize, String msg) {
                 if (KeyStroke.del && mytext.length() > 0) { // delete 0x08
                     // Handle backspace key
                     mytext.remove(mytext.length() - 1);
-                    int fS = FM;
+                    int fontSize = FM;
                     if (mytext.length() > maxFPSize) {
                         tft.setTextSize(FP);
-                        fS = FP;
+                        fontSize = FP;
                     } else tft.setTextSize(FM);
-                    tft.setCursor((cX - fS * LW), cY);
+                    tft.setCursor((cX - fontSize * LW), cY);
                     tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
                     tft.print(" ");
                     tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-                    tft.setCursor(cX - fS * LW, cY);
+                    tft.setCursor(cX - fontSize * LW, cY);
                     cX = tft.getCursorX();
                     cY = tft.getCursorY();
                     if (mytext.length() == maxFMSize) redraw = true;
@@ -641,17 +791,18 @@ String keyboard(String mytext, int maxSize, String msg) {
 
 #endif
         } // end of holdCode detection
+
         if (SerialCmdPress) { // only for Remote Control, if no input was detected on device
             if (check(SelPress)) { goto SELECT; }
             /* Down Btn to move in X axis (to the right) */
             if (check(NextPress)) {
                 x++;
-                if ((y < 0 && x > 3) || x > 11) x = 0;
+                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
                 redraw = true;
             }
             if (check(PrevPress)) {
                 x--;
-                if (y < 0 && x > 3) x = 3;
+                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
                 else if (x < 0) x = 11;
                 redraw = true;
             }
@@ -667,43 +818,564 @@ String keyboard(String mytext, int maxSize, String msg) {
                 redraw = true;
             }
         }
-        if (false) { // When selecting some letter or something, use these goto addresses(ADD, DEL)
-        SELECT:
-            tft.setCursor(cX, cY);
-            if (caps) z = 1;
-            else z = 0;
-            if (x == 0 && y == -1) break;
-            else if (x == 1 && y == -1) caps = !caps;
-            else if (x == 2 && y == -1 && mytext.length() > 0) {
-            DEL:
-                mytext.remove(mytext.length() - 1);
-                int fS = FM;
-                if (mytext.length() > maxFPSize) {
-                    tft.setTextSize(FP);
-                    fS = FP;
-                } else tft.setTextSize(FM);
-                tft.setCursor((cX - fS * LW), cY);
-                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
-                tft.print(" ");
-                tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-                tft.setCursor(cX - fS * LW, cY);
-                cX = tft.getCursorX();
-                cY = tft.getCursorY();
-            } else if (x > 2 && y == -1 && mytext.length() < maxSize) mytext += " ";
-            else if (y > -1 && mytext.length() < maxSize) {
-            ADD:
-                mytext += keys[y][x][z];
-                if (mytext.length() != (maxFMSize + 1) && mytext.length() != (maxFMSize + 1))
-                    tft.print(keys[y][x][z]);
-                cX = tft.getCursorX();
-                cY = tft.getCursorY();
-                if (mytext.length() >= maxSize) { x = 0, y = -1; }; // Put the Cursor at "Ok"
+
+        if (false) { // When selecting some letter or something, use these helper functions instead of goto
+        SELECT:      // so when we "select", so when we click something, this is executed:
+            KeyboardAction action = handleRegularKeyboardSelection(
+                x, y, mytext, caps, cX, cY, maxSize, maxFMSize, maxFPSize, keys
+            );
+
+            if (action == KEYBOARD_OK || action == KEYBOARD_CANCEL) {
+                break;
+            } else if (action == KEYBOARD_REDRAW) {
+                redraw = true;
             }
-            redraw = true;
+
             holdCode = millis();
         }
     WAITING: // Used in long press detection
         yield();
+    }
+
+    // Resets screen when finished writing
+    tft.fillScreen(bruceConfig.bgColor);
+    resetTftDisplay();
+
+    return mytext;
+}
+
+/*********************************************************************
+** Function: hex_keyboard
+** location: mykeyboard.cpp
+** keyboard interface with hex only characters.
+**********************************************************************/
+String hex_keyboard(String mytext, int maxSize, String msg) {
+    resetTftDisplay();
+    touchPoint.Clear();
+    String _mytext = mytext;
+    const uint8_t max_chars = tftWidth / (LW * FM); // Display Width / (Letter Width * Medium Font)
+    const int maxFMSize = tftWidth / (LW * FM) - 1; //
+    const int maxFPSize = tftWidth / (LW)-2;
+    bool redraw = true;
+    long holdCode = millis(); // to hold the inputs for 250ms before adding other letter
+    int cX = 0;               // Cursor position
+    int cY = 0;               // Cursor position
+    int x = 0;
+    int y = -1; // -1 is where buttons are, out of keys[][][] array
+    int x2 = 0;
+    int y2 = 0;
+    //       [x][y], x2 and y2 are the previous position of x and y, used to redraw only that spot on
+    //       keyboard screen
+    char keys[4][4] = {
+        //  2 lines, with 10 characters, high caps
+        // {
+        //  '0', '1',
+        //  '2', '3',
+        //  '4', '5',
+        //  '6', '7',
+        //  '8', '9',
+        //  },
+        // {
+        //  'A', 'B',
+        //  'C', 'D',
+        //  'E', 'F',
+        //  },
+        //  4 lines, with 4 characters, high caps
+        {'0', '1', '2', '3'},
+        {'4', '5', '6', '7'},
+        {'8', '9', 'A', 'B'},
+        {'C', 'D', 'E', 'F'},
+    };
+    /****************TOP-BUTTONS****************/
+#if FM > 1      // Normal keyboard size
+#define KBLH 20 // Keyboard Buttons Line Height
+    // { x coord of btn border, btn width, x coord of the inside text }
+    int ofs[4][3] = {
+        {7,   46, 18 }, // OK button
+        {55,  50, 64 }, // DEL button
+        {107, 74, 115}, // SPACE button
+        {183, 62, 192}, // BACK button
+    };
+#else // small keyboard size, for small letters (smaller screen, like Marauder Mini and others ;) )
+#define KBLH 10
+    // { x coord of btn border, btn width, x coord of the inside text }
+    int ofs[4][3] = {
+        {7,   20, 10 }, // OK button
+        {27,  25, 30 }, // DEL button
+        {52,  50, 55 }, // SPACE button
+        {102, 40, 105}, // BACK button
+    };
+#endif
+    const int _x = tftWidth / 12;
+    const int _y = (tftHeight - (2 * KBLH + 14)) / 4;
+    const int _xo = _x / 2 - 3;
+
+#if defined(HAS_TOUCH)
+    int k = 0;
+    // Setup touch boxes for the 4x4 hex keyboard
+    for (x2 = 0; x2 < 4; x2++) {
+        for (y2 = 0; y2 < 4; y2++) {
+            box_list[k].key = keys[y2][x2];
+            box_list[k].key_sh = keys[y2][x2]; // hex chars don't have shift variants
+            box_list[k].color = ~bruceConfig.bgColor;
+            box_list[k].x = x2 * (_x * 3); // spread out 4 keys across 12-key width
+            box_list[k].y = y2 * _y + 54;
+            box_list[k].w = _x * 3;
+            box_list[k].h = _y;
+            k++;
+        }
+    }
+    // OK button (index 16)
+    box_list[k].key = ' ';
+    box_list[k].key_sh = ' ';
+    box_list[k].color = ~bruceConfig.bgColor;
+    box_list[k].x = ofs[0][0];
+    box_list[k].y = 0;
+    box_list[k].w = ofs[0][1];
+    box_list[k].h = 22;
+    k++;
+    // DEL button (index 17)
+    box_list[k].key = ' ';
+    box_list[k].key_sh = ' ';
+    box_list[k].color = ~bruceConfig.bgColor;
+    box_list[k].x = ofs[1][0];
+    box_list[k].y = 0;
+    box_list[k].w = ofs[1][1];
+    box_list[k].h = 22;
+    k++;
+    // SPACE button (index 18)
+    box_list[k].key = ' ';
+    box_list[k].key_sh = ' ';
+    box_list[k].color = ~bruceConfig.bgColor;
+    box_list[k].x = ofs[2][0];
+    box_list[k].y = 0;
+    box_list[k].w = ofs[2][1];
+    box_list[k].h = 22;
+    k++;
+    // BACK button (index 19)
+    box_list[k].key = ' ';
+    box_list[k].key_sh = ' ';
+    box_list[k].color = ~bruceConfig.bgColor;
+    box_list[k].x = ofs[3][0];
+    box_list[k].y = 0;
+    box_list[k].w = ofs[3][1];
+    box_list[k].h = 22;
+
+    k = 0;
+    x2 = 0;
+    y2 = 0;
+#endif
+
+    tft.fillScreen(bruceConfig.bgColor);
+
+#if defined(HAS_3_BUTTONS) // StickCs and Core for long press detection logic
+    uint8_t longNextPress = 0;
+    uint8_t longPrevPress = 0;
+    unsigned long LongPressTmp = millis();
+#endif
+
+    // main loop, display keyboard, manage keystrokes and displays the string
+    while (1) {
+        if (redraw) {
+            tft.setCursor(0, 0);
+            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+            tft.setTextSize(FM);
+
+            // Draw the top row buttons
+            if (y < 0 || y2 < 0) {
+                tft.fillRect(0, 1, tftWidth, 22, bruceConfig.bgColor);
+                // Draw the borders
+                tft.drawRect(
+                    ofs[0][0], 2, ofs[0][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+                ); // OK btn border
+                tft.drawRect(
+                    ofs[1][0], 2, ofs[1][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+                ); // DEL btn border
+                tft.drawRect(
+                    ofs[2][0], 2, ofs[2][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+                ); // SPACE btn border
+                tft.drawRect(
+                    ofs[3][0], 2, ofs[3][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+                ); // BACK btn border
+
+                tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
+
+                // Highlight the corresponding button when the user cursor is over it
+
+                // OK
+                if (x == 0 && y == -1) {
+                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+                    tft.fillRect(ofs[0][0], 2, ofs[0][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
+                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+                tft.drawString("OK", ofs[0][2], 4);
+
+                // DEL
+                if (x == 1 && y == -1) {
+                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+                    tft.fillRect(ofs[1][0], 2, ofs[1][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
+                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+                tft.drawString("DEL", ofs[1][2], 4);
+
+                // SPACE
+                if (x == 2 && y == -1) {
+                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+                    tft.fillRect(ofs[2][0], 2, ofs[2][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
+                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+                tft.drawString("SPACE", ofs[2][2], 4);
+
+                // BACK
+                if (x > 2 && y == -1) {
+                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+                    tft.fillRect(ofs[3][0], 2, ofs[3][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
+                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+                tft.drawString("BACK", ofs[3][2], 4);
+            }
+
+            // prints the title of the textbox, it should report what the user has to write in it
+            tft.setTextSize(FP);
+            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
+            tft.drawString(msg.substring(0, maxFPSize), 3, KBLH + 4);
+
+            // drawing the textbox and the currently typed string
+            tft.setTextSize(FM);
+            // reset the text box
+            if (mytext.length() == (maxFMSize) || mytext.length() == (maxFMSize + 1) ||
+                mytext.length() == (maxFPSize) || mytext.length() == (maxFPSize + 1))
+                tft.fillRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.bgColor);
+            // write the text
+            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor));
+            if (mytext.length() > maxFMSize) { // if the text is too long, we try to set the smaller font
+                tft.setTextSize(FP);
+                if (mytext.length() > maxFPSize) { // if its still too long, we divide it into two lines
+                    tft.drawString(mytext.substring(0, maxFPSize), 5, KBLH + LH + 6);
+                    tft.drawString(mytext.substring(maxFPSize, mytext.length()), 5, KBLH + 2 * LH + 6);
+                } else {
+                    tft.drawString(mytext, 5, KBLH + 14);
+                }
+            } else {
+                // else if it fits, just draw the text
+                tft.drawString(mytext, 5, KBLH + 14);
+            }
+            // Draw the textbox border again(?)
+            tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
+
+            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+            tft.setTextSize(FM);
+
+            // Draw the actual keyboard (4x4 hex layout)
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 4; j++) {
+                    int key_x = j * (_x * 3); // spread 4 keys across 12-key width
+                    int key_y = i * _y + KBLH * 2 + 16;
+                    int key_w = _x * 3; // key width
+
+                    // Use the previous coordinates to repaint only the previous letter
+                    if (x2 == j && y2 == i) {
+                        tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor);
+                        tft.fillRect(key_x, key_y, key_w, _y, bruceConfig.bgColor);
+                    }
+                    // If selected, highlight it by changing font color and filling the back rectangle
+                    if (x == j && y == i) {
+                        tft.setTextColor(bruceConfig.bgColor, ~bruceConfig.bgColor);
+                        tft.fillRect(key_x, key_y, key_w, _y, ~bruceConfig.bgColor);
+                    }
+
+                    // Print the hex characters
+                    tft.drawString(String(keys[i][j]), key_x + key_w / 2 - FM * LW / 2, key_y + 2);
+
+                    // Return colors to normal to print the other letters
+                    if (x == j && y == i) { tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor); }
+                }
+            }
+            // Save actual key coordinates
+            x2 = x;
+            y2 = y;
+            redraw = false;
+        }
+
+        // Cursor Handler
+        if (mytext.length() > maxFMSize) {
+            tft.setTextSize(FP);
+            if (mytext.length() > (maxFPSize)) {
+                cY = KBLH + 2 * LH + 6;
+                cX = 5 + (mytext.length() - maxFPSize) * LW;
+            } else {
+                cY = KBLH + LH + 6;
+                cX = 5 + mytext.length() * LW;
+            }
+        } else {
+            cY = KBLH + LH + 6;
+            cX = 5 + mytext.length() * LW * FM;
+        }
+
+        if (millis() - holdCode > 250) { // allow reading inputs
+
+#if defined(HAS_TOUCH) // CYD, Core2, CoreS3
+#if defined(USE_TFT_eSPI_TOUCH)
+            check(AnyKeyPress);
+#endif
+            if (touchPoint.pressed) {
+                // If using Touchscreen and buttons, reset the navigation states to not
+                // act weirdly, and put the cursor on Ok again.
+                SelPress = false;
+                EscPress = false;
+                NextPress = false;
+                PrevPress = false;
+                UpPress = false;
+                DownPress = false;
+                x = 0;
+                y = -1;
+
+                bool touchHandled = false;
+
+                // Check buttons (indices 16-19 for hex keyboard)
+                if (box_list[16].contain(touchPoint.x, touchPoint.y)) {
+                    break; // OK button
+                }
+                if (box_list[17].contain(touchPoint.x, touchPoint.y)) {
+                    if (mytext.length() > 0) {
+                        handleDelete(mytext, cX, cY, maxFPSize);
+                        touchHandled = true;
+                    }
+                } // DEL button
+                if (box_list[18].contain(touchPoint.x, touchPoint.y)) {
+                    if (mytext.length() < maxSize) {
+                        handleSpaceAdd(mytext, maxSize);
+                        touchHandled = true;
+                    }
+                } // SPACE button
+                if (box_list[19].contain(touchPoint.x, touchPoint.y)) {
+                    mytext = "\x1B"; // BACK button - ESC
+                    break;
+                }
+
+                // Check hex character keys (indices 0-15)
+                for (k = 0; k < 16; k++) {
+                    if (box_list[k].contain(touchPoint.x, touchPoint.y)) {
+                        handleCharacterAdd(mytext, box_list[k].key, cX, cY, maxSize, maxFMSize);
+                        touchHandled = true;
+                        break;
+                    }
+                }
+
+                if (touchHandled) {
+                    wakeUpScreen();
+                    touchPoint.Clear();
+                    redraw = true;
+                }
+            }
+#endif
+
+#if defined(HAS_3_BUTTONS) // StickCs and Core
+            if (check(SelPress)) { goto SELECT; }
+            /* Down Btn to move in X axis (to the right) */
+            if (longNextPress || NextPress) {
+                unsigned long now = millis();
+                if (!longNextPress) {
+                    longNextPress = 1;
+                    LongPress = true;
+                    LongPressTmp = now;
+                }
+                delay(1); // does not work without it
+                // Check if the button is held long enough (long press)
+                if (now - LongPressTmp > 300) {
+                    x--; // Long press action
+                    longNextPress = 2;
+                    LongPress = false;
+                    check(NextPress);
+                    LongPressTmp = now;
+                } else if (!NextPress) {
+                    if (longNextPress != 2) x++; // Short press action
+                    longNextPress = 0;
+                } else {
+                    goto WAITING;
+                }
+                LongPress = false;
+                // delay(10);
+                if (y < 0 && x > 4) x = 0; // Changed from 3 to 4 to include BACK button
+                if (x > 11) x = 0;
+                else if (x < 0) x = 11;
+                redraw = true;
+            }
+            /* UP Btn to move in Y axis (Downwards) */
+            if (longPrevPress || PrevPress) {
+                unsigned long now = millis();
+                if (!longPrevPress) {
+                    longPrevPress = 1;
+                    LongPress = true;
+                    LongPressTmp = now;
+                }
+                delay(1); // does not work without it
+                // Check if the button is held long enough (long press)
+                if (now - LongPressTmp > 300) {
+                    y--; // Long press action
+                    longPrevPress = 2;
+                    LongPress = false;
+                    check(PrevPress);
+                    LongPressTmp = now;
+                } else if (!PrevPress) {
+                    if (longPrevPress != 2) y++; // Short press action
+                    longPrevPress = 0;
+                } else {
+                    goto WAITING;
+                }
+                LongPress = false;
+                if (y > 3) {
+                    y = -1;
+                } else if (y < -1) y = 3;
+                redraw = true;
+            }
+#elif defined(HAS_5_BUTTONS) // Smoochie and Marauder-Mini
+            if (check(SelPress)) { goto SELECT; }
+            /* Down Btn to move in X axis (to the right) */
+            if (check(NextPress)) {
+                x++;
+                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
+                redraw = true;
+            }
+            if (check(PrevPress)) {
+                x--;
+                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
+                else if (x < 0) x = 11;
+                redraw = true;
+            }
+            /* UP Btn to move in Y axis (Downwards) */
+            if (check(DownPress)) {
+                y++;
+                if (y > 3) { y = -1; }
+                redraw = true;
+            }
+            if (check(UpPress)) {
+                y--;
+                if (y < -1) y = 3;
+                redraw = true;
+            }
+
+#elif defined(HAS_ENCODER) // T-Embed
+            if (check(SelPress)) { goto SELECT; }
+            /* DOWN Btn to move in X axis (to the right) */
+            if (check(NextPress)) {
+                if (check(EscPress)) {
+                    y++;
+                } else if ((x >= 4 && y < 0) || x == 3) {
+                    y++;
+                    x = 0;
+                } else x++;
+
+                if (y > 3) y = -1;
+                if (y == -1 && x > 4) x = 0;
+
+                redraw = true;
+            }
+            /* UP Btn to move in Y axis (Downwards) */
+            if (check(PrevPress)) {
+                if (check(EscPress)) {
+                    y--;
+                    if (y == -1 && x > 4) x = 4;
+                } else if (x == 0) {
+                    y--;
+                    x--;
+                } else x--;
+
+                if (y < -1) {
+                    y = 3;
+                    x = 3;
+                } else if (y < 0 && x < 0) x = 4;
+                else if (x < 0) x = 3;
+
+                redraw = true;
+            }
+
+#elif defined(HAS_KEYBOARD) // Cardputer and T-Deck
+            if (KeyStroke.pressed) {
+                wakeUpScreen();
+                tft.setCursor(cX, cY);
+                String keyStr = "";
+                for (auto i : KeyStroke.word) {
+                    if (keyStr != "") {
+                        keyStr = keyStr + "+" + i;
+                    } else {
+                        keyStr += i;
+                    }
+                }
+
+                if (mytext.length() < maxSize && !KeyStroke.enter && !KeyStroke.del) {
+                    mytext += keyStr;
+                    if (mytext.length() != (maxFMSize + 1) && mytext.length() != (maxFMSize + 1))
+                        tft.print(keyStr.c_str());
+                    cX = tft.getCursorX();
+                    cY = tft.getCursorY();
+                    if (mytext.length() == (maxFMSize + 1)) redraw = true;
+                    if (mytext.length() == (maxFPSize + 1)) redraw = true;
+                }
+                if (KeyStroke.del && mytext.length() > 0) { // delete 0x08
+                    // Handle backspace key
+                    mytext.remove(mytext.length() - 1);
+                    int fontSize = FM;
+                    if (mytext.length() > maxFPSize) {
+                        tft.setTextSize(FP);
+                        fontSize = FP;
+                    } else tft.setTextSize(FM);
+                    tft.setCursor((cX - fontSize * LW), cY);
+                    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                    tft.print(" ");
+                    tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
+                    tft.setCursor(cX - fontSize * LW, cY);
+                    cX = tft.getCursorX();
+                    cY = tft.getCursorY();
+                    if (mytext.length() == maxFMSize) redraw = true;
+                    if (mytext.length() == maxFPSize) redraw = true;
+                }
+                if (KeyStroke.enter) { break; }
+                KeyStroke.Clear();
+            }
+            if (check(SelPress)) break;
+
+#endif
+        } // end of holdCode detection
+
+        if (SerialCmdPress) { // only for Remote Control, if no input was detected on device
+            if (check(SelPress)) { goto SELECT; }
+            /* Down Btn to move in X axis (to the right) */
+            if (check(NextPress)) {
+                x++;
+                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
+                redraw = true;
+            }
+            if (check(PrevPress)) {
+                x--;
+                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
+                else if (x < 0) x = 11;
+                redraw = true;
+            }
+            /* UP Btn to move in Y axis (Downwards) */
+            if (check(DownPress)) {
+                y++;
+                if (y > 3) { y = -1; }
+                redraw = true;
+            }
+            if (check(UpPress)) {
+                y--;
+                if (y < -1) y = 3;
+                redraw = true;
+            }
+        }
+
+        if (false) { // When selecting some letter or something, use these helper functions instead of goto
+        SELECT:      // so when we "select", so when we click something, this is executed:
+            KeyboardAction action =
+                handleHexKeyboardSelection(x, y, mytext, cX, cY, maxSize, maxFMSize, maxFPSize, keys);
+
+            if (action == KEYBOARD_OK || action == KEYBOARD_CANCEL) {
+                break;
+            } else if (action == KEYBOARD_REDRAW) {
+                redraw = true;
+            }
+
+            holdCode = millis();
+        WAITING: // Used in long press detection
+            yield();
+        }
     }
 
     // Resets screen when finished writing

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -7,89 +7,82 @@
 #include "sd_functions.h"
 #include <ArduinoJson.h>
 
-const uint8_t max_chars = tftWidth / (LW * FM); // currently unused
 const int max_FM_size = tftWidth / (LW * FM) - 1;
 const int max_FP_size = tftWidth / (LW)-2;
-const int keyboard_width = 12;
-const int keyboard_height = 4;
-char keys[keyboard_height][keyboard_width][2] = {
-    //  4 lines, with 12 characters, capital and lowercase letters
-    {
-     {'1', '!'},  // 1
-        {'2', '@'},  // 2
-        {'3', '#'},  // 3
-        {'4', '$'},  // 4
-        {'5', '%'},  // 5
-        {'6', '^'},  // 6
-        {'7', '&'},  // 7
-        {'8', '*'},  // 8
-        {'9', '('},  // 9
-        {'0', ')'},  // 10
-        {'-', '_'},  // 11
-        {'=', '+'}  // 12
-    },
-    {
-     {'q', 'Q'},  // 1
-        {'w', 'W'},  // 2
-        {'e', 'E'},  // 3
-        {'r', 'R'},  // 4
-        {'t', 'T'},  // 5
-        {'y', 'Y'},  // 6
-        {'u', 'U'},  // 7
-        {'i', 'I'},  // 8
-        {'o', 'O'},  // 9
-        {'p', 'P'},  // 10
-        {'[', '{'},  // 11
-        {']', '}'}  // 12
-    },
-    {
-     {'a', 'A'},  // 1
-        {'s', 'S'},  // 2
-        {'d', 'D'},  // 3
-        {'f', 'F'},  // 4
-        {'g', 'G'},  // 5
-        {'h', 'H'},  // 6
-        {'j', 'J'},  // 7
-        {'k', 'K'},  // 8
-        {'l', 'L'},  // 9
-        {';', ':'},  // 10
-        {'"', '\''}, // 11
-        {'|', '\\'}  // 12
-    },
-    {
-     {'\\', '|'}, // 1
-        {'z', 'Z'}, // 2
-        {'x', 'X'}, // 3
-        {'c', 'C'}, // 4
-        {'v', 'V'}, // 5
-        {'b', 'B'}, // 6
-        {'n', 'N'}, // 7
-        {'m', 'M'}, // 8
-        {',', '<'}, // 9
-        {'.', '>'}, // 10
-        {'?', '/'}, // 11
-        {'/', '/'}   // 12
-    }
+
+// QWERTY KEYSET
+const int qwerty_keyboard_width = 12;
+const int qwerty_keyboard_height = 4;
+char qwerty_keyset[qwerty_keyboard_height][qwerty_keyboard_width][2] = {
+    //  4 lines, with 12 characters, capital and lowercase
+    {{'1', '!'},
+     {'2', '@'},
+     {'3', '#'},
+     {'4', '$'},
+     {'5', '%'},
+     {'6', '^'},
+     {'7', '&'},
+     {'8', '*'},
+     {'9', '('},
+     {'0', ')'},
+     {'-', '_'},
+     {'=', '+'} },
+    {{'q', 'Q'},
+     {'w', 'W'},
+     {'e', 'E'},
+     {'r', 'R'},
+     {'t', 'T'},
+     {'y', 'Y'},
+     {'u', 'U'},
+     {'i', 'I'},
+     {'o', 'O'},
+     {'p', 'P'},
+     {'[', '{'},
+     {']', '}'} },
+    {{'a', 'A'},
+     {'s', 'S'},
+     {'d', 'D'},
+     {'f', 'F'},
+     {'g', 'G'},
+     {'h', 'H'},
+     {'j', 'J'},
+     {'k', 'K'},
+     {'l', 'L'},
+     {';', ':'},
+     {'"', '\''},
+     {'|', '\\'}},
+    {{'\\', '|'},
+     {'z', 'Z'},
+     {'x', 'X'},
+     {'c', 'C'},
+     {'v', 'V'},
+     {'b', 'B'},
+     {'n', 'N'},
+     {'m', 'M'},
+     {',', '<'},
+     {'.', '>'},
+     {'?', '/'},
+     {'/', '/'} }
 };
-char hex_keys[keyboard_height][keyboard_width][1] = {
-    //  2 lines, with 10 characters, high caps
-    // {
-    //  '0', '1',
-    //  '2', '3',
-    //  '4', '5',
-    //  '6', '7',
-    //  '8', '9',
-    //  },
-    // {
-    //  'A', 'B',
-    //  'C', 'D',
-    //  'E', 'F',
-    //  },
-    //  4 lines, with 4 characters, high caps only
-    {'0', '1', '2', '3'},
-    {'4', '5', '6', '7'},
-    {'8', '9', 'A', 'B'},
-    {'C', 'D', 'E', 'F'},
+
+// HEX KEYSET
+const int hex_keyboard_width = 4;
+const int hex_keyboard_height = 4;
+char hex_keyset[hex_keyboard_height][hex_keyboard_width][2] = {
+    {{'0', '0'}, {'1', '1'}, {'2', '2'}, {'3', '3'}},
+    {{'4', '4'}, {'5', '5'}, {'6', '6'}, {'7', '7'}},
+    {{'8', '8'}, {'9', '9'}, {'A', 'a'}, {'B', 'b'}},
+    {{'C', 'c'}, {'D', 'd'}, {'E', 'e'}, {'F', 'f'}},
+};
+
+// NUMBERS ONLY KEYSET
+const int numpad_keyboard_width = 4;
+const int numpad_keyboard_height = 3;
+char numpad_keyset[numpad_keyboard_height][numpad_keyboard_width][2] = {
+    // 3 lines, with 4 characters each:
+    {{'1', '1'}, {'2', '2'}, {'3', '3'}, {'\0', '\0'}},
+    {{'4', '4'}, {'5', '5'}, {'6', '6'}, {'.', '.'}  },
+    {{'7', '7'}, {'8', '8'}, {'9', '9'}, {'0', '0'}  }
 };
 
 #if defined(HAS_TOUCH)
@@ -118,8 +111,6 @@ struct box_t {
         return this->x <= x && x < (this->x + this->w) && this->y <= y && y < (this->y + this->h);
     }
 };
-
-static constexpr std::size_t box_count = 53;
 
 #endif
 
@@ -277,10 +268,10 @@ enum KeyboardAction { KEYBOARD_CONTINUE, KEYBOARD_OK, KEYBOARD_CANCEL, KEYBOARD_
 
 /// Handles keyboard selection logic for regular keyboard
 KeyboardAction handleKeyboardSelection(
-    int &x, int &y, String &current_text, bool &caps, int &cursor_x, int &cursor_y, const int max_size
+    int &x, int &y, String &current_text, bool &caps, int &cursor_x, int &cursor_y, const int max_size,
+    char character
 ) {
     tft.setCursor(cursor_x, cursor_y);
-    int z = caps ? 1 : 0;
 
     if (y == -1) {
         switch (x) {
@@ -303,7 +294,7 @@ KeyboardAction handleKeyboardSelection(
 
     } else if (y > -1 && current_text.length() < max_size) {
         // add a letter to current_text
-        if (handleCharacterAdd(current_text, keys[x][y][z], cursor_x, cursor_y, max_size)) {
+        if (handleCharacterAdd(current_text, character, cursor_x, cursor_y, max_size)) {
             if (current_text.length() >= max_size) { // put the Cursor at "Ok" when max size reached
                 x = 0;
                 y = -1;
@@ -316,7 +307,10 @@ KeyboardAction handleKeyboardSelection(
     return KEYBOARD_CONTINUE;
 }
 
-String generalKeyboard(String current_text, int max_size, String textbox_title, bool caps_enabled) {
+template <int KeyboardHeight, int KeyboardWidth>
+String generalKeyboard(
+    String current_text, int max_size, String textbox_title, char keys[KeyboardHeight][KeyboardWidth][2]
+) {
     resetTftDisplay();
     touchPoint.Clear();
 
@@ -325,34 +319,69 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
     bool selection_made = false; // used for detecting if an key or a button was selected
     bool redraw = true;
     long last_input_time = millis(); // used for input debouncing
-    int buttons_number = 5;
     // cursor coordinates: kep track of where the next character should be printed (in screen pixels)
     int cursor_x = 0;
     int cursor_y = 0;
     // keyboard navigation coordinates: keep track of which key (or button) is currently selected
     int x = 0;
-    int y = -1; // -1 is where the buttons are, out of the keys[][][] array
-    int z = 0;
+    int y = -1; // -1 is where the buttons_strings are, out of the keys[][][] array
     int old_x = 0;
     int old_y = 0;
     //       [x][y] [z], old_x and old_y are the previous position of x and y, used to redraw only that spot
     //       on keyboard screen
 
+    /*====================Initial Setup====================*/
+
+    int buttons_number = 5;
+
+    /*-----------------------------HOW btns_layout IS CALCULATED-----------------------------*/
+    // const char *buttons_strings[] = {"OK", "CAP", "DEL", "SPACE", "BACK"};
+    // // { x coord of btn border, btn width, x coord of the inside text }
+    // int btns_layout[buttons_number][3];
+    // // OK btn is special, is larger than the others considering its only two letters
+    // btns_layout[0][0] = 7;  // space between the first button and the left margin
+    // btns_layout[0][1] = 46; // we use a padding of 12px instead of 9px
+    // btns_layout[0][3] = 19; // 7+12px
+    // for (size_t i = 0; i < buttons_number; i++) {
+    //     // start of previous btn + width of that btn + 2px padding between the buttons
+    //     btns_layout[i][0] = btns_layout[i - 1][0] + btns_layout[i - 1][1] + 2;
+    //     // 12px per character (10 for char + 2 for padding before next letter) - last padding
+    //     // + 9px padding * 2 (before and after string)
+    //     btns_layout[i][1] = (strlen(buttons_strings[i]) * 12) - 2 + 9 * 2;
+    //     // x coord for start of string
+    //     btns_layout[i][2] = btns_layout[i][0] + 9;
+    // }
+    //
+    // for smaller screens is the same thing, just different values for padding etc.
+    //
+    // btns_layouts are hard coded because there is no way yet to enable/disable buttons,
+    // so these do not change
+    /*---------------------------------------------------------------------------------------*/
+
 #if FM > 1      // Normal keyboard size
 #define KBLH 20 // Keyboard Buttons Line Height
     // { x coord of btn border, btn width, x coord of the inside text }
+    // 12 px = 10 px + 2 of padding between the letters -> refer to the section above to better understand
+    // ((12px * n_letters) - 2px ) + 9*2px = width
     int btns_layout[buttons_number][3] = {
-        {7,   46, 18 }, // OK button
+        {7,   46, 19 }, // OK button
         {55,  52, 64 }, // CAP button
         {109, 52, 118}, // DEL button
         {163, 76, 172}, // SPACE button
         {241, 64, 250}, // BACK button
-        // ~11 px per letter -> actually 10 px + 2 of padding between the letters
-        // ((12 * n_letters) - 2 ) + 9*2 = width
     };
-#else           // small keyboard size, for smaller screen, like Marauder Mini and others ;)
+
+    const int key_width = tftWidth / KeyboardWidth;
+    const int key_height = (tftHeight - (2 * KBLH + 14)) / KeyboardHeight;
+    // characters are 14px high and 10px wide
+    const int text_offset_x = key_width / 2 - 5;
+    const int text_offset_y = key_height / 2 - 7;
+#else           // small keyboard size, for  smaller screen, like Marauder Mini and others ;)
 #define KBLH 10 // Keyboard Buttons Line Height
-    buttons_number = 4;
+    // in smaller screens there is no space left for the BACK button
+    buttons_number = 4; // {"OK", "CAP", "DEL", "SPACE"};
+
+    // 5px per char
     int btns_layout[buttons_number][3] = {
         {2,  20, 5 }, // OK button
         {22, 25, 25}, // CAP button
@@ -360,16 +389,25 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
         {72, 50, 75}, // SPACE button
         // {122, 40, 125}, // BACK button
     };
+
+    const int key_width = tftWidth / KeyboardWidth;
+    const int key_height = (tftHeight - (2 * KBLH + 14)) / KeyboardHeight;
+    // characters are 7px high and 5px wide
+    const int text_offset_x = key_width / 2 - 2;
+    const int text_offset_y = key_height / 2 - 3;
 #endif
-    const int key_width = tftWidth / keyboard_width;
-    const int key_height = (tftHeight - (2 * KBLH + 14)) / keyboard_height;
-    const int text_offset_x = key_width / 2 - 3;
 
 #if defined(HAS_TOUCH) // filling touch box list
+    // Calculate actual box count
+    const int keyboard_boxes = KeyboardHeight * KeyboardWidth;
+    const int box_count = keyboard_boxes + buttons_number;
+
+    box_t box_list[box_count];
+
     int k = 0;
     // Setup keyboard touch boxes
-    for (int i = 0; i < keyboard_width; i++) {      // x coord
-        for (int j = 0; j < keyboard_height; j++) { // y coord
+    for (int i = 0; i < KeyboardWidth; i++) {      // x coord
+        for (int j = 0; j < KeyboardHeight; j++) { // y coord
             box_list[k].key = keys[j][i][0];
             box_list[k].key_sh = keys[j][i][1];
             box_list[k].color = ~bruceConfig.bgColor;
@@ -380,7 +418,8 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
             k++;
         }
     }
-    // Setup buttons touch boxes
+    const int buttons_start_index = k;
+    // Setup buttons_strings touch boxes
     for (int i = 0; i < buttons_number; i++) {
         box_list[k].key = ' ';
         box_list[k].key_sh = ' ';
@@ -411,10 +450,10 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
             tft.setTextSize(FM);
 
-            // Draw the top row buttons
+            // Draw the top row buttons_strings
             if (y < 0 || old_y < 0) {
                 tft.fillRect(0, 1, tftWidth, 22, bruceConfig.bgColor);
-                // Draw the buttons borders
+                // Draw the buttons_strings borders
                 for (int i = 0; i < buttons_number; ++i) {
                     tft.drawRect(
                         btns_layout[i][0],
@@ -495,10 +534,22 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
 #endif
             }
 
-            // Prints the title of the textbox, it should report what the user has to write in it
+            // Prints the chars counter
             tft.setTextSize(FP);
+            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor, true);
+            String chars_counter = String(current_text.length()) + "/" + String(max_size);
+            tft.fillRect(
+                tftWidth - ((chars_counter.length() * 6) + 20), // 5px per char + 1 padding
+                KBLH + 4,
+                (chars_counter.length() * 6) + 20,
+                7,
+                bruceConfig.bgColor
+            ); // clear previous text
+            tft.drawString(chars_counter, tftWidth - ((chars_counter.length() * 6) + 10), KBLH + 4);
+
+            // Prints the title of the textbox, it should report what the user has to write in it
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-            tft.drawString(textbox_title.substring(0, max_FP_size), 3, KBLH + 4);
+            tft.drawString(textbox_title.substring(0, max_FP_size - chars_counter.length() - 1), 3, KBLH + 4);
 
             // Drawing the textbox and the currently typed string
             tft.setTextSize(FM);
@@ -531,8 +582,8 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
             tft.setTextSize(FM);
 
             // Draw the actual keyboard
-            for (int i = 0; i < keyboard_height; i++) {
-                for (int j = 0; j < keyboard_width; j++) {
+            for (int i = 0; i < KeyboardHeight; i++) {
+                for (int j = 0; j < KeyboardWidth; j++) {
                     // key coordinates
                     int key_x = j * key_width;
                     int key_y = i * key_height + KBLH * 2 + 14;
@@ -549,8 +600,9 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
                     }
 
                     // Print the letters
-                    if (!caps) tft.drawString(String(keys[i][j][0]), key_x + text_offset_x, key_y + 2);
-                    else tft.drawString(String(keys[i][j][1]), key_x + text_offset_x, key_y + 2);
+                    if (!caps)
+                        tft.drawString(String(keys[i][j][0]), key_x + text_offset_x, key_y + text_offset_y);
+                    else tft.drawString(String(keys[i][j][1]), key_x + text_offset_x, key_y + text_offset_y);
 
                     // Return colors to normal to print the other letters
                     if (x == j && y == i) { tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor); }
@@ -585,7 +637,7 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
             check(AnyKeyPress);
 #endif
             if (touchPoint.pressed) {
-                // If using touchscreen and buttons, reset the navigation states to avoid inconsistent
+                // If using touchscreen and buttons_strings, reset the navigation states to avoid inconsistent
                 // behavior, and reset the navigation coords to the OK button.
                 SelPress = false;
                 EscPress = false;
@@ -598,31 +650,33 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
 
                 bool touchHandled = false;
 
-                if (box_list[48].contain(touchPoint.x, touchPoint.y)) { // OK btn
+                if (box_list[buttons_start_index].contain(touchPoint.x, touchPoint.y)) { // OK btn
                     break;
                 }
-                if (box_list[49].contain(touchPoint.x, touchPoint.y)) { // CAPS btn
+                if (box_list[buttons_start_index + 1].contain(touchPoint.x, touchPoint.y)) { // CAPS btn
                     caps = !caps;
                     tft.fillRect(0, 54, tftWidth, tftHeight - 54, bruceConfig.bgColor);
                     touchHandled = true;
                 }
-                if (box_list[50].contain(touchPoint.x, touchPoint.y)) { // DEL btn
+                if (box_list[buttons_start_index + 2].contain(touchPoint.x, touchPoint.y)) { // DEL btn
                     if (current_text.length() > 0) {
                         handleDelete(current_text, cursor_x, cursor_y);
                         touchHandled = true;
                     }
                 }
-                if (box_list[51].contain(touchPoint.x, touchPoint.y)) { // SPACE btn
+                if (box_list[buttons_start_index + 3].contain(touchPoint.x, touchPoint.y)) { // SPACE btn
                     if (current_text.length() < max_size) {
                         handleSpaceAdd(current_text, max_size);
                         touchHandled = true;
                     }
                 }
-                if (box_list[52].contain(touchPoint.x, touchPoint.y)) { // BACK btn
-                    current_text = "\x1B";                              // ASCII ESC CHARACTER
+#if FM > 1
+                if (box_list[buttons_start_index + 4].contain(touchPoint.x, touchPoint.y)) { // BACK btn
+                    current_text = "\x1B"; // ASCII ESC CHARACTER
                     break;
                 }
-                for (k = 0; k < 48; k++) {
+#endif
+                for (k = 0; k < keyboard_boxes; k++) {
                     if (box_list[k].contain(touchPoint.x, touchPoint.y)) {
                         if (caps)
                             handleCharacterAdd(
@@ -669,8 +723,8 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
                 LongPress = false;
                 // delay(10);
                 if (y < 0 && x >= buttons_number) x = 0;
-                if (x >= keyboard_width) x = 0;
-                else if (x < 0) x = keyboard_width - 1;
+                if (x >= KeyboardWidth) x = 0;
+                else if (x < 0) x = KeyboardWidth - 1;
                 redraw = true;
             }
             /* UP Btn to move in Y axis (Downwards) */
@@ -696,9 +750,9 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
                     continue;
                 }
                 LongPress = false;
-                if (y >= keyboard_height) {
+                if (y >= KeyboardHeight) {
                     y = -1;
-                } else if (y < -1) y = keyboard_height - 1;
+                } else if (y < -1) y = KeyboardHeight - 1;
                 redraw = true;
             }
 #elif defined(HAS_5_BUTTONS) // Smoochie and Marauder-Mini
@@ -706,24 +760,24 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
             /* Down Btn to move in X axis (to the right) */
             if (check(NextPress)) {
                 x++;
-                if ((y < 0 && x >= buttons_number) || x >= keyboard_width) x = 0;
+                if ((y < 0 && x >= buttons_number) || x >= KeyboardWidth) x = 0;
                 redraw = true;
             }
             if (check(PrevPress)) {
                 x--;
                 if (y < 0 && x >= buttons_number) x = buttons_number - 1;
-                else if (x < 0) x = keyboard_width - 1;
+                else if (x < 0) x = KeyboardWidth - 1;
                 redraw = true;
             }
             /* UP Btn to move in Y axis (Downwards) */
             if (check(DownPress)) {
                 y++;
-                if (y > keyboard_height - 1) { y = -1; }
+                if (y > KeyboardHeight - 1) { y = -1; }
                 redraw = true;
             }
             if (check(UpPress)) {
                 y--;
-                if (y < -1) y = keyboard_height - 1;
+                if (y < -1) y = KeyboardHeight - 1;
                 redraw = true;
             }
 
@@ -734,17 +788,17 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
             if (check(NextPress)) {
                 if (check(EscPress)) {
                     y++;
-                } else if ((x >= buttons_number - 1 && y <= -1) || x >= keyboard_width) {
+                } else if ((x >= buttons_number - 1 && y <= -1) || (x >= KeyboardWidth - 1 && y >= 0)) {
                     // if we are at the end of the current line
                     y++;   // next line
                     x = 0; // reset to first key
                 } else x++;
 
-                if (y >= keyboard_height)
+                if (y >= KeyboardHeight)
                     y = -1; // if we are at the end of the keyboard, then return to the top
 
                 // If we move to a new line using the ESC-press navigation and the previous x coordinate is
-                // greater than the number of available buttons on the new line, reset x to avoid
+                // greater than the number of available buttons_strings on the new line, reset x to avoid
                 // out-of-bounds behavior, this can only happen when switching to the first line, as the
                 // others have all the same number of keys
                 if (y == -1 && x >= buttons_number) x = 0;
@@ -757,14 +811,16 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
                     y--;
                 } else if (x <= 0) {
                     y--;
-                    x = keyboard_width - 1;
+                    if (y == -1) x = buttons_number - 1;
+                    else x = KeyboardWidth - 1;
                 } else x--;
 
-                if (y < -1) {
-                    y = keyboard_height - 1;
-                    x = keyboard_width - 1;
-                } else if (y == -1 && x >= buttons_number) x = buttons_number - 1;
-                else if (x < 0) x = keyboard_width - 1;
+                if (y < -1) { // go back to the bottom right of the keyboard
+                    y = KeyboardHeight - 1;
+                    x = KeyboardWidth - 1;
+                }
+                // else if (y == -1 && x >= buttons_number) x = buttons_number - 1;
+                // else if (x < 0) x = KeyboardWidth - 1;
 
                 redraw = true;
             }
@@ -823,32 +879,38 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
             /* Next-Prev Btns to move in X axis (right-left) */
             if (check(NextPress)) {
                 x++;
-                if ((y < 0 && x >= buttons_number) || x >= keyboard_width) x = 0;
+                if ((y < 0 && x >= buttons_number) || x >= KeyboardWidth) x = 0;
                 redraw = true;
             }
             if (check(PrevPress)) {
                 x--;
                 if (y < 0 && x >= buttons_number) x = buttons_number - 1;
-                else if (x < 0) x = keyboard_width - 1;
+                else if (x < 0) x = KeyboardWidth - 1;
                 redraw = true;
             }
             /* Down-Up Btns to move in Y axis */
             if (check(DownPress)) {
                 y++;
-                if (y >= keyboard_height) { y = -1; }
+                if (y >= KeyboardHeight) { y = -1; }
                 redraw = true;
             }
             if (check(UpPress)) {
                 y--;
-                if (y < -1) y = keyboard_height - 1;
+                if (y < -1) y = KeyboardHeight - 1;
                 redraw = true;
             }
         }
 
         if (selection_made) { // if something was selected then handle it
             selection_made = false;
-            KeyboardAction action =
-                handleKeyboardSelection(x, y, current_text, caps, cursor_x, cursor_y, max_size);
+
+            char selected_char = (y == -1) ? ' ' : keys[y][x][caps];
+
+            if (selected_char == '\0') { continue; } // if we selected a key which have the value of
+
+            KeyboardAction action = handleKeyboardSelection(
+                x, y, current_text, caps, cursor_x, cursor_y, max_size, selected_char
+            );
 
             if (action == KEYBOARD_OK) { // OK BTN
                 break;
@@ -870,17 +932,28 @@ String generalKeyboard(String current_text, int max_size, String textbox_title, 
     return current_text;
 }
 
-/*********************************************************************
-** Function: keyboard
-** location: mykeyboard.cpp
-** keyboard interface.
-**********************************************************************/
+/// This calls the QUERTY keyboard. Returns the user typed strings, return the ASCII ESC character
+/// if the operation was cancelled
 String keyboard(String current_text, int max_size, String textbox_title) {
-    return generalKeyboard(current_text, max_size, textbox_title, true);
+    return generalKeyboard<qwerty_keyboard_height, qwerty_keyboard_width>(
+        current_text, max_size, textbox_title, qwerty_keyset
+    );
 }
 
+/// This calls a keyboard with the characters useful to write hexadecimal codes.
+/// Returns the user typed strings, return the ASCII ESC character if the operation was cancelled
 String hex_keyboard(String current_text, int max_size, String textbox_title) {
-    return generalKeyboard(current_text, max_size, textbox_title, false);
+    return generalKeyboard<hex_keyboard_height, hex_keyboard_width>(
+        current_text, max_size, textbox_title, hex_keyset
+    );
+}
+
+/// This calls a numbers only keyboard. Returns the user typed strings, return the ASCII ESC character
+/// if the operation was cancelled
+String num_keyboard(String current_text, int max_size, String textbox_title) {
+    return generalKeyboard<numpad_keyboard_height, numpad_keyboard_width>(
+        current_text, max_size, textbox_title, numpad_keyset
+    );
 }
 
 void powerOff() { displayWarning("Not available", true); }

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -7,6 +7,72 @@
 #include "sd_functions.h"
 #include <ArduinoJson.h>
 
+const uint8_t max_chars = tftWidth / (LW * FM);
+const int max_FM_size = tftWidth / (LW * FM) - 1;
+const int max_FP_size = tftWidth / (LW)-2;
+const int keyboard_width = 12;
+const int keyboard_heigth = 4;
+const int buttons_number = 5;
+char keys[keyboard_heigth][keyboard_width][2] = {
+    //  4 lines, with 12 characters, capital and lowercase letters
+    {
+     {'1', '!'},  // 1
+        {'2', '@'},  // 2
+        {'3', '#'},  // 3
+        {'4', '$'},  // 4
+        {'5', '%'},  // 5
+        {'6', '^'},  // 6
+        {'7', '&'},  // 7
+        {'8', '*'},  // 8
+        {'9', '('},  // 9
+        {'0', ')'},  // 10
+        {'-', '_'},  // 11
+        {'=', '+'}  // 12
+    },
+    {
+     {'q', 'Q'},  // 1
+        {'w', 'W'},  // 2
+        {'e', 'E'},  // 3
+        {'r', 'R'},  // 4
+        {'t', 'T'},  // 5
+        {'y', 'Y'},  // 6
+        {'u', 'U'},  // 7
+        {'i', 'I'},  // 8
+        {'o', 'O'},  // 9
+        {'p', 'P'},  // 10
+        {'[', '{'},  // 11
+        {']', '}'}  // 12
+    },
+    {
+     {'a', 'A'},  // 1
+        {'s', 'S'},  // 2
+        {'d', 'D'},  // 3
+        {'f', 'F'},  // 4
+        {'g', 'G'},  // 5
+        {'h', 'H'},  // 6
+        {'j', 'J'},  // 7
+        {'k', 'K'},  // 8
+        {'l', 'L'},  // 9
+        {';', ':'},  // 10
+        {'"', '\''}, // 11
+        {'|', '\\'}  // 12
+    },
+    {
+     {'\\', '|'}, // 1
+        {'z', 'Z'}, // 2
+        {'x', 'X'}, // 3
+        {'c', 'C'}, // 4
+        {'v', 'V'}, // 5
+        {'b', 'B'}, // 6
+        {'n', 'N'}, // 7
+        {'m', 'M'}, // 8
+        {',', '<'}, // 9
+        {'.', '>'}, // 10
+        {'?', '/'}, // 11
+        {'/', '/'}   // 12
+    }
+};
+
 #if defined(HAS_TOUCH)
 struct box_t {
     int x;
@@ -146,105 +212,123 @@ char checkLetterShortcutPress() {
 ** Shared keyboard helper functions
 **********************************************************************/
 
-// Handles character deletion from the text string and screen
-bool handleDelete(String &mytext, int &cX, int &cY, const int maxFPSize) {
-    if (mytext.length() == 0) return false;
+/// Handles character deletion from the text string and screen
+bool handleDelete(String &current_text, int &cursor_x, int &cursor_y, const int max_FP_size) {
+    if (current_text.length() == 0) return false;
 
     // remove from string
-    mytext.remove(mytext.length() - 1);
+    current_text.remove(current_text.length() - 1);
     // delete from screen:
     int fontSize = FM;
-    if (mytext.length() > maxFPSize) {
+    if (current_text.length() > max_FP_size) {
         tft.setTextSize(FP);
         fontSize = FP;
     } else tft.setTextSize(FM);
-    tft.setCursor((cX - fontSize * LW), cY);
+    tft.setCursor((cursor_x - fontSize * LW), cursor_y);
     tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
     tft.print(" ");
     tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-    tft.setCursor(cX - fontSize * LW, cY);
-    cX = tft.getCursorX();
-    cY = tft.getCursorY();
+    tft.setCursor(cursor_x - fontSize * LW, cursor_y);
+    cursor_x = tft.getCursorX();
+    cursor_y = tft.getCursorY();
     return true;
 }
 
-// Handles adding a character to the text string
+/// Handles adding a character to the text string
 bool handleCharacterAdd(
-    String &mytext, char character, int &cX, int &cY, const int maxSize, const int maxFMSize
+    String &current_text, char character, int &cursor_x, int &cursor_y, const int max_size,
+    const int max_FM_size
 ) {
-    if (mytext.length() >= maxSize) return false;
+    if (current_text.length() >= max_size) return false;
 
-    mytext += character;
-    if (mytext.length() != (maxFMSize + 1) && mytext.length() != (maxFMSize + 1)) tft.print(character);
-    cX = tft.getCursorX();
-    cY = tft.getCursorY();
+    current_text += character;
+    if (current_text.length() != (max_FM_size + 1) && current_text.length() != (max_FM_size + 1))
+        tft.print(character);
+    cursor_x = tft.getCursorX();
+    cursor_y = tft.getCursorY();
     return true;
 }
 
-// Handles adding space to the text string
-bool handleSpaceAdd(String &mytext, const int maxSize) {
-    if (mytext.length() >= maxSize) return false;
-    mytext += " ";
+/// Handles adding space to the text string
+bool handleSpaceAdd(String &current_text, const int max_size) {
+    if (current_text.length() >= max_size) return false;
+    current_text += " ";
     return true;
 }
 
 // Enum for keyboard action results
 enum KeyboardAction { KEYBOARD_CONTINUE, KEYBOARD_OK, KEYBOARD_CANCEL, KEYBOARD_REDRAW };
 
-// Handles keyboard selection logic for regular keyboard
+/// Handles keyboard selection logic for regular keyboard
 KeyboardAction handleRegularKeyboardSelection(
-    int x, int y, String &mytext, bool &caps, int &cX, int &cY, const int maxSize, const int maxFMSize,
-    const int maxFPSize, char keys[4][12][2]
+    int &x, int &y, String &current_text, bool &caps, int &cursor_x, int &cursor_y, const int max_size
 ) {
-    tft.setCursor(cX, cY);
+    tft.setCursor(cursor_x, cursor_y);
     int z = caps ? 1 : 0;
 
-    if (x == 0 && y == -1) {
-        return KEYBOARD_OK; // OK button
-    } else if (x == 1 && y == -1) {
-        caps = !caps; // CAP button
-        return KEYBOARD_REDRAW;
-    } else if (x == 2 && y == -1 && mytext.length() > 0) {
-        handleDelete(mytext, cX, cY, maxFPSize); // DEL button
-        return KEYBOARD_REDRAW;
-    } else if (x == 3 && y == -1 && mytext.length() < maxSize) {
-        handleSpaceAdd(mytext, maxSize); // SPACE button
-        return KEYBOARD_REDRAW;
-    } else if (x == 4 && y == -1) {
-        mytext = ""; // BACK button - return empty string to cancel
-        return KEYBOARD_CANCEL;
-    } else if (y > -1 && mytext.length() < maxSize) {
-        handleCharacterAdd(mytext, keys[y][x][z], cX, cY, maxSize, maxFMSize); // add letters to mytext
-        if (mytext.length() >= maxSize) {
-            // Put the Cursor at "Ok" when max size reached
-            // This would need to be handled by the caller
+    if (y == -1) {
+        switch (x) {
+            case 0: return KEYBOARD_OK; // OK button
+
+            case 1:
+                caps = !caps; // CAP button
+                return KEYBOARD_REDRAW;
+
+            case 2:
+                if (handleDelete(current_text, cursor_x, cursor_y, max_FP_size)) // DEL button
+                    return KEYBOARD_REDRAW;
+                break;
+
+            case 3:
+                if (handleSpaceAdd(current_text, max_size)) // SPACE button
+                    return KEYBOARD_REDRAW;
+                break;
+
+            case 4:
+                current_text = ""; // BACK button - return empty string to cancel
+                return KEYBOARD_CANCEL;
+
+            default: break;
         }
-        return KEYBOARD_REDRAW;
+
+    } else if (y > -1 && current_text.length() < max_size) {
+        // add a letter to current_text
+        if (handleCharacterAdd(current_text, keys[y][x][z], cursor_x, cursor_y, max_size, max_FM_size)) {
+            if (current_text.length() >= max_size) { // put the Cursor at "Ok" when max size reached
+                x = 0;
+                y = -1;
+            }
+
+            return KEYBOARD_REDRAW;
+        }
     }
+
     return KEYBOARD_CONTINUE;
 }
 
 // Handles keyboard selection logic for hex keyboard
 KeyboardAction handleHexKeyboardSelection(
-    int x, int y, String &mytext, int &cX, int &cY, const int maxSize, const int maxFMSize,
-    const int maxFPSize, char keys[4][4]
+    int x, int y, String &current_text, int &cursor_x, int &cursor_y, const int max_size,
+    const int max_FM_size, const int max_FP_size, char keys[4][4]
 ) {
-    tft.setCursor(cX, cY);
+    tft.setCursor(cursor_x, cursor_y);
 
     if (x == 0 && y == -1) {
         return KEYBOARD_OK; // OK button
-    } else if (x == 1 && y == -1 && mytext.length() > 0) {
-        handleDelete(mytext, cX, cY, maxFPSize); // DEL button
+    } else if (x == 1 && y == -1 && current_text.length() > 0) {
+        handleDelete(current_text, cursor_x, cursor_y, max_FP_size); // DEL button
         return KEYBOARD_REDRAW;
-    } else if (x == 2 && y == -1 && mytext.length() < maxSize) {
-        handleSpaceAdd(mytext, maxSize); // SPACE button
+    } else if (x == 2 && y == -1 && current_text.length() < max_size) {
+        handleSpaceAdd(current_text, max_size); // SPACE button
         return KEYBOARD_REDRAW;
     } else if (x == 3 && y == -1) {
-        mytext = "\x1B"; // BACK button - return ESC to cancel
+        current_text = "\x1B"; // BACK button - return ESC to cancel
         return KEYBOARD_CANCEL;
-    } else if (y > -1 && mytext.length() < maxSize) {
-        handleCharacterAdd(mytext, keys[y][x], cX, cY, maxSize, maxFMSize); // add hex letters to mytext
-        if (mytext.length() >= maxSize) {
+    } else if (y > -1 && current_text.length() < max_size) {
+        handleCharacterAdd(
+            current_text, keys[y][x], cursor_x, cursor_y, max_size, max_FM_size
+        ); // add hex letters to current_text
+        if (current_text.length() >= max_size) {
             // Put the Cursor at "Ok" when max size reached
             // This would need to be handled by the caller
         }
@@ -258,97 +342,39 @@ KeyboardAction handleHexKeyboardSelection(
 ** location: mykeyboard.cpp
 ** keyboard interface.
 **********************************************************************/
-String keyboard(String mytext, int maxSize, String msg) {
+String keyboard(String current_text, int max_size, String msg) {
     resetTftDisplay();
     touchPoint.Clear();
-    String _mytext = mytext;
-    const uint8_t max_chars = tftWidth / (LW * FM);
-    const int maxFMSize = tftWidth / (LW * FM) - 1;
-    const int maxFPSize = tftWidth / (LW)-2;
+    String _mytext = current_text;
     bool caps = false;
+    bool selection_made = false; // used for detecting if an key or a button was selected
     bool redraw = true;
-    long holdCode = millis(); // to hold the inputs for 250ms before adding other letter
-    int cX = 0;               // Cursor position
-    int cY = 0;               // Cursor position
+    long last_input_time = millis(); // used for input debouncing
+    // cursor coordinates: kep track of where the next character should be printed (in screen pixels)
+    int cursor_x = 0;
+    int cursor_y = 0;
+    // keyboard navigation coordinates: keep track of which key (or button) is currently selected
     int x = 0;
-    int y = -1; // -1 is where buttons are, out of keys[][][] array
+    int y = -1; // -1 is where the buttons are, out of the keys[][][] array
     int z = 0;
-    int x2 = 0;
-    int y2 = 0;
-    //       [x][y] [z], x2 and y2 are the previous position of x and y, used to redraw only that spot on
-    //       keyboard screen
-    char keys[4][12][2] = {
-        //  4 lines, with 12 characteres, low and high caps
-        {
-         {'1', '!'},  // 1
-            {'2', '@'},  // 2
-            {'3', '#'},  // 3
-            {'4', '$'},  // 4
-            {'5', '%'},  // 5
-            {'6', '^'},  // 6
-            {'7', '&'},  // 7
-            {'8', '*'},  // 8
-            {'9', '('},  // 9
-            {'0', ')'},  // 10
-            {'-', '_'},  // 11
-            {'=', '+'}  // 12
-        },
-        {
-         {'q', 'Q'},  // 1
-            {'w', 'W'},  // 2
-            {'e', 'E'},  // 3
-            {'r', 'R'},  // 4
-            {'t', 'T'},  // 5
-            {'y', 'Y'},  // 6
-            {'u', 'U'},  // 7
-            {'i', 'I'},  // 8
-            {'o', 'O'},  // 9
-            {'p', 'P'},  // 10
-            {'[', '{'},  // 11
-            {']', '}'}  // 12
-        },
-        {
-         {'a', 'A'},  // 1
-            {'s', 'S'},  // 2
-            {'d', 'D'},  // 3
-            {'f', 'F'},  // 4
-            {'g', 'G'},  // 5
-            {'h', 'H'},  // 6
-            {'j', 'J'},  // 7
-            {'k', 'K'},  // 8
-            {'l', 'L'},  // 9
-            {';', ':'},  // 10
-            {'"', '\''}, // 11
-            {'|', '\\'}  // 12
-        },
-        {
-         {'\\', '|'}, // 1
-            {'z', 'Z'}, // 2
-            {'x', 'X'}, // 3
-            {'c', 'C'}, // 4
-            {'v', 'V'}, // 5
-            {'b', 'B'}, // 6
-            {'n', 'N'}, // 7
-            {'m', 'M'}, // 8
-            {',', '<'}, // 9
-            {'.', '>'}, // 10
-            {'?', '/'}, // 11
-            {'/', '/'}   // 12
-        }
-    };
+    int old_x = 0;
+    int old_y = 0;
+    //       [x][y] [z], old_x and old_y are the previous position of x and y, used to redraw only that spot
+    //       on keyboard screen
+
 #if FM > 1      // Normal keyboard size
 #define KBLH 20 // Keyboard Buttons Line Height
     // { x coord of btn border, btn width, x coord of the inside text }
-    int ofs[5][3] = {
+    int ofs[buttons_number][3] = {
         {7,   46, 18 }, // OK button
         {55,  50, 64 }, // CAP button
         {107, 50, 115}, // DEL button
         {159, 74, 168}, // SPACE button
         {235, 62, 244}, // BACK button
     };
-#else // small keyboard size, for small letters (smaller screen, like Marauder Mini and others ;) )
-#define KBLH 10
-    int ofs[5][3] = {
+#else           // small keyboard size, for smaller screen, like Marauder Mini and others ;)
+#define KBLH 10 // Keyboard Buttons Line Height
+    int ofs[buttons_number][3] = {
         {7,   20, 10 }, // OK button
         {27,  25, 30 }, // CAP button
         {52,  25, 55 }, // DEL button
@@ -356,21 +382,21 @@ String keyboard(String mytext, int maxSize, String msg) {
         {127, 40, 130}, // BACK button
     };
 #endif
-    const int _x = tftWidth / 12;
-    const int _y = (tftHeight - (2 * KBLH + 14)) / 4;
-    const int _xo = _x / 2 - 3;
+    const int key_width = tftWidth / keyboard_width;
+    const int key_height = (tftHeight - (2 * KBLH + 14)) / keyboard_heigth;
+    const int text_offset_x = key_width / 2 - 3;
 
 #if defined(HAS_TOUCH) // filling touch box list
     int k = 0;
-    for (x2 = 0; x2 < 12; x2++) {
-        for (y2 = 0; y2 < 4; y2++) {
-            box_list[k].key = keys[y2][x2][0];
-            box_list[k].key_sh = keys[y2][x2][1];
+    for (old_x = 0; old_x < keyboard_width; old_x++) {
+        for (old_y = 0; old_y < keyboard_heigth; old_y++) {
+            box_list[k].key = keys[old_y][old_x][0];
+            box_list[k].key_sh = keys[old_y][old_x][1];
             box_list[k].color = ~bruceConfig.bgColor;
-            box_list[k].x = x2 * _x;
-            box_list[k].y = y2 * _y + 54;
-            box_list[k].w = _x;
-            box_list[k].h = _y;
+            box_list[k].x = old_x * key_width;
+            box_list[k].y = old_y * key_height + 54;
+            box_list[k].w = key_width;
+            box_list[k].h = key_height;
             k++;
         }
     }
@@ -411,11 +437,11 @@ String keyboard(String mytext, int maxSize, String msg) {
     box_list[k].h = 22;
 
     k = 0;
-    x2 = 0;
-    y2 = 0;
+    old_x = 0;
+    old_y = 0;
 #endif
 
-    tft.fillScreen(bruceConfig.bgColor);
+    tft.fillScreen(bruceConfig.bgColor); // reset the screen
 
 #if defined(HAS_3_BUTTONS) // StickCs and Core for long press detection logic
     uint8_t longNextPress = 0;
@@ -423,14 +449,16 @@ String keyboard(String mytext, int maxSize, String msg) {
     unsigned long LongPressTmp = millis();
 #endif
 
+    // main loop
     while (1) {
         if (redraw) {
+            // setup
             tft.setCursor(0, 0);
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
             tft.setTextSize(FM);
 
             // Draw the top row buttons
-            if (y < 0 || y2 < 0) {
+            if (y < 0 || old_y < 0) {
                 tft.fillRect(0, 1, tftWidth, 22, bruceConfig.bgColor);
                 // Draw the borders
                 tft.drawRect(
@@ -451,7 +479,7 @@ String keyboard(String mytext, int maxSize, String msg) {
 
                 tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
 
-                // Highlight the corresponding button when the user cursor is over it
+                /* Highlight the corresponding button when the user cursor is over it */
 
                 // OK
                 if (x == 0 && y == -1) {
@@ -492,30 +520,34 @@ String keyboard(String mytext, int maxSize, String msg) {
                 tft.drawString("BACK", ofs[4][2], 4);
             }
 
-            // prints the title of the textbox, it should report what the user has to write in it
+            // Prints the title of the textbox, it should report what the user has to write in it
             tft.setTextSize(FP);
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-            tft.drawString(msg.substring(0, maxFPSize), 3, KBLH + 4);
+            tft.drawString(msg.substring(0, max_FP_size), 3, KBLH + 4);
 
-            // drawing the textbox and the currently typed string
+            // Drawing the textbox and the currently typed string
             tft.setTextSize(FM);
             // reset the text box
-            if (mytext.length() == (maxFMSize) || mytext.length() == (maxFMSize + 1) ||
-                mytext.length() == (maxFPSize) || mytext.length() == (maxFPSize + 1))
+            if (current_text.length() == (max_FM_size) || current_text.length() == (max_FM_size + 1) ||
+                current_text.length() == (max_FP_size) || current_text.length() == (max_FP_size + 1))
                 tft.fillRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.bgColor);
             // write the text
             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor));
-            if (mytext.length() > maxFMSize) { // if the text is too long, we try to set the smaller font
+            if (current_text.length() >
+                max_FM_size) { // if the text is too long, we try to set the smaller font
                 tft.setTextSize(FP);
-                if (mytext.length() > maxFPSize) { // if its still too long, we divide it into two lines
-                    tft.drawString(mytext.substring(0, maxFPSize), 5, KBLH + LH + 6);
-                    tft.drawString(mytext.substring(maxFPSize, mytext.length()), 5, KBLH + 2 * LH + 6);
+                if (current_text.length() >
+                    max_FP_size) { // if its still too long, we divide it into two lines
+                    tft.drawString(current_text.substring(0, max_FP_size), 5, KBLH + LH + 6);
+                    tft.drawString(
+                        current_text.substring(max_FP_size, current_text.length()), 5, KBLH + 2 * LH + 6
+                    );
                 } else {
-                    tft.drawString(mytext, 5, KBLH + 14);
+                    tft.drawString(current_text, 5, KBLH + 14);
                 }
             } else {
                 // else if it fits, just draw the text
-                tft.drawString(mytext, 5, KBLH + 14);
+                tft.drawString(current_text, 5, KBLH + 14);
             }
             // Draw the textbox border again(?)
             tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
@@ -524,58 +556,62 @@ String keyboard(String mytext, int maxSize, String msg) {
             tft.setTextSize(FM);
 
             // Draw the actual keyboard
-            for (int i = 0; i < 4; i++) {
-                for (int j = 0; j < 12; j++) {
+            for (int i = 0; i < keyboard_heigth; i++) {
+                for (int j = 0; j < keyboard_width; j++) {
+                    // key coordinates
+                    int key_x = j * key_width;
+                    int key_y = i * key_height + KBLH * 2 + 14;
+
                     // Use the previous coordinates to repaint only the previous letter
-                    if (x2 == j && y2 == i) {
+                    if (old_x == j && old_y == i) {
                         tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor);
-                        tft.fillRect(j * _x, i * _y + KBLH * 2 + 14, _x, _y, bruceConfig.bgColor);
+                        tft.fillRect(key_x, key_y, key_width, key_height, bruceConfig.bgColor);
                     }
                     // If selected, highlight it by changing font color and filling the back rectangle
                     if (x == j && y == i) {
                         tft.setTextColor(bruceConfig.bgColor, ~bruceConfig.bgColor);
-                        tft.fillRect(j * _x, i * _y + KBLH * 2 + 14, _x, _y, ~bruceConfig.bgColor);
+                        tft.fillRect(key_x, key_y, key_width, key_height, ~bruceConfig.bgColor);
                     }
 
                     // Print the letters
-                    if (!caps)
-                        tft.drawString(String(keys[i][j][0]), (j * _x + _xo), (i * _y + KBLH * 2 + 16));
-                    else tft.drawString(String(keys[i][j][1]), (j * _x + _xo), (i * _y + KBLH * 2 + 16));
+                    if (!caps) tft.drawString(String(keys[i][j][0]), key_x + text_offset_x, key_y + 2);
+                    else tft.drawString(String(keys[i][j][1]), key_x + text_offset_x, key_y + 2);
 
                     // Return colors to normal to print the other letters
                     if (x == j && y == i) { tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor); }
                 }
             }
             // Save actual key coordinates
-            x2 = x;
-            y2 = y;
+            old_x = x;
+            old_y = y;
             redraw = false;
         }
 
         // Cursor Handler
-        if (mytext.length() > maxFMSize) {
+        if (current_text.length() > max_FM_size) {
             tft.setTextSize(FP);
-            if (mytext.length() > (maxFPSize)) {
-                cY = KBLH + 2 * LH + 6;
-                cX = 5 + (mytext.length() - maxFPSize) * LW;
+            if (current_text.length() > (max_FP_size)) {
+                cursor_y = KBLH + 2 * LH + 6;
+                cursor_x = 5 + (current_text.length() - max_FP_size) * LW;
             } else {
-                cY = KBLH + LH + 6;
-                cX = 5 + mytext.length() * LW;
+                cursor_y = KBLH + LH + 6;
+                cursor_x = 5 + current_text.length() * LW;
             }
         } else {
-            cY = KBLH + LH + 6;
-            cX = 5 + mytext.length() * LW * FM;
+            cursor_y = KBLH + LH + 6;
+            cursor_x = 5 + current_text.length() * LW * FM;
         }
 
-        if (millis() - holdCode > 250) { // allow reading inputs
+        if (millis() - last_input_time > 250) { // INPUT DEBOUCING
+            // waits at least 250ms before accepting another input, to prevent rapid involuntary repeats
 
 #if defined(HAS_TOUCH) // CYD, Core2, CoreS3
 #if defined(USE_TFT_eSPI_TOUCH)
             check(AnyKeyPress);
 #endif
             if (touchPoint.pressed) {
-                // If using Touchscreen and buttons, reset the navigation states to not
-                // act weirdly, and put the cursor on Ok again.
+                // If using touchscreen and buttons, reset the navigation states to avoid inconsistent
+                // behavior, and reset the navigation coords to the OK button.
                 SelPress = false;
                 EscPress = false;
                 NextPress = false;
@@ -587,30 +623,36 @@ String keyboard(String mytext, int maxSize, String msg) {
 
                 bool touchHandled = false;
 
-                if (box_list[48].contain(touchPoint.x, touchPoint.y)) {
-                    break; // Ok
+                if (box_list[48].contain(touchPoint.x, touchPoint.y)) { // OK btn
+                    break;
                 }
-                if (box_list[49].contain(touchPoint.x, touchPoint.y)) {
+                if (box_list[49].contain(touchPoint.x, touchPoint.y)) { // CAPS btn
                     caps = !caps;
                     tft.fillRect(0, 54, tftWidth, tftHeight - 54, bruceConfig.bgColor);
                     touchHandled = true;
                 }
-                if (box_list[50].contain(touchPoint.x, touchPoint.y)) {
-                    if (mytext.length() > 0) {
-                        handleDelete(mytext, cX, cY, maxFPSize);
+                if (box_list[50].contain(touchPoint.x, touchPoint.y)) { // DEL btn
+                    if (current_text.length() > 0) {
+                        handleDelete(current_text, cursor_x, cursor_y, max_FP_size);
                         touchHandled = true;
                     }
                 }
-                if (box_list[51].contain(touchPoint.x, touchPoint.y)) {
-                    if (mytext.length() < maxSize) {
-                        handleSpaceAdd(mytext, maxSize);
+                if (box_list[51].contain(touchPoint.x, touchPoint.y)) { // SPACE btn
+                    if (current_text.length() < max_size) {
+                        handleSpaceAdd(current_text, max_size);
                         touchHandled = true;
                     }
                 }
                 for (k = 0; k < 48; k++) {
                     if (box_list[k].contain(touchPoint.x, touchPoint.y)) {
-                        if (caps) handleCharacterAdd(mytext, box_list[k].key_sh, cX, cY, maxSize, maxFMSize);
-                        else handleCharacterAdd(mytext, box_list[k].key, cX, cY, maxSize, maxFMSize);
+                        if (caps)
+                            handleCharacterAdd(
+                                current_text, box_list[k].key_sh, cursor_x, cursor_y, max_size, max_FM_size
+                            );
+                        else
+                            handleCharacterAdd(
+                                current_text, box_list[k].key, cursor_x, cursor_y, max_size, max_FM_size
+                            );
                         touchHandled = true;
                         break;
                     }
@@ -625,7 +667,7 @@ String keyboard(String mytext, int maxSize, String msg) {
 #endif
 
 #if defined(HAS_3_BUTTONS) // StickCs and Core
-            if (check(SelPress)) { goto SELECT; }
+            if (check(SelPress)) { selection_made = true; }
             /* Down Btn to move in X axis (to the right) */
             if (longNextPress || NextPress) {
                 unsigned long now = millis();
@@ -646,13 +688,13 @@ String keyboard(String mytext, int maxSize, String msg) {
                     if (longNextPress != 2) x++; // Short press action
                     longNextPress = 0;
                 } else {
-                    goto WAITING;
+                    continue;
                 }
                 LongPress = false;
                 // delay(10);
-                if (y < 0 && x > 4) x = 0; // Changed from 3 to 4 to include BACK button
-                if (x > 11) x = 0;
-                else if (x < 0) x = 11;
+                if (y < 0 && x >= buttons_number) x = 0;
+                if (x >= keyboard_width) x = 0;
+                else if (x < 0) x = keyboard_width - 1;
                 redraw = true;
             }
             /* UP Btn to move in Y axis (Downwards) */
@@ -675,71 +717,78 @@ String keyboard(String mytext, int maxSize, String msg) {
                     if (longPrevPress != 2) y++; // Short press action
                     longPrevPress = 0;
                 } else {
-                    goto WAITING;
+                    continue;
                 }
                 LongPress = false;
-                if (y > 3) {
+                if (y >= keyboard_heigth) {
                     y = -1;
-                } else if (y < -1) y = 3;
+                } else if (y < -1) y = keyboard_heigth - 1;
                 redraw = true;
             }
 #elif defined(HAS_5_BUTTONS) // Smoochie and Marauder-Mini
-            if (check(SelPress)) { goto SELECT; }
+            if (check(SelPress)) { selection_made = true; }
             /* Down Btn to move in X axis (to the right) */
             if (check(NextPress)) {
                 x++;
-                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
+                if ((y < 0 && x >= buttons_number) || x >= keyboard_width) x = 0;
                 redraw = true;
             }
             if (check(PrevPress)) {
                 x--;
-                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
-                else if (x < 0) x = 11;
+                if (y < 0 && x >= buttons_number) x = buttons_number - 1;
+                else if (x < 0) x = keyboard_width - 1;
                 redraw = true;
             }
             /* UP Btn to move in Y axis (Downwards) */
             if (check(DownPress)) {
                 y++;
-                if (y > 3) { y = -1; }
+                if (y > keyboard_heigth - 1) { y = -1; }
                 redraw = true;
             }
             if (check(UpPress)) {
                 y--;
-                if (y < -1) y = 3;
+                if (y < -1) y = keyboard_heigth - 1;
                 redraw = true;
             }
 
 #elif defined(HAS_ENCODER) // T-Embed
-            if (check(SelPress)) { goto SELECT; }
-            /* DOWN Btn to move in X axis (to the right) */
+            if (check(SelPress)) { selection_made = true; }
+            /* NEXT "Btn" to move forward on th X axis (to the right) */
+            // if ESC is pressed while NEXT or PREV is received, then we navigate on the Y axis instead
             if (check(NextPress)) {
                 if (check(EscPress)) {
                     y++;
-                } else if ((x >= 4 && y < 0) || x == 11) {
-                    y++;
-                    x = 0;
+                } else if ((x >= buttons_number - 1 && y <= -1) || x >= keyboard_width) {
+                    // if we are at the end of the current line
+                    y++;   // next line
+                    x = 0; // reset to first key
                 } else x++;
 
-                if (y > 3) y = -1;
-                if (y == -1 && x > 4) x = 0;
+                if (y >= keyboard_heigth)
+                    y = -1; // if we are at the end of the keyboard, then return to the top
+
+                // If we move to a new line using the ESC-press navigation and the previous x coordinate is
+                // greater than the number of available buttons on the new line, reset x to avoid
+                // out-of-bounds behavior, this can only happen when switching to the first line, as the
+                // others have all the same number of keys
+                if (y == -1 && x >= buttons_number) x = 0;
 
                 redraw = true;
             }
-            /* UP Btn to move in Y axis (Downwards) */
+            /* PREV "Btn" to move backwards on th X axis (to the left) */
             if (check(PrevPress)) {
                 if (check(EscPress)) {
                     y--;
-                    if (y == -1 && x > 4) x = 4;
-                } else if (x == 0) {
+                } else if (x <= 0) {
                     y--;
-                    x--;
+                    x = keyboard_width - 1;
                 } else x--;
 
                 if (y < -1) {
-                    y = 3;
-                    x = 11;
-                } else if (y < 0 && x < 0) x = 4;
-                else if (x < 0) x = 11;
+                    y = keyboard_heigth - 1;
+                    x = keyboard_width - 1;
+                } else if (y == -1 && x >= buttons_number) x = buttons_number - 1;
+                else if (x < 0) x = keyboard_width - 1;
 
                 redraw = true;
             }
@@ -747,7 +796,7 @@ String keyboard(String mytext, int maxSize, String msg) {
 #elif defined(HAS_KEYBOARD) // Cardputer and T-Deck
             if (KeyStroke.pressed) {
                 wakeUpScreen();
-                tft.setCursor(cX, cY);
+                tft.setCursor(cursor_x, cursor_y);
                 String keyStr = "";
                 for (auto i : KeyStroke.word) {
                     if (keyStr != "") {
@@ -757,32 +806,33 @@ String keyboard(String mytext, int maxSize, String msg) {
                     }
                 }
 
-                if (mytext.length() < maxSize && !KeyStroke.enter && !KeyStroke.del) {
-                    mytext += keyStr;
-                    if (mytext.length() != (maxFMSize + 1) && mytext.length() != (maxFMSize + 1))
+                if (current_text.length() < max_size && !KeyStroke.enter && !KeyStroke.del) {
+                    current_text += keyStr;
+                    if (current_text.length() != (max_FM_size + 1) &&
+                        current_text.length() != (max_FM_size + 1))
                         tft.print(keyStr.c_str());
-                    cX = tft.getCursorX();
-                    cY = tft.getCursorY();
-                    if (mytext.length() == (maxFMSize + 1)) redraw = true;
-                    if (mytext.length() == (maxFPSize + 1)) redraw = true;
+                    cursor_x = tft.getCursorX();
+                    cursor_y = tft.getCursorY();
+                    if (current_text.length() == (max_FM_size + 1)) redraw = true;
+                    if (current_text.length() == (max_FP_size + 1)) redraw = true;
                 }
-                if (KeyStroke.del && mytext.length() > 0) { // delete 0x08
+                if (KeyStroke.del && current_text.length() > 0) { // delete 0x08
                     // Handle backspace key
-                    mytext.remove(mytext.length() - 1);
+                    current_text.remove(current_text.length() - 1);
                     int fontSize = FM;
-                    if (mytext.length() > maxFPSize) {
+                    if (current_text.length() > max_FP_size) {
                         tft.setTextSize(FP);
                         fontSize = FP;
                     } else tft.setTextSize(FM);
-                    tft.setCursor((cX - fontSize * LW), cY);
+                    tft.setCursor((cursor_x - fontSize * LW), cursor_y);
                     tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
                     tft.print(" ");
                     tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-                    tft.setCursor(cX - fontSize * LW, cY);
-                    cX = tft.getCursorX();
-                    cY = tft.getCursorY();
-                    if (mytext.length() == maxFMSize) redraw = true;
-                    if (mytext.length() == maxFPSize) redraw = true;
+                    tft.setCursor(cursor_x - fontSize * LW, cursor_y);
+                    cursor_x = tft.getCursorX();
+                    cursor_y = tft.getCursorY();
+                    if (current_text.length() == max_FM_size) redraw = true;
+                    if (current_text.length() == max_FP_size) redraw = true;
                 }
                 if (KeyStroke.enter) { break; }
                 KeyStroke.Clear();
@@ -790,591 +840,50 @@ String keyboard(String mytext, int maxSize, String msg) {
             if (check(SelPress)) break;
 
 #endif
-        } // end of holdCode detection
+        } // end of physical input detection
 
         if (SerialCmdPress) { // only for Remote Control, if no input was detected on device
-            if (check(SelPress)) { goto SELECT; }
-            /* Down Btn to move in X axis (to the right) */
+            if (check(SelPress)) { selection_made = true; }
+            /* Next-Prev Btns to move in X axis (right-left) */
             if (check(NextPress)) {
                 x++;
-                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
+                if ((y < 0 && x >= buttons_number) || x >= keyboard_width) x = 0;
                 redraw = true;
             }
             if (check(PrevPress)) {
                 x--;
-                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
-                else if (x < 0) x = 11;
+                if (y < 0 && x >= buttons_number) x = buttons_number - 1;
+                else if (x < 0) x = keyboard_width - 1;
                 redraw = true;
             }
-            /* UP Btn to move in Y axis (Downwards) */
+            /* Down-Up Btns to move in Y axis */
             if (check(DownPress)) {
                 y++;
-                if (y > 3) { y = -1; }
+                if (y >= keyboard_heigth) { y = -1; }
                 redraw = true;
             }
             if (check(UpPress)) {
                 y--;
-                if (y < -1) y = 3;
+                if (y < -1) y = keyboard_heigth - 1;
                 redraw = true;
             }
         }
 
-        if (false) { // When selecting some letter or something, use these helper functions instead of goto
-        SELECT:      // so when we "select", so when we click something, this is executed:
-            KeyboardAction action = handleRegularKeyboardSelection(
-                x, y, mytext, caps, cX, cY, maxSize, maxFMSize, maxFPSize, keys
-            );
-
-            if (action == KEYBOARD_OK || action == KEYBOARD_CANCEL) {
-                break;
-            } else if (action == KEYBOARD_REDRAW) {
-                redraw = true;
-            }
-
-            holdCode = millis();
-        }
-    WAITING: // Used in long press detection
-        yield();
-    }
-
-    // Resets screen when finished writing
-    tft.fillScreen(bruceConfig.bgColor);
-    resetTftDisplay();
-
-    return mytext;
-}
-
-/*********************************************************************
-** Function: hex_keyboard
-** location: mykeyboard.cpp
-** keyboard interface with hex only characters.
-**********************************************************************/
-String hex_keyboard(String mytext, int maxSize, String msg) {
-    resetTftDisplay();
-    touchPoint.Clear();
-    String _mytext = mytext;
-    const uint8_t max_chars = tftWidth / (LW * FM); // Display Width / (Letter Width * Medium Font)
-    const int maxFMSize = tftWidth / (LW * FM) - 1; //
-    const int maxFPSize = tftWidth / (LW)-2;
-    bool redraw = true;
-    long holdCode = millis(); // to hold the inputs for 250ms before adding other letter
-    int cX = 0;               // Cursor position
-    int cY = 0;               // Cursor position
-    int x = 0;
-    int y = -1; // -1 is where buttons are, out of keys[][][] array
-    int x2 = 0;
-    int y2 = 0;
-    //       [x][y], x2 and y2 are the previous position of x and y, used to redraw only that spot on
-    //       keyboard screen
-    char keys[4][4] = {
-        //  2 lines, with 10 characters, high caps
-        // {
-        //  '0', '1',
-        //  '2', '3',
-        //  '4', '5',
-        //  '6', '7',
-        //  '8', '9',
-        //  },
-        // {
-        //  'A', 'B',
-        //  'C', 'D',
-        //  'E', 'F',
-        //  },
-        //  4 lines, with 4 characters, high caps
-        {'0', '1', '2', '3'},
-        {'4', '5', '6', '7'},
-        {'8', '9', 'A', 'B'},
-        {'C', 'D', 'E', 'F'},
-    };
-    /****************TOP-BUTTONS****************/
-#if FM > 1      // Normal keyboard size
-#define KBLH 20 // Keyboard Buttons Line Height
-    // { x coord of btn border, btn width, x coord of the inside text }
-    int ofs[4][3] = {
-        {7,   46, 18 }, // OK button
-        {55,  50, 64 }, // DEL button
-        {107, 74, 115}, // SPACE button
-        {183, 62, 192}, // BACK button
-    };
-#else // small keyboard size, for small letters (smaller screen, like Marauder Mini and others ;) )
-#define KBLH 10
-    // { x coord of btn border, btn width, x coord of the inside text }
-    int ofs[4][3] = {
-        {7,   20, 10 }, // OK button
-        {27,  25, 30 }, // DEL button
-        {52,  50, 55 }, // SPACE button
-        {102, 40, 105}, // BACK button
-    };
-#endif
-    const int _x = tftWidth / 12;
-    const int _y = (tftHeight - (2 * KBLH + 14)) / 4;
-    const int _xo = _x / 2 - 3;
-
-#if defined(HAS_TOUCH)
-    int k = 0;
-    // Setup touch boxes for the 4x4 hex keyboard
-    for (x2 = 0; x2 < 4; x2++) {
-        for (y2 = 0; y2 < 4; y2++) {
-            box_list[k].key = keys[y2][x2];
-            box_list[k].key_sh = keys[y2][x2]; // hex chars don't have shift variants
-            box_list[k].color = ~bruceConfig.bgColor;
-            box_list[k].x = x2 * (_x * 3); // spread out 4 keys across 12-key width
-            box_list[k].y = y2 * _y + 54;
-            box_list[k].w = _x * 3;
-            box_list[k].h = _y;
-            k++;
-        }
-    }
-    // OK button (index 16)
-    box_list[k].key = ' ';
-    box_list[k].key_sh = ' ';
-    box_list[k].color = ~bruceConfig.bgColor;
-    box_list[k].x = ofs[0][0];
-    box_list[k].y = 0;
-    box_list[k].w = ofs[0][1];
-    box_list[k].h = 22;
-    k++;
-    // DEL button (index 17)
-    box_list[k].key = ' ';
-    box_list[k].key_sh = ' ';
-    box_list[k].color = ~bruceConfig.bgColor;
-    box_list[k].x = ofs[1][0];
-    box_list[k].y = 0;
-    box_list[k].w = ofs[1][1];
-    box_list[k].h = 22;
-    k++;
-    // SPACE button (index 18)
-    box_list[k].key = ' ';
-    box_list[k].key_sh = ' ';
-    box_list[k].color = ~bruceConfig.bgColor;
-    box_list[k].x = ofs[2][0];
-    box_list[k].y = 0;
-    box_list[k].w = ofs[2][1];
-    box_list[k].h = 22;
-    k++;
-    // BACK button (index 19)
-    box_list[k].key = ' ';
-    box_list[k].key_sh = ' ';
-    box_list[k].color = ~bruceConfig.bgColor;
-    box_list[k].x = ofs[3][0];
-    box_list[k].y = 0;
-    box_list[k].w = ofs[3][1];
-    box_list[k].h = 22;
-
-    k = 0;
-    x2 = 0;
-    y2 = 0;
-#endif
-
-    tft.fillScreen(bruceConfig.bgColor);
-
-#if defined(HAS_3_BUTTONS) // StickCs and Core for long press detection logic
-    uint8_t longNextPress = 0;
-    uint8_t longPrevPress = 0;
-    unsigned long LongPressTmp = millis();
-#endif
-
-    // main loop, display keyboard, manage keystrokes and displays the string
-    while (1) {
-        if (redraw) {
-            tft.setCursor(0, 0);
-            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
-            tft.setTextSize(FM);
-
-            // Draw the top row buttons
-            if (y < 0 || y2 < 0) {
-                tft.fillRect(0, 1, tftWidth, 22, bruceConfig.bgColor);
-                // Draw the borders
-                tft.drawRect(
-                    ofs[0][0], 2, ofs[0][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                ); // OK btn border
-                tft.drawRect(
-                    ofs[1][0], 2, ofs[1][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                ); // DEL btn border
-                tft.drawRect(
-                    ofs[2][0], 2, ofs[2][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                ); // SPACE btn border
-                tft.drawRect(
-                    ofs[3][0], 2, ofs[3][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
-                ); // BACK btn border
-
-                tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
-
-                // Highlight the corresponding button when the user cursor is over it
-
-                // OK
-                if (x == 0 && y == -1) {
-                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
-                    tft.fillRect(ofs[0][0], 2, ofs[0][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
-                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
-                tft.drawString("OK", ofs[0][2], 4);
-
-                // DEL
-                if (x == 1 && y == -1) {
-                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
-                    tft.fillRect(ofs[1][0], 2, ofs[1][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
-                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
-                tft.drawString("DEL", ofs[1][2], 4);
-
-                // SPACE
-                if (x == 2 && y == -1) {
-                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
-                    tft.fillRect(ofs[2][0], 2, ofs[2][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
-                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
-                tft.drawString("SPACE", ofs[2][2], 4);
-
-                // BACK
-                if (x > 2 && y == -1) {
-                    tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
-                    tft.fillRect(ofs[3][0], 2, ofs[3][1], KBLH, getComplementaryColor2(bruceConfig.bgColor));
-                } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
-                tft.drawString("BACK", ofs[3][2], 4);
-            }
-
-            // prints the title of the textbox, it should report what the user has to write in it
-            tft.setTextSize(FP);
-            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-            tft.drawString(msg.substring(0, maxFPSize), 3, KBLH + 4);
-
-            // drawing the textbox and the currently typed string
-            tft.setTextSize(FM);
-            // reset the text box
-            if (mytext.length() == (maxFMSize) || mytext.length() == (maxFMSize + 1) ||
-                mytext.length() == (maxFPSize) || mytext.length() == (maxFPSize + 1))
-                tft.fillRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.bgColor);
-            // write the text
-            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor));
-            if (mytext.length() > maxFMSize) { // if the text is too long, we try to set the smaller font
-                tft.setTextSize(FP);
-                if (mytext.length() > maxFPSize) { // if its still too long, we divide it into two lines
-                    tft.drawString(mytext.substring(0, maxFPSize), 5, KBLH + LH + 6);
-                    tft.drawString(mytext.substring(maxFPSize, mytext.length()), 5, KBLH + 2 * LH + 6);
-                } else {
-                    tft.drawString(mytext, 5, KBLH + 14);
-                }
-            } else {
-                // else if it fits, just draw the text
-                tft.drawString(mytext, 5, KBLH + 14);
-            }
-            // Draw the textbox border again(?)
-            tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
-
-            tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
-            tft.setTextSize(FM);
-
-            // Draw the actual keyboard (4x4 hex layout)
-            for (int i = 0; i < 4; i++) {
-                for (int j = 0; j < 4; j++) {
-                    int key_x = j * (_x * 3); // spread 4 keys across 12-key width
-                    int key_y = i * _y + KBLH * 2 + 16;
-                    int key_w = _x * 3; // key width
-
-                    // Use the previous coordinates to repaint only the previous letter
-                    if (x2 == j && y2 == i) {
-                        tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor);
-                        tft.fillRect(key_x, key_y, key_w, _y, bruceConfig.bgColor);
-                    }
-                    // If selected, highlight it by changing font color and filling the back rectangle
-                    if (x == j && y == i) {
-                        tft.setTextColor(bruceConfig.bgColor, ~bruceConfig.bgColor);
-                        tft.fillRect(key_x, key_y, key_w, _y, ~bruceConfig.bgColor);
-                    }
-
-                    // Print the hex characters
-                    tft.drawString(String(keys[i][j]), key_x + key_w / 2 - FM * LW / 2, key_y + 2);
-
-                    // Return colors to normal to print the other letters
-                    if (x == j && y == i) { tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor); }
-                }
-            }
-            // Save actual key coordinates
-            x2 = x;
-            y2 = y;
-            redraw = false;
-        }
-
-        // Cursor Handler
-        if (mytext.length() > maxFMSize) {
-            tft.setTextSize(FP);
-            if (mytext.length() > (maxFPSize)) {
-                cY = KBLH + 2 * LH + 6;
-                cX = 5 + (mytext.length() - maxFPSize) * LW;
-            } else {
-                cY = KBLH + LH + 6;
-                cX = 5 + mytext.length() * LW;
-            }
-        } else {
-            cY = KBLH + LH + 6;
-            cX = 5 + mytext.length() * LW * FM;
-        }
-
-        if (millis() - holdCode > 250) { // allow reading inputs
-
-#if defined(HAS_TOUCH) // CYD, Core2, CoreS3
-#if defined(USE_TFT_eSPI_TOUCH)
-            check(AnyKeyPress);
-#endif
-            if (touchPoint.pressed) {
-                // If using Touchscreen and buttons, reset the navigation states to not
-                // act weirdly, and put the cursor on Ok again.
-                SelPress = false;
-                EscPress = false;
-                NextPress = false;
-                PrevPress = false;
-                UpPress = false;
-                DownPress = false;
-                x = 0;
-                y = -1;
-
-                bool touchHandled = false;
-
-                // Check buttons (indices 16-19 for hex keyboard)
-                if (box_list[16].contain(touchPoint.x, touchPoint.y)) {
-                    break; // OK button
-                }
-                if (box_list[17].contain(touchPoint.x, touchPoint.y)) {
-                    if (mytext.length() > 0) {
-                        handleDelete(mytext, cX, cY, maxFPSize);
-                        touchHandled = true;
-                    }
-                } // DEL button
-                if (box_list[18].contain(touchPoint.x, touchPoint.y)) {
-                    if (mytext.length() < maxSize) {
-                        handleSpaceAdd(mytext, maxSize);
-                        touchHandled = true;
-                    }
-                } // SPACE button
-                if (box_list[19].contain(touchPoint.x, touchPoint.y)) {
-                    mytext = "\x1B"; // BACK button - ESC
-                    break;
-                }
-
-                // Check hex character keys (indices 0-15)
-                for (k = 0; k < 16; k++) {
-                    if (box_list[k].contain(touchPoint.x, touchPoint.y)) {
-                        handleCharacterAdd(mytext, box_list[k].key, cX, cY, maxSize, maxFMSize);
-                        touchHandled = true;
-                        break;
-                    }
-                }
-
-                if (touchHandled) {
-                    wakeUpScreen();
-                    touchPoint.Clear();
-                    redraw = true;
-                }
-            }
-#endif
-
-#if defined(HAS_3_BUTTONS) // StickCs and Core
-            if (check(SelPress)) { goto SELECT; }
-            /* Down Btn to move in X axis (to the right) */
-            if (longNextPress || NextPress) {
-                unsigned long now = millis();
-                if (!longNextPress) {
-                    longNextPress = 1;
-                    LongPress = true;
-                    LongPressTmp = now;
-                }
-                delay(1); // does not work without it
-                // Check if the button is held long enough (long press)
-                if (now - LongPressTmp > 300) {
-                    x--; // Long press action
-                    longNextPress = 2;
-                    LongPress = false;
-                    check(NextPress);
-                    LongPressTmp = now;
-                } else if (!NextPress) {
-                    if (longNextPress != 2) x++; // Short press action
-                    longNextPress = 0;
-                } else {
-                    goto WAITING;
-                }
-                LongPress = false;
-                // delay(10);
-                if (y < 0 && x > 4) x = 0; // Changed from 3 to 4 to include BACK button
-                if (x > 11) x = 0;
-                else if (x < 0) x = 11;
-                redraw = true;
-            }
-            /* UP Btn to move in Y axis (Downwards) */
-            if (longPrevPress || PrevPress) {
-                unsigned long now = millis();
-                if (!longPrevPress) {
-                    longPrevPress = 1;
-                    LongPress = true;
-                    LongPressTmp = now;
-                }
-                delay(1); // does not work without it
-                // Check if the button is held long enough (long press)
-                if (now - LongPressTmp > 300) {
-                    y--; // Long press action
-                    longPrevPress = 2;
-                    LongPress = false;
-                    check(PrevPress);
-                    LongPressTmp = now;
-                } else if (!PrevPress) {
-                    if (longPrevPress != 2) y++; // Short press action
-                    longPrevPress = 0;
-                } else {
-                    goto WAITING;
-                }
-                LongPress = false;
-                if (y > 3) {
-                    y = -1;
-                } else if (y < -1) y = 3;
-                redraw = true;
-            }
-#elif defined(HAS_5_BUTTONS) // Smoochie and Marauder-Mini
-            if (check(SelPress)) { goto SELECT; }
-            /* Down Btn to move in X axis (to the right) */
-            if (check(NextPress)) {
-                x++;
-                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
-                redraw = true;
-            }
-            if (check(PrevPress)) {
-                x--;
-                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
-                else if (x < 0) x = 11;
-                redraw = true;
-            }
-            /* UP Btn to move in Y axis (Downwards) */
-            if (check(DownPress)) {
-                y++;
-                if (y > 3) { y = -1; }
-                redraw = true;
-            }
-            if (check(UpPress)) {
-                y--;
-                if (y < -1) y = 3;
-                redraw = true;
-            }
-
-#elif defined(HAS_ENCODER) // T-Embed
-            if (check(SelPress)) { goto SELECT; }
-            /* DOWN Btn to move in X axis (to the right) */
-            if (check(NextPress)) {
-                if (check(EscPress)) {
-                    y++;
-                } else if ((x >= 4 && y < 0) || x == 3) {
-                    y++;
-                    x = 0;
-                } else x++;
-
-                if (y > 3) y = -1;
-                if (y == -1 && x > 4) x = 0;
-
-                redraw = true;
-            }
-            /* UP Btn to move in Y axis (Downwards) */
-            if (check(PrevPress)) {
-                if (check(EscPress)) {
-                    y--;
-                    if (y == -1 && x > 4) x = 4;
-                } else if (x == 0) {
-                    y--;
-                    x--;
-                } else x--;
-
-                if (y < -1) {
-                    y = 3;
-                    x = 3;
-                } else if (y < 0 && x < 0) x = 4;
-                else if (x < 0) x = 3;
-
-                redraw = true;
-            }
-
-#elif defined(HAS_KEYBOARD) // Cardputer and T-Deck
-            if (KeyStroke.pressed) {
-                wakeUpScreen();
-                tft.setCursor(cX, cY);
-                String keyStr = "";
-                for (auto i : KeyStroke.word) {
-                    if (keyStr != "") {
-                        keyStr = keyStr + "+" + i;
-                    } else {
-                        keyStr += i;
-                    }
-                }
-
-                if (mytext.length() < maxSize && !KeyStroke.enter && !KeyStroke.del) {
-                    mytext += keyStr;
-                    if (mytext.length() != (maxFMSize + 1) && mytext.length() != (maxFMSize + 1))
-                        tft.print(keyStr.c_str());
-                    cX = tft.getCursorX();
-                    cY = tft.getCursorY();
-                    if (mytext.length() == (maxFMSize + 1)) redraw = true;
-                    if (mytext.length() == (maxFPSize + 1)) redraw = true;
-                }
-                if (KeyStroke.del && mytext.length() > 0) { // delete 0x08
-                    // Handle backspace key
-                    mytext.remove(mytext.length() - 1);
-                    int fontSize = FM;
-                    if (mytext.length() > maxFPSize) {
-                        tft.setTextSize(FP);
-                        fontSize = FP;
-                    } else tft.setTextSize(FM);
-                    tft.setCursor((cX - fontSize * LW), cY);
-                    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
-                    tft.print(" ");
-                    tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
-                    tft.setCursor(cX - fontSize * LW, cY);
-                    cX = tft.getCursorX();
-                    cY = tft.getCursorY();
-                    if (mytext.length() == maxFMSize) redraw = true;
-                    if (mytext.length() == maxFPSize) redraw = true;
-                }
-                if (KeyStroke.enter) { break; }
-                KeyStroke.Clear();
-            }
-            if (check(SelPress)) break;
-
-#endif
-        } // end of holdCode detection
-
-        if (SerialCmdPress) { // only for Remote Control, if no input was detected on device
-            if (check(SelPress)) { goto SELECT; }
-            /* Down Btn to move in X axis (to the right) */
-            if (check(NextPress)) {
-                x++;
-                if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
-                redraw = true;
-            }
-            if (check(PrevPress)) {
-                x--;
-                if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
-                else if (x < 0) x = 11;
-                redraw = true;
-            }
-            /* UP Btn to move in Y axis (Downwards) */
-            if (check(DownPress)) {
-                y++;
-                if (y > 3) { y = -1; }
-                redraw = true;
-            }
-            if (check(UpPress)) {
-                y--;
-                if (y < -1) y = 3;
-                redraw = true;
-            }
-        }
-
-        if (false) { // When selecting some letter or something, use these helper functions instead of goto
-        SELECT:      // so when we "select", so when we click something, this is executed:
+        if (selection_made) { // if something was selected then handle it
+            selection_made = false;
             KeyboardAction action =
-                handleHexKeyboardSelection(x, y, mytext, cX, cY, maxSize, maxFMSize, maxFPSize, keys);
+                handleRegularKeyboardSelection(x, y, current_text, caps, cursor_x, cursor_y, max_size);
 
-            if (action == KEYBOARD_OK || action == KEYBOARD_CANCEL) {
+            if (action == KEYBOARD_OK) { // OK BTN
+                break;
+            } else if (action == KEYBOARD_CANCEL) { // BACK BTN
+                current_text = "\x1B";              // ASCII ESC CHARACTER
                 break;
             } else if (action == KEYBOARD_REDRAW) {
                 redraw = true;
             }
 
-            holdCode = millis();
-        WAITING: // Used in long press detection
-            yield();
+            last_input_time = millis();
         }
     }
 
@@ -1382,8 +891,566 @@ String hex_keyboard(String mytext, int maxSize, String msg) {
     tft.fillScreen(bruceConfig.bgColor);
     resetTftDisplay();
 
-    return mytext;
+    return current_text;
 }
+
+// /*********************************************************************
+// ** Function: hex_keyboard
+// ** location: mykeyboard.cpp
+// ** keyboard interface with hex only characters.
+// **********************************************************************/
+// String hex_keyboard(String current_text, int max_size, String msg) {
+//     resetTftDisplay();
+//     touchPoint.Clear();
+//     String _mytext = current_text;
+//     const uint8_t max_chars = tftWidth / (LW * FM);   // Display Width / (Letter Width * Medium Font)
+//     const int max_FM_size = tftWidth / (LW * FM) - 1; //
+//     const int max_FP_size = tftWidth / (LW)-2;
+//     bool redraw = true;
+//     bool selection_made = false;
+//     long last_input_time = millis(); // to hold the inputs for 250ms before adding other letter
+//     int cursor_x = 0;                // Cursor position
+//     int cursor_y = 0;                // Cursor position
+//     int x = 0;
+//     int y = -1; // -1 is where the buttons are, out of keys[][][] array
+//     int old_x = 0;
+//     int old_y = 0;
+//     //       [x][y], old_x and old_y are the previous position of x and y, used to redraw only that spot on
+//     //       keyboard screen
+//     const int keyboard_width = 4;
+//     const int keyboard_heigth = 4;
+//     char keys[4][4] = {
+//         //  2 lines, with 10 characters, high caps
+//         // {
+//         //  '0', '1',
+//         //  '2', '3',
+//         //  '4', '5',
+//         //  '6', '7',
+//         //  '8', '9',
+//         //  },
+//         // {
+//         //  'A', 'B',
+//         //  'C', 'D',
+//         //  'E', 'F',
+//         //  },
+//         //  4 lines, with 4 characters, high caps
+//         {'0', '1', '2', '3'},
+//         {'4', '5', '6', '7'},
+//         {'8', '9', 'A', 'B'},
+//         {'C', 'D', 'E', 'F'},
+//     };
+//     /****************TOP-BUTTONS****************/
+// #if FM > 1      // Normal keyboard size
+// #define KBLH 20 // Keyboard Buttons Line Height
+//     // { x coord of btn border, btn width, x coord of the inside text }
+//     int ofs[4][3] = {
+//         {7,   46, 18 }, // OK button
+//         {55,  50, 64 }, // DEL button
+//         {107, 74, 115}, // SPACE button
+//         {183, 62, 192}, // BACK button
+//     };
+// #else // small keyboard size, for small letters (smaller screen, like Marauder Mini and others ;) )
+// #define KBLH 10
+//     // { x coord of btn border, btn width, x coord of the inside text }
+//     int ofs[4][3] = {
+//         {7,   20, 10 }, // OK button
+//         {27,  25, 30 }, // DEL button
+//         {52,  50, 55 }, // SPACE button
+//         {102, 40, 105}, // BACK button
+//     };
+// #endif
+//     const int key_width = tftWidth / keyboard_width;
+//     const int key_height = (tftHeight - (2 * KBLH + 14)) / 4;
+//     const int text_offset_x = key_width / 2 - 3;
+
+// #if defined(HAS_TOUCH)
+//     int k = 0;
+//     // Setup touch boxes for the 4x4 hex keyboard
+//     for (old_x = 0; old_x < 4; old_x++) {
+//         for (old_y = 0; old_y < 4; old_y++) {
+//             box_list[k].key = keys[old_y][old_x];
+//             box_list[k].key_sh = keys[old_y][old_x]; // hex chars don't have shift variants
+//             box_list[k].color = ~bruceConfig.bgColor;
+//             box_list[k].x = old_x * (key_width * 3); // spread out 4 keys across 12-key width
+//             box_list[k].y = old_y * key_height + 54;
+//             box_list[k].w = key_width * 3;
+//             box_list[k].h = key_height;
+//             k++;
+//         }
+//     }
+//     // OK button (index 16)
+//     box_list[k].key = ' ';
+//     box_list[k].key_sh = ' ';
+//     box_list[k].color = ~bruceConfig.bgColor;
+//     box_list[k].x = ofs[0][0];
+//     box_list[k].y = 0;
+//     box_list[k].w = ofs[0][1];
+//     box_list[k].h = 22;
+//     k++;
+//     // DEL button (index 17)
+//     box_list[k].key = ' ';
+//     box_list[k].key_sh = ' ';
+//     box_list[k].color = ~bruceConfig.bgColor;
+//     box_list[k].x = ofs[1][0];
+//     box_list[k].y = 0;
+//     box_list[k].w = ofs[1][1];
+//     box_list[k].h = 22;
+//     k++;
+//     // SPACE button (index 18)
+//     box_list[k].key = ' ';
+//     box_list[k].key_sh = ' ';
+//     box_list[k].color = ~bruceConfig.bgColor;
+//     box_list[k].x = ofs[2][0];
+//     box_list[k].y = 0;
+//     box_list[k].w = ofs[2][1];
+//     box_list[k].h = 22;
+//     k++;
+//     // BACK button (index 19)
+//     box_list[k].key = ' ';
+//     box_list[k].key_sh = ' ';
+//     box_list[k].color = ~bruceConfig.bgColor;
+//     box_list[k].x = ofs[3][0];
+//     box_list[k].y = 0;
+//     box_list[k].w = ofs[3][1];
+//     box_list[k].h = 22;
+
+//     k = 0;
+//     old_x = 0;
+//     old_y = 0;
+// #endif
+
+//     tft.fillScreen(bruceConfig.bgColor);
+
+// #if defined(HAS_3_BUTTONS) // StickCs and Core for long press detection logic
+//     uint8_t longNextPress = 0;
+//     uint8_t longPrevPress = 0;
+//     unsigned long LongPressTmp = millis();
+// #endif
+
+//     // main loop, display keyboard, manage keystrokes and displays the string
+//     while (1) {
+//         if (redraw) {
+//             tft.setCursor(0, 0);
+//             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+//             tft.setTextSize(FM);
+
+//             // Draw the top row buttons
+//             if (y < 0 || old_y < 0) {
+//                 tft.fillRect(0, 1, tftWidth, 22, bruceConfig.bgColor);
+//                 // Draw the borders
+//                 tft.drawRect(
+//                     ofs[0][0], 2, ofs[0][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+//                 ); // OK btn border
+//                 tft.drawRect(
+//                     ofs[1][0], 2, ofs[1][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+//                 ); // DEL btn border
+//                 tft.drawRect(
+//                     ofs[2][0], 2, ofs[2][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+//                 ); // SPACE btn border
+//                 tft.drawRect(
+//                     ofs[3][0], 2, ofs[3][1], KBLH, getComplementaryColor2(bruceConfig.bgColor)
+//                 ); // BACK btn border
+
+//                 tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string
+//                 border
+
+//                 // Highlight the corresponding button when the user cursor is over it
+
+//                 // OK
+//                 if (x == 0 && y == -1) {
+//                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+//                     tft.fillRect(ofs[0][0], 2, ofs[0][1], KBLH,
+//                     getComplementaryColor2(bruceConfig.bgColor));
+//                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+//                 tft.drawString("OK", ofs[0][2], 4);
+
+//                 // DEL
+//                 if (x == 1 && y == -1) {
+//                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+//                     tft.fillRect(ofs[1][0], 2, ofs[1][1], KBLH,
+//                     getComplementaryColor2(bruceConfig.bgColor));
+//                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+//                 tft.drawString("DEL", ofs[1][2], 4);
+
+//                 // SPACE
+//                 if (x == 2 && y == -1) {
+//                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+//                     tft.fillRect(ofs[2][0], 2, ofs[2][1], KBLH,
+//                     getComplementaryColor2(bruceConfig.bgColor));
+//                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+//                 tft.drawString("SPACE", ofs[2][2], 4);
+
+//                 // BACK
+//                 if (x > 2 && y == -1) {
+//                     tft.setTextColor(bruceConfig.bgColor, getComplementaryColor2(bruceConfig.bgColor));
+//                     tft.fillRect(ofs[3][0], 2, ofs[3][1], KBLH,
+//                     getComplementaryColor2(bruceConfig.bgColor));
+//                 } else tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+//                 tft.drawString("BACK", ofs[3][2], 4);
+//             }
+
+//             // prints the title of the textbox, it should report what the user has to write in it
+//             tft.setTextSize(FP);
+//             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
+//             tft.drawString(msg.substring(0, max_FP_size), 3, KBLH + 4);
+
+//             // drawing the textbox and the currently typed string
+//             tft.setTextSize(FM);
+//             // reset the text box
+//             if (current_text.length() == (max_FM_size) || current_text.length() == (max_FM_size + 1) ||
+//                 current_text.length() == (max_FP_size) || current_text.length() == (max_FP_size + 1))
+//                 tft.fillRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.bgColor);
+//             // write the text
+//             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor));
+//             if (current_text.length() >
+//                 max_FM_size) { // if the text is too long, we try to set the smaller font
+//                 tft.setTextSize(FP);
+//                 if (current_text.length() >
+//                     max_FP_size) { // if its still too long, we divide it into two lines
+//                     tft.drawString(current_text.substring(0, max_FP_size), 5, KBLH + LH + 6);
+//                     tft.drawString(
+//                         current_text.substring(max_FP_size, current_text.length()), 5, KBLH + 2 * LH + 6
+//                     );
+//                 } else {
+//                     tft.drawString(current_text, 5, KBLH + 14);
+//                 }
+//             } else {
+//                 // else if it fits, just draw the text
+//                 tft.drawString(current_text, 5, KBLH + 14);
+//             }
+//             // Draw the textbox border again(?)
+//             tft.drawRect(3, KBLH + 12, tftWidth - 3, KBLH, bruceConfig.priColor); // typed string border
+
+//             tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), bruceConfig.bgColor);
+//             tft.setTextSize(FM);
+
+//             // Draw the actual keyboard (4x4 hex layout)
+//             for (int i = 0; i < keyboard_heigth; i++) {
+//                 for (int j = 0; j < keyboard_width; j++) {
+//                     // key coordinates
+//                     int key_x = j * key_width;
+//                     int key_y = i * key_height + KBLH * 2 + 16;
+
+//                     // Use the previous coordinates to repaint only the previous letter
+//                     if (old_x == j && old_y == i) {
+//                         tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor);
+//                         tft.fillRect(key_x, key_y, key_width, key_height, bruceConfig.bgColor);
+//                     }
+//                     // If selected, highlight it by changing font color and filling the back rectangle
+//                     if (x == j && y == i) {
+//                         tft.setTextColor(bruceConfig.bgColor, ~bruceConfig.bgColor);
+//                         tft.fillRect(key_x, key_y, key_width, key_height, ~bruceConfig.bgColor);
+//                     }
+
+//                     // Print the hex characters
+//                     tft.drawString(String(keys[i][j]), key_x + text_offset_x, key_y + 2);
+
+//                     // Return colors to normal to print the other letters
+//                     if (x == j && y == i) { tft.setTextColor(~bruceConfig.bgColor, bruceConfig.bgColor); }
+//                 }
+//             }
+//             // Save actual key coordinates
+//             old_x = x;
+//             old_y = y;
+//             redraw = false;
+//         }
+
+//         // Cursor Handler
+//         if (current_text.length() > max_FM_size) {
+//             tft.setTextSize(FP);
+//             if (current_text.length() > (max_FP_size)) {
+//                 cursor_y = KBLH + 2 * LH + 6;
+//                 cursor_x = 5 + (current_text.length() - max_FP_size) * LW;
+//             } else {
+//                 cursor_y = KBLH + LH + 6;
+//                 cursor_x = 5 + current_text.length() * LW;
+//             }
+//         } else {
+//             cursor_y = KBLH + LH + 6;
+//             cursor_x = 5 + current_text.length() * LW * FM;
+//         }
+
+//         if (millis() - last_input_time > 250) { // allow reading inputs
+
+// #if defined(HAS_TOUCH) // CYD, Core2, CoreS3
+// #if defined(USE_TFT_eSPI_TOUCH)
+//             check(AnyKeyPress);
+// #endif
+//             if (touchPoint.pressed) {
+//                 // If using Touchscreen and buttons, reset the navigation states to not
+//                 // act weirdly, and put the cursor on Ok again.
+//                 SelPress = false;
+//                 EscPress = false;
+//                 NextPress = false;
+//                 PrevPress = false;
+//                 UpPress = false;
+//                 DownPress = false;
+//                 x = 0;
+//                 y = -1;
+
+//                 bool touchHandled = false;
+
+//                 // Check buttons (indices 16-19 for hex keyboard)
+//                 if (box_list[16].contain(touchPoint.x, touchPoint.y)) {
+//                     break; // OK button
+//                 }
+//                 if (box_list[17].contain(touchPoint.x, touchPoint.y)) {
+//                     if (current_text.length() > 0) {
+//                         handleDelete(current_text, cursor_x, cursor_y, max_FP_size);
+//                         touchHandled = true;
+//                     }
+//                 } // DEL button
+//                 if (box_list[18].contain(touchPoint.x, touchPoint.y)) {
+//                     if (current_text.length() < max_size) {
+//                         handleSpaceAdd(current_text, max_size);
+//                         touchHandled = true;
+//                     }
+//                 } // SPACE button
+//                 if (box_list[19].contain(touchPoint.x, touchPoint.y)) {
+//                     current_text = "\x1B"; // BACK button - ESC
+//                     break;
+//                 }
+
+//                 // Check hex character keys (indices 0-15)
+//                 for (k = 0; k < 16; k++) {
+//                     if (box_list[k].contain(touchPoint.x, touchPoint.y)) {
+//                         handleCharacterAdd(
+//                             current_text, box_list[k].key, cursor_x, cursor_y, max_size, max_FM_size
+//                         );
+//                         touchHandled = true;
+//                         break;
+//                     }
+//                 }
+
+//                 if (touchHandled) {
+//                     wakeUpScreen();
+//                     touchPoint.Clear();
+//                     redraw = true;
+//                 }
+//             }
+// #endif
+
+// #if defined(HAS_3_BUTTONS) // StickCs and Core
+//             if (check(SelPress)) { selection_made = true; }
+//             /* Down Btn to move in X axis (to the right) */
+//             if (longNextPress || NextPress) {
+//                 unsigned long now = millis();
+//                 if (!longNextPress) {
+//                     longNextPress = 1;
+//                     LongPress = true;
+//                     LongPressTmp = now;
+//                 }
+//                 delay(1); // does not work without it
+//                 // Check if the button is held long enough (long press)
+//                 if (now - LongPressTmp > 300) {
+//                     x--; // Long press action
+//                     longNextPress = 2;
+//                     LongPress = false;
+//                     check(NextPress);
+//                     LongPressTmp = now;
+//                 } else if (!NextPress) {
+//                     if (longNextPress != 2) x++; // Short press action
+//                     longNextPress = 0;
+//                 } else {
+//                     continue;
+//                 }
+//                 LongPress = false;
+//                 // delay(10);
+//                 if (y < 0 && x > 4) x = 0; // Changed from 3 to 4 to include BACK button
+//                 if (x > 11) x = 0;
+//                 else if (x < 0) x = 11;
+//                 redraw = true;
+//             }
+//             /* UP Btn to move in Y axis (Downwards) */
+//             if (longPrevPress || PrevPress) {
+//                 unsigned long now = millis();
+//                 if (!longPrevPress) {
+//                     longPrevPress = 1;
+//                     LongPress = true;
+//                     LongPressTmp = now;
+//                 }
+//                 delay(1); // does not work without it
+//                 // Check if the button is held long enough (long press)
+//                 if (now - LongPressTmp > 300) {
+//                     y--; // Long press action
+//                     longPrevPress = 2;
+//                     LongPress = false;
+//                     check(PrevPress);
+//                     LongPressTmp = now;
+//                 } else if (!PrevPress) {
+//                     if (longPrevPress != 2) y++; // Short press action
+//                     longPrevPress = 0;
+//                 } else {
+//                     continue;
+//                 }
+//                 LongPress = false;
+//                 if (y > 3) {
+//                     y = -1;
+//                 } else if (y < -1) y = 3;
+//                 redraw = true;
+//             }
+// #elif defined(HAS_5_BUTTONS) // Smoochie and Marauder-Mini
+//             if (check(SelPress)) { selection_made = true; }
+//             /* Down Btn to move in X axis (to the right) */
+//             if (check(NextPress)) {
+//                 x++;
+//                 if ((y < 0 && x > 4) || x > 11) x = 0; // Changed from 3 to 4 to include BACK button
+//                 redraw = true;
+//             }
+//             if (check(PrevPress)) {
+//                 x--;
+//                 if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
+//                 else if (x < 0) x = 11;
+//                 redraw = true;
+//             }
+//             /* UP Btn to move in Y axis (Downwards) */
+//             if (check(DownPress)) {
+//                 y++;
+//                 if (y > 3) { y = -1; }
+//                 redraw = true;
+//             }
+//             if (check(UpPress)) {
+//                 y--;
+//                 if (y < -1) y = 3;
+//                 redraw = true;
+//             }
+
+// #elif defined(HAS_ENCODER) // T-Embed
+//             if (check(SelPress)) { selection_made = true; }
+//             /* DOWN Btn to move in X axis (to the right) */
+//             if (check(NextPress)) {
+//                 if (check(EscPress)) {
+//                     y++;
+//                 } else if ((x >= 4 && y < 0) || x == 3) {
+//                     y++;
+//                     x = 0;
+//                 } else x++;
+
+//                 if (y > 3) y = -1;
+//                 if (y == -1 && x > 4) x = 0;
+
+//                 redraw = true;
+//             }
+//             /* UP Btn to move in Y axis (Downwards) */
+//             if (check(PrevPress)) {
+//                 if (check(EscPress)) {
+//                     y--;
+//                     if (y == -1 && x > 4) x = 4;
+//                 } else if (x == 0) {
+//                     y--;
+//                     x--;
+//                 } else x--;
+
+//                 if (y < -1) {
+//                     y = 3;
+//                     x = 3;
+//                 } else if (y < 0 && x < 0) x = 4;
+//                 else if (x < 0) x = 3;
+
+//                 redraw = true;
+//             }
+
+// #elif defined(HAS_KEYBOARD) // Cardputer and T-Deck
+//             if (KeyStroke.pressed) {
+//                 wakeUpScreen();
+//                 tft.setCursor(cursor_x, cursor_y);
+//                 String keyStr = "";
+//                 for (auto i : KeyStroke.word) {
+//                     if (keyStr != "") {
+//                         keyStr = keyStr + "+" + i;
+//                     } else {
+//                         keyStr += i;
+//                     }
+//                 }
+
+//                 if (current_text.length() < max_size && !KeyStroke.enter && !KeyStroke.del) {
+//                     current_text += keyStr;
+//                     if (current_text.length() != (max_FM_size + 1) &&
+//                         current_text.length() != (max_FM_size + 1))
+//                         tft.print(keyStr.c_str());
+//                     cursor_x = tft.getCursorX();
+//                     cursor_y = tft.getCursorY();
+//                     if (current_text.length() == (max_FM_size + 1)) redraw = true;
+//                     if (current_text.length() == (max_FP_size + 1)) redraw = true;
+//                 }
+//                 if (KeyStroke.del && current_text.length() > 0) { // delete 0x08
+//                     // Handle backspace key
+//                     current_text.remove(current_text.length() - 1);
+//                     int fontSize = FM;
+//                     if (current_text.length() > max_FP_size) {
+//                         tft.setTextSize(FP);
+//                         fontSize = FP;
+//                     } else tft.setTextSize(FM);
+//                     tft.setCursor((cursor_x - fontSize * LW), cursor_y);
+//                     tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+//                     tft.print(" ");
+//                     tft.setTextColor(getComplementaryColor2(bruceConfig.bgColor), 0x5AAB);
+//                     tft.setCursor(cursor_x - fontSize * LW, cursor_y);
+//                     cursor_x = tft.getCursorX();
+//                     cursor_y = tft.getCursorY();
+//                     if (current_text.length() == max_FM_size) redraw = true;
+//                     if (current_text.length() == max_FP_size) redraw = true;
+//                 }
+//                 if (KeyStroke.enter) { break; }
+//                 KeyStroke.Clear();
+//             }
+//             if (check(SelPress)) break;
+
+// #endif
+//         } // end of last_input_time detection
+
+//         if (SerialCmdPress) { // only for Remote Control, if no input was detected on device
+//             if (check(SelPress)) { selection_made = true; }
+//             /* Down Btn to move in X axis (to the right) */
+//             if (check(NextPress)) {
+//                 x++;
+//                 if ((y < 0 && x >= 000000000000000) || x > 11) x = 0;
+//                 redraw = true;
+//             }
+//             if (check(PrevPress)) {
+//                 x--;
+//                 if (y < 0 && x > 4) x = 4; // Changed from 3 to 4 to include BACK button
+//                 else if (x < 0) x = 11;
+//                 redraw = true;
+//             }
+//             /* UP Btn to move in Y axis (Downwards) */
+//             if (check(DownPress)) {
+//                 y++;
+//                 if (y > 3) { y = -1; }
+//                 redraw = true;
+//             }
+//             if (check(UpPress)) {
+//                 y--;
+//                 if (y < -1) y = 3;
+//                 redraw = true;
+//             }
+//         }
+
+//         if (selection_made) { // if something was selected then handle it
+//             selection_made = false;
+//             KeyboardAction action = handleHexKeyboardSelection(
+//                 x, y, current_text, cursor_x, cursor_y, max_size, max_FM_size, max_FP_size, keys
+//             );
+
+//             if (action == KEYBOARD_OK) { // OK BTN
+//                 break;
+//             } else if (action == KEYBOARD_CANCEL) { // BACK BTN
+//                 current_text = "\x1B";              // ASCII ESC CHARACTER
+//                 break;
+//             } else if (action == KEYBOARD_REDRAW) {
+//                 redraw = true;
+//             }
+
+//             last_input_time = millis();
+//         }
+//     }
+
+//     // Resets screen when finished writing
+//     tft.fillScreen(bruceConfig.bgColor);
+//     resetTftDisplay();
+
+//     return current_text;
+// }
 
 void powerOff() { displayWarning("Not available", true); }
 void goToDeepSleep() {

--- a/src/core/mykeyboard.h
+++ b/src/core/mykeyboard.h
@@ -3,6 +3,7 @@
 #include <globals.h>
 
 String keyboard(String mytext, int maxSize = 76, String msg = "Type your message:");
+String hex_keyboard(String mytext, int maxSize = 76, String msg = "Type your HEX message:");
 
 void __attribute__((weak)) powerOff();
 void __attribute__((weak)) goToDeepSleep();

--- a/src/core/mykeyboard.h
+++ b/src/core/mykeyboard.h
@@ -3,7 +3,8 @@
 #include <globals.h>
 
 String keyboard(String mytext, int maxSize = 76, String msg = "Type your message:");
-String hex_keyboard(String mytext, int maxSize = 76, String msg = "Type your HEX message:");
+String hex_keyboard(String mytext, int maxSize = 76, String msg = "Type you HEX value:");
+String num_keyboard(String mytext, int maxSize = 76, String msg = "Insert your number:");
 
 void __attribute__((weak)) powerOff();
 void __attribute__((weak)) goToDeepSleep();


### PR DESCRIPTION
![QWERTY](https://github.com/user-attachments/assets/8bc649a8-fe31-43e0-8630-6acf86166350)

### Proposed Changes ###

I was originally developing another feature for the IR module when I decided to explore adding a hexadecimal-only mode to the keyboard. While reviewing the existing keyboard code, I found it difficult to understand due to lack of comments, magic numbers, goto statements, and other not-so-good coding practices.

I decided to refactor it: modularizing the code, adding comments so that its easier to understand, and making the keyboard’s functionality easier to maintain. With the new structure, adding additional keyboard layouts is straightforward.

As part of this update, I added both a hexadecimal-only keyboard and a numeric keypad with digits and a decimal point for floating-point input.

![HEX](https://github.com/user-attachments/assets/4d1f6aa3-1966-431b-9d44-6c8421518c82)

### Types of Changes ###

- Added a BACK button for normal-sized screens, which returns the ESCAPE ASCII character (`\x1B`). Callers can check for this value to exit or return to the previous screen if appropriate.  
- Removed magic numbers and replaced them with named variables where useful.  
- Improved styling: characters are now centered in keys, and button spacing is more consistent.  
- Added a live character counter, which lets the user know how many more characters can be typed (based on the `max_size` variable passed to the function). Like this: `typed/max_size`.
- Made the touch box initialization dynamic, so that it works for every type of keyboard, and not just QWERTY.  
- Added HEX keyboard layout (0–9, A–F).  
- Added NUMPAD layout for numeric input (digits and decimal point).  
- Added documentation. 

#### Verification ####

The only modified files are `mykeyboard.cpp` and its corresponding header file `mykeyboard.h` (which now includes two additional lines for `hex_keyboard` and `num_keyboard` functions). 


#### Testing ####

I tested this with a t-embed cc1101. But currently I do not have any other device to do this on. So the other input methods should be tested, like touch, 3-buttons, 5-buttons and keyboard.

### User-Facing Change ###

```release-note
Added two new keyboard layouts:  
- HEX keyboard (0–9, A–F)  
- NUMPAD keyboard (digits and decimal point)  

Added a BACK button for normal-sized screens that returns an ESC character for exit handling.  
Improved keyboard appearance, spacing, and added a live character counter.
```

### Further Comments ###

This change is fully backward-compatible: code using the existing keyboard() function will continue to work without modification. Callers can however be upgraded with the ESC character recognition, returned by the back button, to handle that case.

![NUMPAD](https://github.com/user-attachments/assets/04ae8e72-d6d5-4199-ad3b-5055430232f2)