### PR TITLE
Add RF Jammer Timeout configuration and validation

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -717,6 +717,16 @@ void BruceConfig::validateRfidModuleValue() {
         rfidModule = M5_RFID2_MODULE;
     }
 }
+void BruceConfig::setRfJammerTimeout(int value) {
+    rfJammerTimeout = value;
+    validateRfJammerTimeout();
+    saveFile();
+}
+
+void BruceConfig::validateRfJammerTimeout() {
+    if (rfJammerTimeout < 0) rfJammerTimeout = 0;
+    if (rfJammerTimeout > 3600000) rfJammerTimeout = 3600000;
+}
 
 void BruceConfig::setiButtonPin(int value) {
     if (value < GPIO_NUM_MAX) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -77,6 +77,8 @@ public:
     float rfFreq = 433.92;
     int rfFxdFreq = 1;
     int rfScanRange = 3;
+    // Jammer timeout in milliseconds
+    int rfJammerTimeout = 20000;
 
     // iButton Pin
     int iButton = 0;
@@ -178,6 +180,8 @@ public:
     void setRfFxdFreq(float value);
     void setRfScanRange(int value, int fxdFreq = 0);
     void validateRfScanRangeValue();
+    void setRfJammerTimeout(int value);
+    void validateRfJammerTimeout();
 
     // iButton
     void setiButtonPin(int value);

--- a/src/core/menu_items/RFMenu.cpp
+++ b/src/core/menu_items/RFMenu.cpp
@@ -43,6 +43,7 @@ void RFMenu::configMenu() {
         {"RF RX Pin", lambdaHelper(gsetRfRxPin, true)},
         {"RF Module", setRFModuleMenu},
         {"RF Frequency", setRFFreqMenu},
+        {"RF Jammer Timeout", lambdaHelper(gsetRfJammerTimeout, true)},
         {"Back", [=]() { optionsMenu(); }},
     };
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -961,6 +961,59 @@ int gsetRfRxPin(bool set) {
 }
 
 /*********************************************************************
+ * * Function: setRfJammerTimeout
+ *  Get or set RF Jammer Timeout
+ *********************************************************************/
+int gsetRfJammerTimeout(bool set) {
+    int result = bruceConfig.rfJammerTimeout;
+
+    if (set) {
+        options.clear();
+        options.push_back(
+            {"0 s (infinite)", [=]() { bruceConfig.setRfJammerTimeout(0); }, bruceConfig.rfJammerTimeout == 0}
+        );
+
+        options.push_back(
+            {"20 s", [=]() { bruceConfig.setRfJammerTimeout(20000); }, bruceConfig.rfJammerTimeout == 20000}
+        );
+        options.push_back(
+            {"30 s", [=]() { bruceConfig.setRfJammerTimeout(30000); }, bruceConfig.rfJammerTimeout == 30000}
+        );
+        options.push_back(
+            {"60 s", [=]() { bruceConfig.setRfJammerTimeout(60000); }, bruceConfig.rfJammerTimeout == 60000}
+        );
+        options.push_back(
+            {"90 s", [=]() { bruceConfig.setRfJammerTimeout(90000); }, bruceConfig.rfJammerTimeout == 90000}
+        );
+        options.push_back(
+            {"120 s", [=]() { bruceConfig.setRfJammerTimeout(60000); }, bruceConfig.rfJammerTimeout == 120000}
+        );
+        options.push_back(
+            {"Custom",
+             [=]() {
+                 String timeout_str =
+                     keyboard(String(bruceConfig.rfJammerTimeout / 1000), 5, "Timeout (seconds):");
+                 if (timeout_str.length() > 0) {
+                     int timeout_val = timeout_str.toInt();
+                     if (timeout_val >= 0 && timeout_val <= 3600) { // Max 1 hour
+                         bruceConfig.setRfJammerTimeout(timeout_val * 1000);
+                     } else {
+                         displayError("Invalid timeout (0-3600s)");
+                         delay(1000);
+                     }
+                 }
+             },
+             false}
+        );
+
+        loopOptions(options);
+    }
+
+    returnToMenu = true;
+    return bruceConfig.rfJammerTimeout;
+}
+
+/*********************************************************************
 **  Function: setStartupApp
 **  Handles Menu to set startup app
 **********************************************************************/

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -59,6 +59,8 @@ int gsetRfTxPin(bool set = false);
 
 int gsetRfRxPin(bool set = false);
 
+int gsetRfJammerTimeout(bool set = false);
+
 void runClockLoop();
 
 void setSoundConfig();

--- a/src/modules/rf/rf_jammer.cpp
+++ b/src/modules/rf/rf_jammer.cpp
@@ -56,7 +56,8 @@ void RFJammer::run_itmt_jammer() {
         for (int sequence = 1; sequence < 50; sequence++) {
             for (int duration = 1; duration <= 3; duration++) {
                 // Moved Escape check into this loop to check every cycle
-                if (check(EscPress) || (millis() - tmr0) > 20000) {
+                if (check(EscPress) ||
+                    (bruceConfig.rfJammerTimeout > 0 && (millis() - tmr0 > bruceConfig.rfJammerTimeout))) {
                     sendRF = false;
                     returnToMenu = true;
                     break;

--- a/src/modules/rf/rf_jammer.cpp
+++ b/src/modules/rf/rf_jammer.cpp
@@ -40,7 +40,8 @@ void RFJammer::run_full_jammer() {
     int tmr0 = millis();                 // control total jammer time;
 
     while (sendRF) {
-        if (check(EscPress) || (millis() - tmr0 > 20000)) {
+        if (check(EscPress) ||
+            (bruceConfig.rfJammerTimeout > 0 && (millis() - tmr0 > bruceConfig.rfJammerTimeout))) {
             sendRF = false;
             returnToMenu = true;
             break;


### PR DESCRIPTION
- Introduced `rfJammerTimeout` variable in `config.h` with a default value.
- Implemented `setRfJammerTimeout` and `validateRfJammerTimeout` methods in `config.cpp`.
- Added menu option for configuring RF Jammer Timeout in `RFMenu.cpp`.
- Created `gsetRfJammerTimeout` function in `settings.cpp` to handle timeout settings.
- Updated `run_full_jammer` method in `rf_jammer.cpp` to utilize the new timeout setting.

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

so the idea is to remove the hardcoded 20seconds for the jammer and add a config option so a custom jammer operation time could be setted 

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->
Feature
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####


