### PR TITLE
T-Embed CC1101 RGB LEDs go out when the screen is turned off

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -1,6 +1,7 @@
 #include "display.h"
 #include "core/wifi/webInterface.h" // for server
 #include "core/wifi/wg.h"           //for isConnectedWireguard to print wireguard lock
+#include "led_control.h"            // for setLedState
 #include "mykeyboard.h"
 #include "settings.h" //for timeStr
 #include "utils.h"
@@ -104,6 +105,7 @@ void setTftDisplay(int x, int y, uint16_t fc, int size, uint16_t bg) {
 void turnOffDisplay() { setBrightness(0, false); }
 
 bool wakeUpScreen() {
+    setLedState(true);
     previousMillis = millis();
     if (isScreenOff) {
         isScreenOff = false;

--- a/src/core/led_control.cpp
+++ b/src/core/led_control.cpp
@@ -192,6 +192,7 @@ void ledEffectTask(void *pvParameters) {
 }
 
 void beginLed() {
+    log_i("Begin LED");
 #ifdef RGB_LED_CLK
     FastLED.addLeds<LED_TYPE, RGB_LED, RGB_LED_CLK, LED_ORDER>(leds, LED_COUNT);
 #else
@@ -686,5 +687,15 @@ void setLedBrightnessConfig() {
 
     loopOptions(options, idx);
     setLedBrightness(bruceConfig.ledBright);
+}
+
+void setLedState(bool state) {
+    if (state) {
+        ledSetup();
+    } else {
+        ledEffects(false);
+        fill_solid(leds, LED_COUNT, CRGB::Black);
+        FastLED.show();
+    }
 }
 #endif

--- a/src/core/led_control.h
+++ b/src/core/led_control.h
@@ -34,6 +34,7 @@ void ledEffects(bool enable);
 void ledPreviewMode(bool enable);
 void setLedBrightness(int value);
 void setLedBrightnessConfig();
+void setLedState(bool state);
 
 #else
 inline void blinkLed(int blinkTime = 50) {};

--- a/src/core/powerSave.cpp
+++ b/src/core/powerSave.cpp
@@ -1,5 +1,6 @@
 #include "powerSave.h"
 #include "display.h"
+#include "led_control.h"
 #include "settings.h"
 
 /* Check if it's time to put the device to sleep */
@@ -23,6 +24,7 @@ void checkPowerSaveTime() {
     if (elapsed >= dimmerSetMs && !dimmer && !isSleeping) {
         dimmer = true;
         setBrightness(startDimmerBright, false);
+        setLedState(false);
     } else if (elapsed >= (dimmerSetMs + SCREEN_OFF_DELAY) && !isScreenOff && !isSleeping) {
         isScreenOff = true;
         fadeOutScreen(startDimmerBright);
@@ -37,9 +39,7 @@ void sleepModeOn() {
 
     fadeOutScreen(startDimmerBright);
 
-
     panelSleep(true); //  power down screen
-
 
     disableCore0WDT();
     disableCore1WDT();
@@ -51,9 +51,7 @@ void sleepModeOff() {
     isSleeping = false;
     setCpuFrequencyMhz(240);
 
-
     panelSleep(false); // wake the screen back up
-
 
     getBrightness();
     enableCore0WDT();


### PR DESCRIPTION
Previously, when the screen was turned off, the standby mode remained on, which increased power consumption and looked strange. The LEDs now turn off when the screen is turned off, and turn on when it is turned on. Tested on T-Embed CC1101. There are bugs, for example, the preview of effects does not work well, but it's better than nothing.
