### PR TITLE
Implementation of MAC Management and MAC Spoofing

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -34,6 +34,7 @@ JsonDocument BruceConfig::toJson() const {
     JsonObject _wifiAp = setting["wifiAp"].to<JsonObject>();
     _wifiAp["ssid"] = wifiAp.ssid;
     _wifiAp["pwd"] = wifiAp.pwd;
+    setting["wifiMAC"] = wifiMAC; //@IncursioHack
 
     JsonArray _evilWifiNames = setting["evilWifiNames"].to<JsonArray>();
     for (auto key : evilWifiNames) _evilWifiNames.add(key);
@@ -251,6 +252,17 @@ void BruceConfig::fromFile(bool checkFS) {
         count++;
         log_e("Fail");
     }
+
+    //@IncursioHack
+    if (!setting["wifiMAC"].isNull()) {
+    wifiMAC = setting["wifiMAC"].as<String>();
+    } else {
+        wifiMAC = "";
+        count++;
+        log_e("wifiMAC not found, using default");
+    }
+
+
 
     // Wifi List
     if (!setting["wifi"].isNull()) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -62,6 +62,12 @@ public:
     WiFiCredential wifiAp = {"BruceNet", "brucenet"};
     std::map<String, String> wifi = {};
     std::set<String> evilWifiNames = {};
+    String wifiMAC = ""; //@IncursioHack
+
+    void setWifiMAC(const String &mac) {
+        wifiMAC = mac;
+        saveFile(); // opcional, para salvar imediatamente
+    }
 
     // BLE
     String bleName = String("Keyboard_" + String((uint8_t)(ESP.getEfuseMac() >> 32), HEX));

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1110,6 +1110,51 @@ void setNetworkCredsMenu() {
 }
 
 /*********************************************************************
+**  Function: setMacAddressMenu - @IncursioHack
+**  Handles Menu to configure WiFi MAC Address
+**********************************************************************/
+void setMacAddressMenu() {
+
+    String currentMAC = bruceConfig.wifiMAC;
+    if (currentMAC == "") currentMAC = WiFi.macAddress();
+
+    options.clear();
+    options = {
+        {"Default MAC (" + WiFi.macAddress() + ")",
+         [&]() { bruceConfig.setWifiMAC(""); },
+         bruceConfig.wifiMAC == ""},
+        {"Set Custom MAC",
+         [&]() {
+             String newMAC = keyboard(bruceConfig.wifiMAC, 17, "XX:YY:ZZ:AA:BB:CC");
+             if (newMAC.length() == 17) {
+                 bruceConfig.setWifiMAC(newMAC);
+             } else {
+                 displayError("Invalid MAC format");
+             }
+         }, bruceConfig.wifiMAC != ""},
+        {"Random MAC", [&]() {
+             uint8_t randomMac[6];
+             for (int i = 0; i < 6; i++) randomMac[i] = random(0x00, 0xFF);
+             char buf[18];
+             sprintf(
+                 buf,
+                 "%02X:%02X:%02X:%02X:%02X:%02X",
+                 randomMac[0],
+                 randomMac[1],
+                 randomMac[2],
+                 randomMac[3],
+                 randomMac[4],
+                 randomMac[5]
+             );
+             bruceConfig.setWifiMAC(String(buf));
+         }}
+    };
+
+    addOptionToMainMenu();
+    loopOptions(options, MENU_TYPE_REGULAR, ("Current: " + currentMAC).c_str());
+}
+
+/*********************************************************************
 **  Function: setSPIPins
 **  Main Menu to manually set SPI Pins
 **********************************************************************/

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -27,7 +27,9 @@ void setCustomUIColorSettingMenuG(int colorType);
 
 void setCustomUIColorSettingMenuB(int colorType);
 
-void setCustomUIColorSettingMenu(int colorType, int rgb, std::function<uint16_t(uint16_t, int)> colorGenerator);
+void setCustomUIColorSettingMenu(
+    int colorType, int rgb, std::function<uint16_t(uint16_t, int)> colorGenerator
+);
 
 void addEvilWifiMenu();
 
@@ -78,5 +80,7 @@ void setNetworkCredsMenu();
 void setSPIPinsMenu(BruceConfigPins::SPIPins &value);
 
 void setTheme();
+
+void setMacAddressMenu();
 
 #endif

--- a/src/core/wifi/wifi_common.cpp
+++ b/src/core/wifi/wifi_common.cpp
@@ -4,6 +4,7 @@
 #include "core/powerSave.h"
 #include "core/settings.h"
 #include "core/utils.h"
+#include "core/wifi/wifi_mac.h" // Set Mac Address - @IncursioHack
 #include <globals.h>
 
 bool _wifiConnect(const String &ssid, int encryption) {
@@ -103,6 +104,10 @@ bool wifiConnectMenu(wifi_mode_t mode) {
         case WIFI_STA: { // station mode
             int nets;
             WiFi.mode(WIFI_MODE_STA);
+
+            wifiMACMenu();
+            applyConfiguredMAC();
+
             bool refresh_scan = false;
             do {
                 displayTextLine("Scanning..");
@@ -127,8 +132,9 @@ bool wifiConnectMenu(wifi_mode_t mode) {
                         }
                         String optionText =
                             encryptionPrefix + ssid + "(" + String(rssi) + "|" + encryptionTypeStr + ")";
-                        options.push_back({optionText.c_str(), [=]() { _wifiConnect(ssid, encryptionType); }}
-                        );
+                        options.push_back({optionText.c_str(), [=]() {
+                                               _wifiConnect(ssid, encryptionType);
+                                           }});
                     }
                 }
                 options.push_back({"Hidden SSID", [=]() {

--- a/src/core/wifi/wifi_mac.cpp
+++ b/src/core/wifi/wifi_mac.cpp
@@ -1,0 +1,93 @@
+// @IncursioHack
+#include "core/wifi/wifi_mac.h"
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/utils.h"
+#include <esp_wifi.h>
+
+void applyConfiguredMAC() {
+    if (bruceConfig.wifiMAC.length() == 17 && validateMACFormat(bruceConfig.wifiMAC)) {
+        uint8_t newMAC[6];
+        sscanf(
+            bruceConfig.wifiMAC.c_str(),
+            "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+            &newMAC[0],
+            &newMAC[1],
+            &newMAC[2],
+            &newMAC[3],
+            &newMAC[4],
+            &newMAC[5]
+        );
+
+        if (esp_wifi_set_mac(WIFI_IF_STA, newMAC) == ESP_OK) {
+            Serial.println("[WiFi] Custom MAC applied: " + bruceConfig.wifiMAC);
+        } else {
+            Serial.println("[WiFi] Failed to apply custom MAC, using default");
+        }
+    }
+}
+
+bool validateMACFormat(const String &mac) {
+    if (mac.length() != 17) return false;
+    for (int i = 0; i < 17; i++) {
+        if ((i + 1) % 3 == 0) {
+            if (mac[i] != ':') return false;
+        } else {
+            if (!isxdigit(mac[i])) return false;
+        }
+    }
+    return true;
+}
+
+bool setCustomMAC(const String &mac) {
+    if (!validateMACFormat(mac)) {
+        displayError("Invalid MAC Format!");
+        return false;
+    }
+    bruceConfig.wifiMAC = mac;
+    bruceConfig.saveFile();
+    return true;
+}
+
+String generateRandomMAC() {
+    uint8_t mac[6];
+    mac[0] = 0x02;
+    for (int i = 1; i < 6; i++) mac[i] = random(0, 256);
+
+    char buf[18];
+    sprintf(buf, "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    return String(buf);
+}
+
+void wifiMACMenu() {
+    String currentMAC;
+
+    if (bruceConfig.wifiMAC != "" && validateMACFormat(bruceConfig.wifiMAC)) {
+        currentMAC = bruceConfig.wifiMAC + " (Custom)";
+    } else {
+        currentMAC = WiFi.macAddress() + " (Default)";
+    }
+
+    displayTextLine("Current MAC: " + currentMAC);
+    delay(1000);
+
+    options.clear();
+    options.push_back({"Default MAC", []() {
+                           bruceConfig.wifiMAC = "";
+                           bruceConfig.saveFile();
+                           displayTextLine("Default MAC set");
+                       }});
+
+    options.push_back({"Set MAC", []() {
+                           String newMAC = keyboard("", 17, "Enter MAC XX:YY:ZZ:AA:BB:CC");
+                           if (setCustomMAC(newMAC)) { displayTextLine("MAC Saved: " + newMAC); }
+                       }});
+
+    options.push_back({"Random MAC", []() {
+                           String randMAC = generateRandomMAC();
+                           setCustomMAC(randMAC);
+                           displayTextLine("Random MAC: " + randMAC);
+                       }});
+
+    loopOptions(options);
+}

--- a/src/core/wifi/wifi_mac.h
+++ b/src/core/wifi/wifi_mac.h
@@ -1,0 +1,19 @@
+#ifndef __WIFI_MAC_H__
+#define __WIFI_MAC_H__
+// @IncursioHack
+
+#include "core/settings.h"
+#include <Arduino.h>
+#include <WiFi.h>
+
+void applyConfiguredMAC();
+
+void wifiMACMenu();
+
+bool validateMACFormat(const String &mac);
+
+bool setCustomMAC(const String &mac);
+
+String generateRandomMAC();
+
+#endif


### PR DESCRIPTION
This PR adds support for managing and changing the Wi-Fi interface MAC address, serving as the foundation for the MAC Spoofing feature in the Bruce firmware.

### **Changes and Features**

- Current MAC Display: the device’s MAC address is shown before the Wi-Fi connection, allowing immediate verification.
- Selectable MAC Options:

1. MAC Default – the ESP32’s original hardware address.
2. MAC Custom – user-defined address saved in bruce.conf.
3. MAC Random – generates a temporary MAC for device anonymization.

- Persistence: the selected MAC is stored in the configuration and automatically applied on subsequent connections.
Foundation for MAC Spoofing: enables network audits, penetration testing, and device anonymization without requiring a reboot.

### **Next Steps**

- Integrate the MAC function into the Evil Portal and Wi-Fi Clone modules.
- Log all MACs used in Evil Portal / Wi-Fi Clone connections.
- Allow access to the feature via Serial Command.
- Consider MAC Default as the standard during Wi-Fi Startup.

### **Notes**

- The feature is integrated into the Wi-Fi configuration interface.
- MAC selection occurs before connection startup, ensuring compatibility with protected networks.
- This PR does not alter existing network behavior when MAC Default is selected.
- **For full functionality, BACKUP and DELETE the bruce.conf file from both the SD card and LittleFS. A new modified file will then be generated.**

