### PR TITLE
Add config settings for EvilPortal

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -46,6 +46,8 @@ JsonDocument BruceConfig::toJson() const {
     _evilWifiEndpoints["allowSetSsid"] = evilPortalEndpoints.allowSetSsid;
     _evilWifiEndpoints["allowGetCreds"] = evilPortalEndpoints.allowGetCreds;
 
+    setting["evilWifiPasswordMode"] = evilPortalPasswordMode;
+
     setting["bleName"] = bleName;
 
     JsonObject _wifi = setting["wifi"].to<JsonObject>();
@@ -299,6 +301,19 @@ void BruceConfig::fromFile(bool checkFS) {
         log_e("Fail");
     }
 
+    if (!setting["evilWifiPasswordMode"].isNull()) {
+        int mode = setting["evilWifiPasswordMode"].as<int>();
+        if (mode >= 0 && mode <= 2) {
+            evilPortalPasswordMode = static_cast<EvilPortalPasswordMode>(mode);
+        } else {
+            evilPortalPasswordMode = FULL_PASSWORD;
+            log_w("Invalid evilWifiPasswordMode, using FULL_PASSWORD");
+        }
+    } else {
+        count++;
+        log_e("Fail");
+    }
+
     if (!setting["bleName"].isNull()) {
         bleName = setting["bleName"].as<String>();
     } else {
@@ -497,6 +512,9 @@ void BruceConfig::validateConfig() {
     validateGpsBaudrateValue();
     validateDevModeValue();
     validateColorInverted();
+    validateEvilEndpointCreds();
+    validateEvilEndpointSsid();
+    validateEvilPasswordMode();
 }
 
 void BruceConfig::setUiColor(uint16_t primary, uint16_t *secondary, uint16_t *background) {
@@ -717,6 +735,15 @@ void BruceConfig::setEvilAllowGetCreds(bool value) {
 void BruceConfig::setEvilAllowSetSsid(bool value) {
     evilPortalEndpoints.allowSetSsid = value;
     saveFile();
+}
+
+void BruceConfig::setEvilPasswordMode(EvilPortalPasswordMode value) {
+    evilPortalPasswordMode = value;
+    saveFile();
+}
+
+void BruceConfig::validateEvilPasswordMode() {
+    if (evilPortalPasswordMode < 0 || evilPortalPasswordMode > 2) evilPortalPasswordMode = FULL_PASSWORD;
 }
 
 void BruceConfig::setBleName(String value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -22,7 +22,7 @@ enum RFModules {
     CC1101_SPI_MODULE = 1,
 };
 
-enum EvilPortalPasswordMode { FULL_PASSWORD = 0, FIRST_LAST_CHAR = 1, HIDE_PASSWORD = 2 };
+enum EvilPortalPasswordMode { FULL_PASSWORD = 0, FIRST_LAST_CHAR = 1, HIDE_PASSWORD = 2, SAVE_LENGTH = 3 };
 
 class BruceConfig : public BruceTheme {
 public:

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -36,6 +36,13 @@ public:
         String menuName;
         String content;
     };
+    struct EvilPortalEndpoints {
+        String getCredsEndpoint;
+        String setSsidEndpoint;
+        bool showEndpoints;
+        bool allowSetSsid;
+        bool allowGetCreds;
+    };
 
     const char *filepath = "/bruce.conf";
 
@@ -63,6 +70,9 @@ public:
     std::map<String, String> wifi = {};
     std::set<String> evilWifiNames = {};
     String wifiMAC = ""; //@IncursioHack
+
+    // EvilPortal
+    EvilPortalEndpoints evilPortalEndpoints = {"/creds", "/ssid", true, true, true};
 
     void setWifiMAC(const String &mac) {
         wifiMAC = mac;
@@ -167,6 +177,13 @@ public:
     String getWifiPassword(const String &ssid) const;
     void addEvilWifiName(String value);
     void removeEvilWifiName(String value);
+    void setEvilEndpointCreds(String value);
+    void setEvilEndpointSsid(String value);
+    void setEvilAllowEndpointDisplay(bool value);
+    void setEvilAllowGetCreds(bool value);
+    void setEvilAllowSetSsid(bool value);
+    void validateEvilEndpointCreds();
+    void validateEvilEndpointSsid();
 
     // BLE
     void setBleName(const String name);

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -22,6 +22,8 @@ enum RFModules {
     CC1101_SPI_MODULE = 1,
 };
 
+enum EvilPortalPasswordMode { FULL_PASSWORD = 0, FIRST_LAST_CHAR = 1, HIDE_PASSWORD = 2 };
+
 class BruceConfig : public BruceTheme {
 public:
     struct WiFiCredential {
@@ -73,6 +75,7 @@ public:
 
     // EvilPortal
     EvilPortalEndpoints evilPortalEndpoints = {"/creds", "/ssid", true, true, true};
+    EvilPortalPasswordMode evilPortalPasswordMode = FULL_PASSWORD;
 
     void setWifiMAC(const String &mac) {
         wifiMAC = mac;
@@ -182,8 +185,10 @@ public:
     void setEvilAllowEndpointDisplay(bool value);
     void setEvilAllowGetCreds(bool value);
     void setEvilAllowSetSsid(bool value);
+    void setEvilPasswordMode(EvilPortalPasswordMode value);
     void validateEvilEndpointCreds();
     void validateEvilEndpointSsid();
+    void validateEvilPasswordMode();
 
     // BLE
     void setBleName(const String name);

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -118,9 +118,9 @@ void WifiMenu::configMenu() {
                                std::vector<Option> evilOptions;
 
                                evilOptions.push_back({"Password Mode", setEvilPasswordMode});
-                               evilOptions.push_back({"Set /creds endpoint", setEvilEndpointCreds});
+                               evilOptions.push_back({"Rename /creds", setEvilEndpointCreds});
                                evilOptions.push_back({"Allow /creds access", setEvilAllowGetCreds});
-                               evilOptions.push_back({"Set /ssid endpoint", setEvilEndpointSsid});
+                               evilOptions.push_back({"Rename /ssid", setEvilEndpointSsid});
                                evilOptions.push_back({"Allow /ssid access", setEvilAllowSetSsid});
                                evilOptions.push_back({"Display endpoints", setEvilAllowEndpointDisplay});
                                evilOptions.push_back({"Back", [=]() { configMenu(); }});

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -109,10 +109,15 @@ void WifiMenu::optionsMenu() {
 
 void WifiMenu::configMenu() {
     options = {
-        {"Add Evil Wifi",    addEvilWifiMenu         },
-        {"Remove Evil Wifi", removeEvilWifiMenu      },
-        {"Change MAC",       wifiMACMenu             },
-        {"Back",             [=]() { optionsMenu(); }},
+        {"Change MAC",                wifiMACMenu                },
+        {"Add Evil Wifi",             addEvilWifiMenu            },
+        {"Remove Evil Wifi",          removeEvilWifiMenu         },
+        {"Set /creds endpoint",       setEvilEndpointCreds       },
+        {"Allow /creds access",       setEvilAllowGetCreds       },
+        {"Set /ssid endpoint",        setEvilEndpointSsid        },
+        {"Allow /ssid access",        setEvilAllowSetSsid        },
+        {"Show endpoints in AP mode", setEvilAllowEndpointDisplay},
+        {"Back",                      [=]() { optionsMenu(); }   },
     };
 
     loopOptions(options, MENU_TYPE_SUBMENU, "WiFi Config");

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -112,6 +112,7 @@ void WifiMenu::configMenu() {
         {"Change MAC",                wifiMACMenu                },
         {"Add Evil Wifi",             addEvilWifiMenu            },
         {"Remove Evil Wifi",          removeEvilWifiMenu         },
+        {"Evil Wifi Password Mode",   setEvilPasswordMode        },
         {"Set /creds endpoint",       setEvilEndpointCreds       },
         {"Allow /creds access",       setEvilAllowGetCreds       },
         {"Set /ssid endpoint",        setEvilEndpointSsid        },

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -114,21 +114,18 @@ void WifiMenu::configMenu() {
     wifiOptions.push_back({"Add Evil Wifi", addEvilWifiMenu});
     wifiOptions.push_back({"Remove Evil Wifi", removeEvilWifiMenu});
 
-    wifiOptions.push_back(
-        {"Evil Wifi Settings", [=]() {
-             std::vector<Option> evilOptions;
+    wifiOptions.push_back({"Evil Wifi Settings", [=]() {
+                               std::vector<Option> evilOptions;
 
-             evilOptions.push_back({"Evil Wifi Password Mode", setEvilPasswordMode});
-             evilOptions.push_back({"Set /creds endpoint", setEvilEndpointCreds});
-             evilOptions.push_back({"Allow /creds access", setEvilAllowGetCreds});
-             evilOptions.push_back({"Set /ssid endpoint", setEvilEndpointSsid});
-             evilOptions.push_back({"Allow /ssid access", setEvilAllowSetSsid});
-             evilOptions.push_back({"Show endpoints in AP mode", setEvilAllowEndpointDisplay});
-             evilOptions.push_back({"Back", [=]() { configMenu(); }});
-
-             loopOptions(evilOptions, MENU_TYPE_SUBMENU, "Evil Wifi Settings");
-         }}
-    );
+                               evilOptions.push_back({"Password Mode", setEvilPasswordMode});
+                               evilOptions.push_back({"Set /creds endpoint", setEvilEndpointCreds});
+                               evilOptions.push_back({"Allow /creds access", setEvilAllowGetCreds});
+                               evilOptions.push_back({"Set /ssid endpoint", setEvilEndpointSsid});
+                               evilOptions.push_back({"Allow /ssid access", setEvilAllowSetSsid});
+                               evilOptions.push_back({"Display endpoints", setEvilAllowEndpointDisplay});
+                               evilOptions.push_back({"Back", [=]() { configMenu(); }});
+                               loopOptions(evilOptions, MENU_TYPE_SUBMENU, "Evil Wifi Settings");
+                           }});
 
     wifiOptions.push_back({"Back", [=]() { optionsMenu(); }});
 

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -108,21 +108,33 @@ void WifiMenu::optionsMenu() {
 }
 
 void WifiMenu::configMenu() {
-    options = {
-        {"Change MAC",                wifiMACMenu                },
-        {"Add Evil Wifi",             addEvilWifiMenu            },
-        {"Remove Evil Wifi",          removeEvilWifiMenu         },
-        {"Evil Wifi Password Mode",   setEvilPasswordMode        },
-        {"Set /creds endpoint",       setEvilEndpointCreds       },
-        {"Allow /creds access",       setEvilAllowGetCreds       },
-        {"Set /ssid endpoint",        setEvilEndpointSsid        },
-        {"Allow /ssid access",        setEvilAllowSetSsid        },
-        {"Show endpoints in AP mode", setEvilAllowEndpointDisplay},
-        {"Back",                      [=]() { optionsMenu(); }   },
-    };
+    std::vector<Option> wifiOptions;
 
-    loopOptions(options, MENU_TYPE_SUBMENU, "WiFi Config");
+    wifiOptions.push_back({"Change MAC", wifiMACMenu});
+    wifiOptions.push_back({"Add Evil Wifi", addEvilWifiMenu});
+    wifiOptions.push_back({"Remove Evil Wifi", removeEvilWifiMenu});
+
+    wifiOptions.push_back(
+        {"Evil Wifi Settings", [=]() {
+             std::vector<Option> evilOptions;
+
+             evilOptions.push_back({"Evil Wifi Password Mode", setEvilPasswordMode});
+             evilOptions.push_back({"Set /creds endpoint", setEvilEndpointCreds});
+             evilOptions.push_back({"Allow /creds access", setEvilAllowGetCreds});
+             evilOptions.push_back({"Set /ssid endpoint", setEvilEndpointSsid});
+             evilOptions.push_back({"Allow /ssid access", setEvilAllowSetSsid});
+             evilOptions.push_back({"Show endpoints in AP mode", setEvilAllowEndpointDisplay});
+             evilOptions.push_back({"Back", [=]() { configMenu(); }});
+
+             loopOptions(evilOptions, MENU_TYPE_SUBMENU, "Evil Wifi Settings");
+         }}
+    );
+
+    wifiOptions.push_back({"Back", [=]() { optionsMenu(); }});
+
+    loopOptions(wifiOptions, MENU_TYPE_SUBMENU, "WiFi Config");
 }
+
 void WifiMenu::drawIconImg() {
     drawImg(
         *bruceConfig.themeFS(), bruceConfig.getThemeItemImg(bruceConfig.theme.paths.wifi), 0, imgCenterY, true

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -576,6 +576,9 @@ void setEvilPasswordMode() {
         {"Save '*hidden*'",
          [=]() { bruceConfig.setEvilPasswordMode(HIDE_PASSWORD); },
          bruceConfig.evilPortalPasswordMode == HIDE_PASSWORD  },
+        {"Save length",
+         [=]() { bruceConfig.setEvilPasswordMode(SAVE_LENGTH); },
+         bruceConfig.evilPortalPasswordMode == SAVE_LENGTH    },
     };
     loopOptions(options, bruceConfig.evilPortalPasswordMode);
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -493,6 +493,75 @@ void removeEvilWifiMenu() {
 }
 
 /*********************************************************************
+**  Function: setEvilEndpointCreds
+**  Handles menu for changing the endpoint to access captured creds
+**********************************************************************/
+void setEvilEndpointCreds() {
+    String userInput = keyboard(bruceConfig.evilPortalEndpoints.getCredsEndpoint, 30, "Evil creds endpoint");
+    bruceConfig.setEvilEndpointCreds(userInput);
+}
+
+/*********************************************************************
+**  Function: setEvilEndpointSsid
+**  Handles menu for changing the endpoint to change evilSsid
+**********************************************************************/
+void setEvilEndpointSsid() {
+    String userInput = keyboard(bruceConfig.evilPortalEndpoints.setSsidEndpoint, 30, "Evil creds endpoint");
+    bruceConfig.setEvilEndpointSsid(userInput);
+}
+
+/*********************************************************************
+**  Function: setEvilAllowGetCredentials
+**  Handles menu for toggling access to the credential list endpoint
+**********************************************************************/
+
+void setEvilAllowGetCreds() {
+    options = {
+        {"Disallow",
+         [=]() { bruceConfig.setEvilAllowGetCreds(false); },
+         bruceConfig.evilPortalEndpoints.allowGetCreds == false},
+        {"Allow",
+         [=]() { bruceConfig.setEvilAllowGetCreds(true); },
+         bruceConfig.evilPortalEndpoints.allowGetCreds == true },
+    };
+    loopOptions(options, bruceConfig.evilPortalEndpoints.allowGetCreds);
+}
+
+/*********************************************************************
+**  Function: setEvilAllowGetCredentials
+**  Handles menu for toggling access to the change SSID endpoint
+**********************************************************************/
+
+void setEvilAllowSetSsid() {
+    options = {
+        {"Disallow",
+         [=]() { bruceConfig.setEvilAllowSetSsid(false); },
+         bruceConfig.evilPortalEndpoints.allowSetSsid == false},
+        {"Allow",
+         [=]() { bruceConfig.setEvilAllowSetSsid(true); },
+         bruceConfig.evilPortalEndpoints.allowSetSsid == true },
+    };
+    loopOptions(options, bruceConfig.evilPortalEndpoints.allowSetSsid);
+}
+
+/*********************************************************************
+**  Function: setEvilAllowEndpointDisplay
+**  Handles menu for toggling the display of the Evil Portal endpoints
+**********************************************************************/
+
+void setEvilAllowEndpointDisplay() {
+    options = {
+        {"Disallow",
+         [=]() { bruceConfig.setEvilAllowEndpointDisplay(false); },
+         bruceConfig.evilPortalEndpoints.showEndpoints == false},
+        {"Allow",
+         [=]() { bruceConfig.setEvilAllowEndpointDisplay(true); },
+         bruceConfig.evilPortalEndpoints.showEndpoints == true },
+    };
+    loopOptions(options, bruceConfig.evilPortalEndpoints.showEndpoints);
+}
+
+/*********************************************************************
 **  Function: setRFModuleMenu
 **  Handles Menu to set the RF module in use
 **********************************************************************/

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -562,6 +562,25 @@ void setEvilAllowEndpointDisplay() {
 }
 
 /*********************************************************************
+** Function: setEvilPasswordMode
+** Handles menu for setting the evil portal password mode
+***********************************************************************/
+void setEvilPasswordMode() {
+    options = {
+        {"Save 'password'",
+         [=]() { bruceConfig.setEvilPasswordMode(FULL_PASSWORD); },
+         bruceConfig.evilPortalPasswordMode == FULL_PASSWORD  },
+        {"Save 'p******d'",
+         [=]() { bruceConfig.setEvilPasswordMode(FIRST_LAST_CHAR); },
+         bruceConfig.evilPortalPasswordMode == FIRST_LAST_CHAR},
+        {"Save '*hidden*'",
+         [=]() { bruceConfig.setEvilPasswordMode(HIDE_PASSWORD); },
+         bruceConfig.evilPortalPasswordMode == HIDE_PASSWORD  },
+    };
+    loopOptions(options, bruceConfig.evilPortalPasswordMode);
+}
+
+/*********************************************************************
 **  Function: setRFModuleMenu
 **  Handles Menu to set the RF module in use
 **********************************************************************/

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -35,6 +35,16 @@ void addEvilWifiMenu();
 
 void removeEvilWifiMenu();
 
+void setEvilEndpointCreds();
+
+void setEvilEndpointSsid();
+
+void setEvilAllowEndpointDisplay();
+
+void setEvilAllowGetCreds();
+
+void setEvilAllowSetSsid();
+
 void setRFModuleMenu();
 
 void setRFFreqMenu();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -45,6 +45,8 @@ void setEvilAllowGetCreds();
 
 void setEvilAllowSetSsid();
 
+void setEvilPasswordMode();
+
 void setRFModuleMenu();
 
 void setRFFreqMenu();

--- a/src/modules/wifi/evil_portal.cpp
+++ b/src/modules/wifi/evil_portal.cpp
@@ -233,15 +233,15 @@ void EvilPortal::drawScreen() {
         if (bruceConfig.evilPortalEndpoints.allowGetCreds) {
             padprintln("-> " + apIp + bruceConfig.evilPortalEndpoints.getCredsEndpoint + " -> get creds");
         } else {
-            padprintln("-> credential extraction disabled in config");
+            padprintln("-> cred access disabled");
         }
         if (bruceConfig.evilPortalEndpoints.allowSetSsid) {
             padprintln("-> " + apIp + bruceConfig.evilPortalEndpoints.setSsidEndpoint + " -> set ssid");
         } else {
-            padprintln("-> change of SSID disabled in config");
+            padprintln("-> SSID change disabled");
         }
     } else {
-        padprintln("Nothing to see here, move along.");
+        padprintln("Endpoints hidden");
     }
     padprintln("");
 
@@ -253,11 +253,11 @@ void EvilPortal::drawScreen() {
     String passMode = "";
     switch (bruceConfig.evilPortalPasswordMode) {
         case FULL_PASSWORD: passMode = "Full"; break;
-        case FIRST_LAST_CHAR: passMode = "first/last: p******d"; break;
-        case HIDE_PASSWORD: passMode = "Hidden: *hidden*"; break;
-        case SAVE_LENGTH: passMode = "Length only: X chars"; break;
+        case FIRST_LAST_CHAR: passMode = "p******d"; break;
+        case HIDE_PASSWORD: passMode = "*hidden*"; break;
+        case SAVE_LENGTH: passMode = "Length only"; break;
     }
-    padprintln("Password mode: " + passMode);
+    padprintln("Pwd mode: " + passMode);
     printLastCapturedCredential();
 
     printDeauthStatus();

--- a/src/modules/wifi/evil_portal.cpp
+++ b/src/modules/wifi/evil_portal.cpp
@@ -255,8 +255,9 @@ void EvilPortal::drawScreen() {
         case FULL_PASSWORD: passMode = "Full"; break;
         case FIRST_LAST_CHAR: passMode = "first/last: p******d"; break;
         case HIDE_PASSWORD: passMode = "Hidden: *hidden*"; break;
+        case SAVE_LENGTH: passMode = "Length only: X chars"; break;
     }
-    padprint("Password mode: " + passMode);
+    padprintln("Password mode: " + passMode);
     printLastCapturedCredential();
 
     printDeauthStatus();


### PR DESCRIPTION
#### Proposed Changes ####

I'd like to make the evil portal more useful for pentesting a live environment without exposing more of it's sensitive information than necessary. For that I want to add features to prevent users from remotely viewing captured credentials or changing settings - or making that harder by changing the endpoint URLs.

- Adding support for changing the endpoint urls `/creds` and `/ssid` via the config file
- Adding support for changing the endpoint urls `/creds` and `/ssid` via the WIFI settings menu
- Adding support for disabling the endpoints `/creds` and `/ssid` individually
- Changing the `/ssid` POST target to `/ssid` instead of `/ssidpost` to reduce the number of URLs used
- Adding support for not storing the password when capturing credentials
- Adding support for obduscating the password when capturing credentials

#### Types of Changes ####

I consider this a new feature

#### Verification ####

I can and will test my changes on the cardputer as well as the T-Embed device as much as possible

#### Testing ####

Needs to be checked

#### Linked Issues ####

#1617 1617

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Add support for configuring EvilPortal exposed endpoints via Menu and Config-file.
```

#### Further Comments ####

