### PR TITLE
docs - update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ It also supports m5stack products and works great with Cardputer, Sticks, M5Core
 ### The easiest way to install Bruce is using our official Web Flasher!
 ### Check out: https://bruce.computer/flasher
 
-Alternatively, you can download the latest binary from releases or actions and flash locally using esptool.py
+Alternatively, you can download the latest binary from releases or actions and flash locally using [esptool.py](https://github.com/espressif/esptool). Visit the [documentation](https://docs.espressif.com/projects/esptool/en/latest/esp32/).
+
 ```sh
-esptool.py --port /dev/ttyACM0 write_flash 0x00000 Bruce-<device>.bin
+esptool --port /dev/ttyACM0 write-flash 0x00000 Bruce-<device>.bin
 ```
 
 **For m5stack devices**


### PR DESCRIPTION
#### Proposed Changes ####

Update of esptool commands
#### Types of Changes ####

Added links to the installation tool. Fixed commands.
Removed ".py" to execute the command as per https://docs.espressif.com/projects/esptool/en/latest/esp32/migration-guide.html?highlight=write_flash

Changed "_" to "-" as described in:

Command and Option Renaming

All commands and options have been renamed to use - instead of _ as a separator (e.g., write_flash -> write-flash).



