### PR TITLE
Custom WebUI from SD Card or LittleFS

### DIFF
--- a/embedded_resources/web_interface/theme.css
+++ b/embedded_resources/web_interface/theme.css
@@ -1,0 +1,5 @@
+:root {
+  --color: #ad007b;
+  --sec-color: #ce6db5;
+  --background: #000000;
+}

--- a/src/core/wifi/webInterface.cpp
+++ b/src/core/wifi/webInterface.cpp
@@ -290,10 +290,10 @@ void serveWebUIFile(
 ) {
     AsyncWebServerResponse *response;
     FS *fs = NULL;
-    if (sdcardMounted) {
-        if (SD.exists("/BruceWebUI/" + filename)) fs = &SD;
-    } else {
-        if (LittleFS.exists("/BruceWebUI/" + filename)) fs = &LittleFS;
+    if (sdcardMounted && SD.exists("/BruceWebUI/" + filename)) {
+        fs = &SD;
+    } else if (LittleFS.exists("/BruceWebUI/" + filename)) {
+        fs = &LittleFS;
     }
     if (fs) {
         // try to read the custom file

--- a/src/core/wifi/webInterface.h
+++ b/src/core/wifi/webInterface.h
@@ -16,6 +16,11 @@ String readLineFromFile(File myFile);
 
 void loopOptionsWebUi();
 
+void serveWebUIFile(AsyncWebServerRequest *request, String filename, const char *contentType);
+void serveWebUIFile(
+    AsyncWebServerRequest *request, String filename, const char *contentType, bool gzip,
+    const uint8_t *originaFile, uint32_t originalFileSize
+);
 void configureWebServer();
 void startWebUi(bool mode_ap = false);
 void stopWebUi();


### PR DESCRIPTION
#### Proposed Changes ####

Add the ability to upload WebUI files to the SD Card or LittleFS to allow customisation without compiling the firmware. This allows simple changes like colours or layout, to the more the complex like translations.
It also makes on-device WebUI editing possible, I have used https://github.com/lshaf/bruce-web-interface to simulate which is great but sometimes you need the real thing.

Only the customised files need to be uploaded, it will fallback to the versions included in the compiled firmware.

I added the default `theme.css` to the repository which is generated on the fly by the firmware to use as an example.

#### Types of Changes ####

New Feature

#### Verification ####

This shows a modified `theme.css` changing the WebUI colours from the device UI theme. Plus changes to the `index.html` altering the title, font (who does not love Comic Sans!) and some very useful emoji. :joy: 

<img width="4032" height="2529" alt="image" src="https://github.com/user-attachments/assets/fd5504cd-7fca-4fe7-824f-070186441b57" />

#### Testing ####

None

#### Linked Issues ####

https://github.com/pr3y/Bruce/issues/1462
https://github.com/pr3y/Bruce/pull/1409

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Customize the WebUI by uploading modified versions of the default files.
```

#### Further Comments ####

Updated the wiki https://github.com/pr3y/Bruce/wiki/Files#webui

Preview: https://github.com/emericklaw/Bruce/wiki/Files#webui

```
## WebUI
Make you device as an AP or connect to a network to use the WebUI, with this you can manage your files on the SD card and also LittleFS
Before setting up, you need to access http://bruce.local with the credentials on screen to have access to the manager.

### Customizing the WebUI
You can customize the WebUI by editing the files in the [embedded_resources/web_interface](https://github.com/pr3y/Bruce/tree/main/embedded_resources/web_interface) folder.

After making your changes, upload the modified files to your device’s SD card or LittleFS inside a folder named `BruceWebUI`.

* You only need to upload the files you have modified.
* Any files not present in the `BruceWebUI` folder will automatically fall back to the default version.

⚠️ **Warning:** If you customize these files, you are responsible for keeping them up to date. Future updates to the default WebUI may conflict with your changes, which could cause the WebUI on your device to stop working. Should this happen, rename or delete the files inside the `BruceWebUI` folder.
```