### PR TITLE
remove #include "modules/wifi/dpwo.h" inside WifiMenu.cpp

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -125,7 +125,7 @@ lib_deps =
 	https://github.com/rennancockles/SimpleCLI
 	https://github.com/whywilson/ESP-PN532BLE
 	https://github.com/whywilson/ESP-PN532-UART@^0.0.2
-	https://github.com/whywilson/ESP-PN532Killer@^0.0.5
+	https://github.com/whywilson/ESP-PN532Killer@^0.0.6
 	NTPClient
 	Timezone
 	ESP32Time

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -8,7 +8,6 @@
 #include "modules/ethernet/ARPScanner.h"
 #include "modules/wifi/ap_info.h"
 #include "modules/wifi/clients.h"
-#include "modules/wifi/dpwo.h"
 #include "modules/wifi/evil_portal.h"
 #include "modules/wifi/scan_hosts.h"
 #include "modules/wifi/sniffer.h"


### PR DESCRIPTION
removed #include "modules/wifi/dpwo.h" because it caused build error in visual studio because dpwo.h and dpwo.cpp were deleted



