### PR TITLE
Optimize PN532 on UART

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ default_envs =
 	;LAUNCHER_Marauder-v61
 	;Awok-Touch"
   ;esp32-c5
-  
+
 ;uncomment to not use global dirs to avoid possible conflicts
 ;platforms_dir = .pio/platforms
 ;packages_dir = .pio/packages
@@ -135,7 +135,7 @@ lib_deps =
 	https://github.com/rennancockles/SimpleCLI
 	https://github.com/bmorcelli/ESP-PN532BLE
 	https://github.com/whywilson/ESP-PN532-UART@^0.0.2
-	https://github.com/whywilson/ESP-PN532Killer #@^0.0.5 #version control
+	https://github.com/whywilson/ESP-PN532Killer@^0.0.6
 	NTPClient
 	Timezone
 	ESP32Time

--- a/src/core/startup_app.cpp
+++ b/src/core/startup_app.cpp
@@ -35,7 +35,7 @@ StartupApp::StartupApp() {
     _startupApps["WebUI"] = []() { startWebUi(!wifiConnecttoKnownNet()); };
 #ifndef LITE_VERSION
     _startupApps["PN532 BLE"] = []() { Pn532ble(); };
-    _startupApps["PN532Killer"] = []() { PN532KillerTools(); };
+    _startupApps["PN532 UART"] = []() { PN532KillerTools(); };
 #endif
 }
 

--- a/src/modules/rfid/PN532KillerTools.h
+++ b/src/modules/rfid/PN532KillerTools.h
@@ -26,10 +26,15 @@ private:
     PN532Killer _pn532Killer = PN532Killer(Serial1);
     String _titleName = "PN532Killer";
     bool _isPn532killer = false;
+    bool _deviceInitialized = false;
     void hardwareProbe();
 
     void sendCommand(const std::vector<uint8_t> &data);
     void displayBanner();
+    void displayInitialScreen();
+    void playDeviceDetectedSound();
+    void playUidFoundSound();
+    void resetDevice();
 
     void setEmulatorNextSlot(bool reverse = false, bool redrawTypeName = true);
     void setSnifferMode();

--- a/src/modules/rfid/PN532KillerTools.h
+++ b/src/modules/rfid/PN532KillerTools.h
@@ -27,6 +27,7 @@ private:
     String _titleName = "PN532Killer";
     bool _isPn532killer = false;
     bool _deviceInitialized = false;
+    bool _initializationFailed = false;
     void hardwareProbe();
 
     void sendCommand(const std::vector<uint8_t> &data);
@@ -34,12 +35,13 @@ private:
     void displayInitialScreen();
     void playDeviceDetectedSound();
     void playUidFoundSound();
-    void resetDevice();
+    void resetDevice(bool showInitialScreen = true);
 
     void setEmulatorNextSlot(bool reverse = false, bool redrawTypeName = true);
     void setSnifferMode();
     void setSnifferUid();
     void mainMenu();
+    void failedInitMenu();
     void netMenu();
     void emulatorMenu();
     void snifferMenu();


### PR DESCRIPTION
#### Proposed Changes ####

Now we can check PN532 or PN532Killer via UART. And turn PN532/PN532Killer as the BLE/TCP/UDP Reader.

#### Verification ####

- M5StickC Adater with PN532Killer
- M5StickC with PN532

