### PR TITLE
Hide default UI when using tx_from_file for subghz and ir

### DIFF
--- a/src/core/serial_commands/ir_commands.cpp
+++ b/src/core/serial_commands/ir_commands.cpp
@@ -100,12 +100,14 @@ uint32_t irTxRawCallback(cmd *c) {
 }
 
 uint32_t irTxFileCallback(cmd *c) {
-    // example: ir tx_from_file LG_AKB72915206_power.ir
+    // example: ir tx_from_file LG_AKB72915206_power.ir false
 
     Command cmd(c);
 
-    Argument arg = cmd.getArgument("filepath");
-    String filepath = arg.getValue();
+    Argument filepathArg = cmd.getArgument("filepath");
+    Argument hideDefaultUIArg = cmd.getArgument("hideDefaultUI");
+    String filepath = filepathArg.getValue();
+    String hideDefaultUI = hideDefaultUIArg.getValue();
     filepath.trim();
 
     if (filepath.indexOf(".ir") == -1) {
@@ -123,7 +125,7 @@ uint32_t irTxFileCallback(cmd *c) {
         return false;
     }
 
-    return txIrFile(fs, filepath);
+    return txIrFile(fs, filepath, hideDefaultUI);
 }
 
 uint32_t irTxBufferCallback(cmd *c) {
@@ -206,6 +208,7 @@ void createIrTxRawCommand(Command *irCmd) {
 void createIrTxFileCommand(Command *irCmd) {
     Command cmd = irCmd->addCommand("tx_from_file", irTxFileCallback);
     cmd.addPositionalArgument("filepath");
+    cmd.addPositionalArgument("hideDefaultUI", "false");
 }
 
 void createIrTxBufferCommand(Command *irCmd) {

--- a/src/core/serial_commands/rf_commands.cpp
+++ b/src/core/serial_commands/rf_commands.cpp
@@ -95,12 +95,15 @@ uint32_t rfScanCallback(cmd *c) {
 }
 
 uint32_t rfTxFileCallback(cmd *c) {
-    // example: subghz tx_from_file plug1_on.sub
+    // example: subghz tx_from_file plug1_on.sub false
 
     Command cmd(c);
 
-    Argument arg = cmd.getArgument("filepath");
-    String filepath = arg.getValue();
+    Argument filepathArg = cmd.getArgument("filepath");
+    Argument hideDefaultUIArg = cmd.getArgument("hideDefaultUI");
+    String filepath = filepathArg.getValue();
+    String hideDefaultUI = hideDefaultUIArg.getValue();
+    filepath.trim();
 
     if (filepath.indexOf(".sub") == -1) {
         serialDevice->println("Invalid file");
@@ -117,7 +120,7 @@ uint32_t rfTxFileCallback(cmd *c) {
         return false;
     }
 
-    return txSubFile(fs, filepath);
+    return txSubFile(fs, filepath, hideDefaultUI);
 }
 
 uint32_t rfTxBufferCallback(cmd *c) {
@@ -221,6 +224,7 @@ void createRfScanCommand(Command *rfCmd) {
 void createRfTxFileCommand(Command *rfCmd) {
     Command cmd = rfCmd->addCommand("tx_from_file", rfTxFileCallback);
     cmd.addPosArg("filepath");
+    cmd.addPosArg("hideDefaultUI", "false");
 }
 
 void createRfTxBufferCommand(Command *rfCmd) {

--- a/src/core/serial_commands/util_commands.cpp
+++ b/src/core/serial_commands/util_commands.cpp
@@ -139,7 +139,10 @@ uint32_t helpCallback(cmd *c) {
     serialDevice->println("  ir rx <timeout>      - Read an IR signal and print the dump on serialDevice->");
     serialDevice->println("  ir rx raw <timeout>  - Read an IR signal in RAW mode and print the dump on serialDevice->");
     serialDevice->println("  ir tx <protocol> <address> <decoded_value>  - Send a custom decoded IR signal.");
-    serialDevice->println("  ir tx_from_file <ir file path>  - Send an IR signal saved in storage.");
+    serialDevice->println(
+        "  ir tx_from_file <ir file path> [hide default UI true/false] - Send an IR signal saved in "
+        "storage. Optionally hide the default UI."
+    );
 
     serialDevice->println("\nRF Commands:");
     serialDevice->println(
@@ -153,7 +156,10 @@ uint32_t helpCallback(cmd *c) {
         "  subghz tx <decoded_value> <frequency> <te> <count>  - Send a custom decoded RF signal. (alias: rf "
         "tx)"
     );
-    serialDevice->println("  subghz tx_from_file <sub file path>  - Send an RF signal saved in storage.");
+    serialDevice->println(
+        "  subghz tx_from_file <sub file path> [hide default UI true/false] - Send an RF signal "
+        "saved in storage. Optionally hide the default UI."
+    );
 
     serialDevice->println("\nAudio Commands:");
     serialDevice->println("  music_player <audio file path>  - Play an audio file.");

--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -455,17 +455,37 @@ static duk_ret_t native_tone(duk_context *ctx) {
 }
 
 static duk_ret_t native_irTransmitFile(duk_context *ctx) {
-    // usage: irTransmitFile(filename : string);
+    // usage: irTransmitFile(filename : string, hideDefaultUI : boolean);
     // returns: bool==true on success, false on any error
-    bool r = serialCli.parse("ir tx_from_file " + String(duk_to_string(ctx, 0)));
+
+    // Get the filename (required)
+    const char *filename = duk_to_string(ctx, 0);
+
+    // Default for the hideDefaultUI parameter
+    bool hideDefaultUI = false;
+
+    // Check if second argument exists and is boolean
+    if (duk_get_top(ctx) > 1 && duk_is_boolean(ctx, 1)) { hideDefaultUI = duk_to_boolean(ctx, 1); }
+
+    bool r = serialCli.parse("ir tx_from_file " + String(filename) + " " + String(hideDefaultUI));
     duk_push_boolean(ctx, r);
     return 1;
 }
 
 static duk_ret_t native_subghzTransmitFile(duk_context *ctx) {
-    // usage: subghzTransmitFile(filename : string);
+    // usage: subghzTransmitFile(filename : string, hideDefaultUI : boolean);
     // returns: bool==true on success, false on any error
-    bool r = serialCli.parse("subghz tx_from_file " + String(duk_to_string(ctx, 0)));
+
+    // Get the filename (required)
+    const char *filename = duk_to_string(ctx, 0);
+
+    // Default for the hideDefaultUI parameter
+    bool hideDefaultUI = false;
+
+    // Check if second argument exists and is boolean
+    if (duk_get_top(ctx) > 1 && duk_is_boolean(ctx, 1)) { hideDefaultUI = duk_to_boolean(ctx, 1); }
+
+    bool r = serialCli.parse("subghz tx_from_file " + String(filename) + " " + String(hideDefaultUI));
     duk_push_boolean(ctx, r);
     return 1;
 }

--- a/src/modules/ir/custom_ir.cpp
+++ b/src/modules/ir/custom_ir.cpp
@@ -69,7 +69,7 @@ void selectRecentIrMenu() {
     return;
 }
 
-bool txIrFile(FS *fs, String filepath) {
+bool txIrFile(FS *fs, String filepath, bool hideDefaultUI) {
     // SPAM all codes of the file
 
     int total_codes = 0;
@@ -110,7 +110,7 @@ bool txIrFile(FS *fs, String filepath) {
     // comes back to first position, beggining of the file
     databaseFile.seek(0);
     while (databaseFile.available()) {
-        progressHandler(codes_sent, total_codes);
+        if (!hideDefaultUI) { progressHandler(codes_sent, total_codes); }
         line = databaseFile.readStringUntil('\n');
         if (line.endsWith("\r")) line.remove(line.length() - 1);
 
@@ -139,7 +139,7 @@ bool txIrFile(FS *fs, String filepath) {
                         code.type = "raw";
                         code.data = rawData;
                         code.frequency = frequency;
-                        sendIRCommand(&code);
+                        sendIRCommand(&code, hideDefaultUI);
 
                         rawData = "";
                         frequency = 0;
@@ -175,7 +175,7 @@ bool txIrFile(FS *fs, String filepath) {
                         Serial.println("bits: " + bits);
                     } else if (line.indexOf("#") != -1) { // TODO: also detect EOF
                         IRCode code(protocol, address, command, value, bits);
-                        sendIRCommand(&code);
+                        sendIRCommand(&code, hideDefaultUI);
 
                         protocol = "";
                         address = "";
@@ -193,7 +193,7 @@ bool txIrFile(FS *fs, String filepath) {
         if (check(SelPress)) // Pause TV-B-Gone
         {
             while (check(SelPress)) yield();
-            displayTextLine("Paused");
+            if (!hideDefaultUI) { displayTextLine("Paused"); }
 
             while (!check(SelPress)) { // If Presses Select again, continues
                 if (check(EscPress)) {
@@ -203,7 +203,7 @@ bool txIrFile(FS *fs, String filepath) {
             }
             while (check(SelPress)) { yield(); }
             if (endingEarly) break; // Cancels  custom IR Spam
-            displayTextLine("Running, Wait");
+            if (!hideDefaultUI) { displayTextLine("Running, Wait"); }
         }
     } // end while file has lines to process
     databaseFile.close();
@@ -341,29 +341,37 @@ void otherIRcodes() {
 
 // IR commands
 
-void sendIRCommand(IRCode *code) {
+void sendIRCommand(IRCode *code, bool hideDefaultUI) {
     // https://developer.flipper.net/flipperzero/doxygen/infrared_file_format.html
-    if (code->type.equalsIgnoreCase("raw")) sendRawCommand(code->frequency, code->data);
-    else if (code->protocol.equalsIgnoreCase("NEC")) sendNECCommand(code->address, code->command);
-    else if (code->protocol.equalsIgnoreCase("NECext")) sendNECextCommand(code->address, code->command);
+    if (code->type.equalsIgnoreCase("raw")) sendRawCommand(code->frequency, code->data, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("NEC"))
+        sendNECCommand(code->address, code->command, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("NECext"))
+        sendNECextCommand(code->address, code->command, hideDefaultUI);
     else if (code->protocol.equalsIgnoreCase("RC5") || code->protocol.equalsIgnoreCase("RC5X"))
-        sendRC5Command(code->address, code->command);
-    else if (code->protocol.equalsIgnoreCase("RC6")) sendRC6Command(code->address, code->command);
-    else if (code->protocol.equalsIgnoreCase("Samsung32")) sendSamsungCommand(code->address, code->command);
-    else if (code->protocol.equalsIgnoreCase("SIRC")) sendSonyCommand(code->address, code->command, 12);
-    else if (code->protocol.equalsIgnoreCase("SIRC15")) sendSonyCommand(code->address, code->command, 15);
-    else if (code->protocol.equalsIgnoreCase("SIRC20")) sendSonyCommand(code->address, code->command, 20);
-    else if (code->protocol.equalsIgnoreCase("Kaseikyo")) sendKaseikyoCommand(code->address, code->command);
+        sendRC5Command(code->address, code->command, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("RC6"))
+        sendRC6Command(code->address, code->command, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("Samsung32"))
+        sendSamsungCommand(code->address, code->command, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("SIRC"))
+        sendSonyCommand(code->address, code->command, 12, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("SIRC15"))
+        sendSonyCommand(code->address, code->command, 15, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("SIRC20"))
+        sendSonyCommand(code->address, code->command, 20, hideDefaultUI);
+    else if (code->protocol.equalsIgnoreCase("Kaseikyo"))
+        sendKaseikyoCommand(code->address, code->command, hideDefaultUI);
     // Others protocols of IRRemoteESP8266, not related to Flipper Zero IR File Format
     else if (code->protocol != "" && code->data != "" &&
              strToDecodeType(code->protocol.c_str()) != decode_type_t::UNKNOWN)
-        sendDecodedCommand(code->protocol, code->data, code->bits);
+        sendDecodedCommand(code->protocol, code->data, code->bits, hideDefaultUI);
 }
 
-void sendNECCommand(String address, String command) {
+void sendNECCommand(String address, String command, bool hideDefaultUI) {
     IRsend irsend(bruceConfig.irTx); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
     uint16_t addressValue = strtoul(address.substring(0, 2).c_str(), nullptr, 16);
     uint16_t commandValue = strtoul(command.substring(0, 2).c_str(), nullptr, 16);
     uint64_t data = irsend.encodeNEC(addressValue, commandValue);
@@ -381,10 +389,10 @@ void sendNECCommand(String address, String command) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 
-void sendNECextCommand(String address, String command) {
+void sendNECextCommand(String address, String command, bool hideDefaultUI) {
     IRsend irsend(bruceConfig.irTx); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
 
     int first_zero_byte_pos = address.indexOf("00", 2);
     if (first_zero_byte_pos != -1) address = address.substring(0, first_zero_byte_pos);
@@ -419,10 +427,10 @@ void sendNECextCommand(String address, String command) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 
-void sendRC5Command(String address, String command) {
+void sendRC5Command(String address, String command, bool hideDefaultUI) {
     IRsend irsend(bruceConfig.irTx, true); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
     uint8_t addressValue = strtoul(address.substring(0, 2).c_str(), nullptr, 16);
     uint8_t commandValue = strtoul(command.substring(0, 2).c_str(), nullptr, 16);
     uint16_t data = irsend.encodeRC5(addressValue, commandValue);
@@ -438,10 +446,10 @@ void sendRC5Command(String address, String command) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 
-void sendRC6Command(String address, String command) {
+void sendRC6Command(String address, String command, bool hideDefaultUI) {
     IRsend irsend(bruceConfig.irTx, true); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
     address.replace(" ", "");
     command.replace(" ", "");
     uint32_t addressValue = strtoul(address.substring(0, 2).c_str(), nullptr, 16);
@@ -461,10 +469,10 @@ void sendRC6Command(String address, String command) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 
-void sendSamsungCommand(String address, String command) {
+void sendSamsungCommand(String address, String command, bool hideDefaultUI) {
     IRsend irsend(bruceConfig.irTx); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
     uint8_t addressValue = strtoul(address.substring(0, 2).c_str(), nullptr, 16);
     uint8_t commandValue = strtoul(command.substring(0, 2).c_str(), nullptr, 16);
     uint64_t data = irsend.encodeSAMSUNG(addressValue, commandValue);
@@ -482,10 +490,10 @@ void sendSamsungCommand(String address, String command) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 
-void sendSonyCommand(String address, String command, uint8_t nbits) {
+void sendSonyCommand(String address, String command, uint8_t nbits, bool hideDefaultUI) {
     IRsend irsend(bruceConfig.irTx); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
 
     address.replace(" ", "");
     command.replace(" ", "");
@@ -529,10 +537,10 @@ void sendSonyCommand(String address, String command, uint8_t nbits) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 
-void sendKaseikyoCommand(String address, String command) {
+void sendKaseikyoCommand(String address, String command, bool hideDefaultUI) {
     IRsend irsend(bruceConfig.irTx); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
 
     address.replace(" ", "");
     command.replace(" ", "");
@@ -582,7 +590,7 @@ void sendKaseikyoCommand(String address, String command) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
 }
 
-bool sendDecodedCommand(String protocol, String value, uint8_t bits) {
+bool sendDecodedCommand(String protocol, String value, uint8_t bits, bool hideDefaultUI) {
     // https://github.com/crankyoldgit/IRremoteESP8266/blob/master/examples/SmartIRRepeater/SmartIRRepeater.ino
 #if !defined(LITE_VERSION) && !defined(ARDUINO_M5STICK_C_PLUS)
     decode_type_t type = strToDecodeType(protocol.c_str());
@@ -591,7 +599,7 @@ bool sendDecodedCommand(String protocol, String value, uint8_t bits) {
     IRsend irsend(bruceConfig.irTx); // Set the GPIO to be used to sending the message.
     irsend.begin();
     bool success = false;
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
 
     if (hasACState(type)) {
         // need to send the state (still passed from value)
@@ -632,20 +640,20 @@ bool sendDecodedCommand(String protocol, String value, uint8_t bits) {
     digitalWrite(bruceConfig.irTx, LED_OFF);
     return success;
 #else
-    displayTextLine("Unavailable on this Version");
+    if (!hideDefaultUI) { displayTextLine("Unavailable on this Version"); }
     delay(1000);
     return false;
 #endif
 }
 
-void sendRawCommand(uint16_t frequency, String rawData) {
+void sendRawCommand(uint16_t frequency, String rawData, bool hideDefaultUI) {
 #ifdef USE_BQ25896 /// ENABLE 5V OUTPUT
     PPM.enableOTG();
 #endif
 
     IRsend irsend(bruceConfig.irTx); // Set the GPIO to be used to sending the message.
     irsend.begin();
-    displayTextLine("Sending..");
+    if (!hideDefaultUI) { displayTextLine("Sending.."); }
 
     uint16_t dataBufferSize = 1;
     for (int i = 0; i < rawData.length(); i++) {

--- a/src/modules/ir/custom_ir.h
+++ b/src/modules/ir/custom_ir.h
@@ -38,15 +38,15 @@ struct IRCode {
 };
 
 // Custom IR
-void sendIRCommand(IRCode *code);
-void sendRawCommand(uint16_t frequency, String rawData);
-void sendNECCommand(String address, String command);
-void sendNECextCommand(String address, String command);
-void sendRC5Command(String address, String command);
-void sendRC6Command(String address, String command);
-void sendSamsungCommand(String address, String command);
-void sendSonyCommand(String address, String command, uint8_t nbits);
-void sendKaseikyoCommand(String address, String command);
-bool sendDecodedCommand(String protocol, String value, uint8_t bits = 32);
+void sendIRCommand(IRCode *code, bool hideDefaultUI = false);
+void sendRawCommand(uint16_t frequency, String rawData, bool hideDefaultUI = false);
+void sendNECCommand(String address, String command, bool hideDefaultUI = false);
+void sendNECextCommand(String address, String command, bool hideDefaultUI = false);
+void sendRC5Command(String address, String command, bool hideDefaultUI = false);
+void sendRC6Command(String address, String command, bool hideDefaultUI = false);
+void sendSamsungCommand(String address, String command, bool hideDefaultUI = false);
+void sendSonyCommand(String address, String command, uint8_t nbits, bool hideDefaultUI = false);
+void sendKaseikyoCommand(String address, String command, bool hideDefaultUI = false);
+bool sendDecodedCommand(String protocol, String value, uint8_t bits = 32, bool hideDefaultUI = false);
 void otherIRcodes();
-bool txIrFile(FS *fs, String filepath);
+bool txIrFile(FS *fs, String filepath, bool hideDefaultUI = false);

--- a/src/modules/rf/rf_send.cpp
+++ b/src/modules/rf/rf_send.cpp
@@ -35,7 +35,7 @@ void sendCustomRF() {
     }
 }
 
-bool txSubFile(FS *fs, String filepath) {
+bool txSubFile(FS *fs, String filepath, bool hideDefaultUI) {
     struct RfCodes selected_code;
     File databaseFile;
     String line;
@@ -45,7 +45,8 @@ bool txSubFile(FS *fs, String filepath) {
     if (!fs) return false;
 
     databaseFile = fs->open(filepath, FILE_READ);
-    drawMainBorder();
+
+    if (!hideDefaultUI) { drawMainBorder(); }
 
     if (!databaseFile) {
         Serial.println("Failed to open database file.");
@@ -75,7 +76,8 @@ bool txSubFile(FS *fs, String filepath) {
         if (line.startsWith("Bit_RAW:"))
             bitRawList.push_back(txt.toInt()); // selected_code.BitRAW = txt.toInt();
         if (line.startsWith("Key:"))
-            keyList.push_back(hexStringToDecimal(txt.c_str())
+            keyList.push_back(
+                hexStringToDecimal(txt.c_str())
             ); // selected_code.key = hexStringToDecimal(txt.c_str());
         if (line.startsWith("RAW_Data:") || line.startsWith("Data_RAW:"))
             rawDataList.push_back(txt); // selected_code.data = txt;
@@ -90,31 +92,37 @@ bool txSubFile(FS *fs, String filepath) {
     if (selected_code.protocol != "" && selected_code.preset != "" && selected_code.frequency > 0) {
         for (int bit : bitList) {
             selected_code.Bit = bit;
-            sendRfCommand(selected_code);
+            sendRfCommand(selected_code, hideDefaultUI);
             sent++;
-            if (check(EscPress)) break;
-            displayTextLine("Sent " + String(sent) + "/" + String(total));
+            if (!hideDefaultUI) {
+                if (check(EscPress)) break;
+                displayTextLine("Sent " + String(sent) + "/" + String(total));
+            }
         }
         for (int bitRaw : bitRawList) {
             selected_code.Bit = bitRaw;
-            sendRfCommand(selected_code);
+            sendRfCommand(selected_code, hideDefaultUI);
             sent++;
-            if (check(EscPress)) break;
-            displayTextLine("Sent " + String(sent) + "/" + String(total));
+            if (!hideDefaultUI) {
+                if (check(EscPress)) break;
+                displayTextLine("Sent " + String(sent) + "/" + String(total));
+            }
         }
         for (uint64_t key : keyList) {
             selected_code.key = key;
-            sendRfCommand(selected_code);
+            sendRfCommand(selected_code, hideDefaultUI);
             sent++;
-            if (check(EscPress)) break;
-            displayTextLine("Sent " + String(sent) + "/" + String(total));
+            if (!hideDefaultUI) {
+                if (check(EscPress)) break;
+                displayTextLine("Sent " + String(sent) + "/" + String(total));
+            }
         }
 
         // RAS_Data is considered one long signal, doesn't matter the number of lines it has
         if (rawDataList.size() > 0) sent++;
         for (String rawData : rawDataList) {
             selected_code.data = rawData;
-            sendRfCommand(selected_code);
+            sendRfCommand(selected_code, hideDefaultUI);
             // sent++;
             if (check(EscPress)) break;
             // displayTextLine("Sent " + String(sent) + "/" + String(total));
@@ -123,7 +131,7 @@ bool txSubFile(FS *fs, String filepath) {
     }
 
     Serial.printf("\nSent %d of %d signals\n", sent, total);
-    displayTextLine("Sent " + String(sent) + "/" + String(total), true);
+    if (!hideDefaultUI) { displayTextLine("Sent " + String(sent) + "/" + String(total), true); }
 
     // Clear the vectors from memory
     bitList.clear();
@@ -140,7 +148,7 @@ bool txSubFile(FS *fs, String filepath) {
     return true;
 }
 
-void sendRfCommand(struct RfCodes rfcode) {
+void sendRfCommand(struct RfCodes rfcode, bool hideDefaultUI) {
     uint32_t frequency = rfcode.frequency;
     String protocol = rfcode.protocol;
     String preset = rfcode.preset;
@@ -271,7 +279,7 @@ void sendRfCommand(struct RfCodes rfcode) {
         transmittimings[transmittimings_idx] = 0; // termination
 
         // send rf command
-        displayTextLine("Sending..");
+        if (!hideDefaultUI) { displayTextLine("Sending.."); }
         RCSwitch_RAW_send(transmittimings);
         free(transmittimings);
     } else if (protocol == "BinRAW") {
@@ -296,7 +304,7 @@ void sendRfCommand(struct RfCodes rfcode) {
         Serial.println(pulse);
         Serial.println(rcswitch_protocol_no);
         */
-        displayTextLine("Sending..");
+        if (!hideDefaultUI) { displayTextLine("Sending.."); }
         RCSwitch_send(data_val, bits, pulse, rcswitch_protocol_no, repeat);
     } else if (protocol.startsWith("Princeton")) {
         RCSwitch_send(rfcode.key, rfcode.Bit, 350, 1, 10);

--- a/src/modules/rf/rf_send.h
+++ b/src/modules/rf/rf_send.h
@@ -4,9 +4,9 @@
 #include "structs.h"
 
 void sendCustomRF();
-bool txSubFile(FS *fs, String filepath);
+bool txSubFile(FS *fs, String filepath, bool hideDefaultUI = false);
 
-void sendRfCommand(struct RfCodes rfcode);
+void sendRfCommand(struct RfCodes rfcode, bool hideDefaultUI = false);
 void RCSwitch_send(uint64_t data, unsigned int bits, int pulse = 0, int protocol = 1, int repeat = 10);
 
 void RCSwitch_RAW_Bit_send(RfCodes data);


### PR DESCRIPTION
#### Proposed Changes ####

Hide default UI when using tx_from_file for subghz and ir.

Added new optional parameter to:
`subghz.transmitFile(path_to_file, true)`
and
`ir.transmitFile(path_to_file, true)`

Also applies to serial:
`subghz tx_from_file path_to_file true`
and
`ir tx_from_file path_to_file true`

#### Types of Changes ####

New feature

#### Verification ####

Before the change the UI was cleared, `drawMainBorder()` was called and `Sending..` was shown. It also paused after sending the files.
If you set the optional parameter to `true` then the default UI is hidden and can be fully controlled by either JS Interpreter.

**Run through of SubGHz and IR using JS Interpreter showing it not displaying the default UI**
https://youtu.be/n9auJtO2al0

#### Testing ####

None

#### Linked Issues ####

Fixes #1672 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow default UI to be hudden when using tx_from_file for subghz and ir for both serial and JS interpreter.
```

#### Further Comments ####

This could be done for other commands that interact with the UI, however I think a better solution might be needed, there is a lot of repetition in this implementation.