### PR TITLE
Add missing timezones and add UTC offset to menu

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -177,7 +177,7 @@ void BruceConfig::fromFile(bool checkFS) {
         log_e("Fail");
     }
     if (!setting["tmz"].isNull()) {
-        tmz = setting["tmz"].as<int>();
+        tmz = setting["tmz"].as<float>();
     } else {
         count++;
         log_e("Fail");
@@ -553,14 +553,14 @@ void BruceConfig::validateBrightValue() {
     if (bright > 100) bright = 100;
 }
 
-void BruceConfig::setTmz(int value) {
+void BruceConfig::setTmz(float value) {
     tmz = value;
     validateTmzValue();
     saveFile();
 }
 
 void BruceConfig::validateTmzValue() {
-    if (tmz < -12 || tmz > 12) tmz = 0;
+    if (tmz < -12 || tmz > 14) tmz = 0;
 }
 
 void BruceConfig::setSoundEnabled(int value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -52,7 +52,7 @@ public:
     int rotation = ROTATION > 1 ? 3 : 1;
     int dimmerSet = 10;
     int bright = 100;
-    int tmz = 0;
+    float tmz = 0;
     int soundEnabled = 1;
     int soundVolume = 100;
     int wifiAtStartup = 0;
@@ -148,7 +148,7 @@ public:
     void validateDimmerValue();
     void setBright(uint8_t value);
     void validateBrightValue();
-    void setTmz(int value);
+    void setTmz(float value);
     void validateTmzValue();
     void setSoundEnabled(int value);
     void setSoundVolume(int value);

--- a/src/core/serial_commands/settings_commands.cpp
+++ b/src/core/serial_commands/settings_commands.cpp
@@ -37,7 +37,7 @@ uint32_t settingsCallback(cmd *c) {
     if (setting_name == "rot") bruceConfig.setRotation(setting_value.toInt());
     if (setting_name == "dimmerSet") bruceConfig.setDimmer(setting_value.toInt());
     if (setting_name == "bright") bruceConfig.setBright(setting_value.toInt());
-    if (setting_name == "tmz") bruceConfig.setTmz(setting_value.toInt());
+    if (setting_name == "tmz") bruceConfig.setTmz(setting_value.toFloat());
     if (setting_name == "soundEnabled") bruceConfig.setSoundEnabled(setting_value.toInt());
     if (setting_name == "wifiAtStartup") bruceConfig.setWifiAtStartup(setting_value.toInt());
     if (setting_name == "webUI") {


### PR DESCRIPTION
#### Proposed Changes ####

Add missing timezones and add UTC offset to menu.

#### Types of Changes ####

New feature

#### Verification ####

Scrolling text menu items cause some weirdness but it looks fine on device.

![firefox_2025-09-27_23-58-03](https://github.com/user-attachments/assets/9cf8f32d-2303-45d5-aded-493ad2ffaa88)

#### Testing ####

None

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a full list of timezones
```

#### Further Comments ####

