### PR TITLE
Fix incorrect ledEffectDirection in openThemeFile

### DIFF
--- a/src/core/theme.cpp
+++ b/src/core/theme.cpp
@@ -94,7 +94,7 @@ bool BruceTheme::openThemeFile(FS *fs, String filepath, bool overwriteConfigSett
         if (!_th["ledEffect"].isNull()) { bruceConfig.ledEffect = _th["ledEffect"].as<int>(); }
         if (!_th["ledEffectSpeed"].isNull()) { bruceConfig.ledEffectSpeed = _th["ledEffectSpeed"].as<int>(); }
         if (!_th["ledEffectDirection"].isNull()) {
-            bruceConfig.ledBright = _th["ledEffectDirection"].as<int>();
+            bruceConfig.ledEffectDirection = _th["ledEffectDirection"].as<int>();
         }
         ledSetup();
 #endif


### PR DESCRIPTION
#### Proposed Changes ####

Fix incorrect ledEffectDirection in openThemeFile

Was
`bruceConfig.ledBright = _th["ledEffectDirection"].as<int>();`

Now
`bruceConfig.ledEffectDirection = _th["ledEffectDirection"].as<int>();`

#### Types of Changes ####

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

