### PR TITLE
Theme builder LED color fix and new author and url fields

### DIFF
--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -866,7 +866,7 @@
 
                             const baseName = file.name.substring(0, file.name.lastIndexOf(".")) || file.name;
                             const blob = await fetch(imageDataUrl).then(res => res.blob());
-                            const fileName = `${baseName}.${fileExtension}`;
+                            const fileName = isGuid(baseName) ? `${name}.${fileExtension}` : `${baseName}.${fileExtension}`;
                             jsonMapping[name] = fileName;
                             imageFolder.file(fileName, blob);
                             totalProcessed++;
@@ -1024,6 +1024,11 @@
 
                 container.appendChild(div);
             });
+        }
+
+        function isGuid(str) {
+            const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+            return guidRegex.test(str);
         }
 
         createFileInputs();

--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -551,7 +551,7 @@
                     <input type="text" id="heightInputCustom" class="form-text" value="105,140,180,222" />
                 </div>
                 <div class="control-item">
-                    <label for="qualityInput">Quality:</label>
+                    <label for="qualityInput">Image Quality:</label>
                     <input type="range" id="qualityInput" min="0" max="1" step="0.1" value="0.8"
                         oninput="updateQualityValue(this.value)">
                     <div id="qualityValue" class="quality-value">0.8</div>

--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -864,8 +864,9 @@
                             let fileExtension = fileType.split('/')[1];
                             let imageDataUrl = canvas.toDataURL(fileType, quality);
 
+                            const baseName = file.name.substring(0, file.name.lastIndexOf(".")) || file.name;
                             const blob = await fetch(imageDataUrl).then(res => res.blob());
-                            const fileName = `${name}.${fileExtension}`;
+                            const fileName = `${baseName}.${fileExtension}`;
                             jsonMapping[name] = fileName;
                             imageFolder.file(fileName, blob);
                             totalProcessed++;

--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -786,7 +786,7 @@
                 secColor: rgbToRGB565(document.getElementById('secColor').value),
                 bgColor: rgbToRGB565(document.getElementById('bgColor').value),
                 ledBright: document.getElementById('ledBrightnessInput').value,
-                ledColor: document.getElementById('ledColor').value.substring(0, 7),
+                ledColor: document.getElementById('ledColor').value.substring(1, 7),
                 ledEffect: document.getElementById('ledEffectInput').value,
                 ledEffectSpeed: document.getElementById('ledSyncToEncoder').checked ? 11 : document.getElementById('ledEffectSpeedInput').value,
                 ledEffectDirection: document.getElementById('ledEffectDirection').checked ? -1 : 1

--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -527,6 +527,14 @@
                     <input type="text" id="themeNameInput" class="form-text" />
                 </div>
                 <div class="control-item">
+                    <label for="themeAuthorInput">Theme Author:</label>
+                    <input type="text" id="themeAuthorInput" class="form-text" />
+                </div>
+                <div class="control-item">
+                    <label for="themeUrlInput">Theme URL:</label>
+                    <input type="text" id="themeUrlInput" class="form-text" />
+                </div>
+                <div class="control-item">
                     <label for="heightInput">Target Device:</label>
                     <select id="heightInput" class="form-select"
                         onchange="document.getElementById('heightInputCustom').parentElement.style.display = this.value === 'CUSTOM' ? 'block' : 'none';">
@@ -551,19 +559,17 @@
             </div>
 
             <div class="control-group">
-                <div class="colors-group">
-                    <div class="control-item">
-                        <label for="priColor">Primary Color:</label>
-                        <input type="color" id="priColor" value="#ad007b" onchange="updateColorDisplay()">
-                    </div>
-                    <div class="control-item">
-                        <label for="secColor">Secondary Color:</label>
-                        <input type="color" id="secColor" value="#8c007b" onchange="updateColorDisplay()">
-                    </div>
-                    <div class="control-item">
-                        <label for="bgColor">Background Color:</label>
-                        <input type="color" id="bgColor" value="#000000" onchange="updateColorDisplay()">
-                    </div>
+                <div class="control-item">
+                    <label for="priColor">Primary Color:</label>
+                    <input type="color" id="priColor" value="#ad007b" onchange="updateColorDisplay()">
+                </div>
+                <div class="control-item">
+                    <label for="secColor">Secondary Color:</label>
+                    <input type="color" id="secColor" value="#8c007b" onchange="updateColorDisplay()">
+                </div>
+                <div class="control-item">
+                    <label for="bgColor">Background Color:</label>
+                    <input type="color" id="bgColor" value="#000000" onchange="updateColorDisplay()">
                 </div>
                 <div class="border-control">
                     <input type="checkbox" id="border" checked>
@@ -781,16 +787,26 @@
         }
 
         function getCommonMapping() {
-            return {
-                priColor: rgbToRGB565(document.getElementById('priColor').value),
-                secColor: rgbToRGB565(document.getElementById('secColor').value),
-                bgColor: rgbToRGB565(document.getElementById('bgColor').value),
-                ledBright: document.getElementById('ledBrightnessInput').value,
-                ledColor: document.getElementById('ledColor').value.substring(1, 7),
-                ledEffect: document.getElementById('ledEffectInput').value,
-                ledEffectSpeed: document.getElementById('ledSyncToEncoder').checked ? 11 : document.getElementById('ledEffectSpeedInput').value,
-                ledEffectDirection: document.getElementById('ledEffectDirection').checked ? -1 : 1
-            };
+            const mapping = {};
+
+            const name = document.getElementById("themeNameInput").value.trim();
+            const author = document.getElementById("themeAuthorInput").value.trim();
+            const url = document.getElementById("themeUrlInput").value.trim();
+
+            if (name) mapping.name = name;
+            if (author) mapping.author = author;
+            if (url) mapping.url = url;
+
+            mapping.priColor = rgbToRGB565(document.getElementById('priColor').value);
+            mapping.secColor = rgbToRGB565(document.getElementById('secColor').value);
+            mapping.bgColor = rgbToRGB565(document.getElementById('bgColor').value);
+            mapping.ledBright = document.getElementById('ledBrightnessInput').value;
+            mapping.ledColor = document.getElementById('ledColor').value.substring(1, 7);
+            mapping.ledEffect = document.getElementById('ledEffectInput').value;
+            mapping.ledEffectSpeed = document.getElementById('ledSyncToEncoder').checked ? 11 : document.getElementById('ledEffectSpeedInput').value;
+            mapping.ledEffectDirection = document.getElementById('ledEffectDirection').checked ? -1 : 1;
+
+            return mapping;
         }
 
         async function generateAndDownload() {

--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -862,11 +862,10 @@
 
                             let fileType = file.type;
                             let fileExtension = fileType.split('/')[1];
-                            const baseName = file.name.substring(0, file.name.lastIndexOf(".")) || file.name;
                             let imageDataUrl = canvas.toDataURL(fileType, quality);
 
                             const blob = await fetch(imageDataUrl).then(res => res.blob());
-                            const fileName = `${baseName}.${fileExtension}`;
+                            const fileName = `${name}.${fileExtension}`;
                             jsonMapping[name] = fileName;
                             imageFolder.file(fileName, blob);
                             totalProcessed++;


### PR DESCRIPTION
#### Proposed Changes ####

* Bugfix - the LED colour being saved in the JSON included the # this has been removed
* New Feature - Add author and URL fields which are added to the JSON - no actual use for them yet but nice to have them in there
* Bugfix - on Edge (and possibly other Chromium browsers) when you drag upload multiple files, then drag them to a menu item the filename gets lost and a GUID used. This then creates horrible filenames in the theme.zip. When creating the zip if a guid is detected then the menu item name is used instead.  `f8a48e26-af2b-4115-80af-0dddcc6a637b.gif` becomes `wifi.gif`

#### Types of Changes ####

Bugfix/New Feature

#### Verification ####

<img width="1177" height="533" alt="image" src="https://github.com/user-attachments/assets/c292fb51-fa9c-4960-9d0c-36ee7a044c4f" />


Resulting JSON:

```json
{
  "name": "Theme Name",
  "author": "Theme Author",
  "url": "Theme URL",
  "priColor": "a80f",
  "secColor": "880f",
  "bgColor": "0000",
  "ledBright": "50",
  "ledColor": "ad007b",
  "ledEffect": "0",
  "ledEffectSpeed": "5",
  "ledEffectDirection": 1
}
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

