### PR TITLE
Remove clearImgArea() for better themed menu experience

### DIFF
--- a/include/MenuItemInterface.h
+++ b/include/MenuItemInterface.h
@@ -21,7 +21,6 @@ public:
             drawArrows(scale);
             drawTitle(scale);
         } else {
-            clearImgArea();
             if (bruceConfig.theme.label)
                 drawTitle(scale); // If using .GIF, labels are draw after complete, which takes some time
             drawIconImg();


### PR DESCRIPTION
#### Proposed Changes ####

Remove clearImgArea() for better themed menu experience.
This stops the flashing you get when the screen is cleared then the menu image is loaded.
`clearImgArea()` was added to stop themes with different sized images from drawing over each other. The downside of this is very flashy menu changes when themes are setup correctly with all images using the same dimensions.

Wiki should be updated to state something like 'All theme images should use the same width and height to avoid display issues'.

#### Types of Changes ####

Bugfix

#### Verification ####


## Before

https://github.com/user-attachments/assets/8cba0aa8-72b4-4f5e-ac6c-3c89643c581b

## After

https://github.com/user-attachments/assets/08dede40-ce57-4a9c-a1a5-c408c06a3666

## Looks lovely with animated gif menus

https://github.com/user-attachments/assets/ee7f2118-3849-41e4-b5db-4e59b8518c53


#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Theme menus no longer flash when changing
Breaking change - theme images should all be the same dimentions to avoid display issues
```

#### Further Comments ####

