### PR TITLE
WebUI text editor improvements

### DIFF
--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -20,6 +20,9 @@ body {
     padding: 10px;
     margin: 0;
 }
+.ml-10 {
+  margin-left: 10px !important;
+}
 .act-browse, .btn-action,
 .icon-action, .act-edit-file {
     cursor: pointer;
@@ -132,9 +135,8 @@ svg > g, svg > path {
 }
 .container .action-content .breadcrumb {
     display: flex;
-    align-content: center;
+    align-items: center;
     gap: 5px;
-    padding-left: 5px;
 }
 .container .content .table {
     width: 100%;
@@ -417,7 +419,7 @@ svg > g, svg > path {
   background: var(--color);
   color: var(--background);
 }
-#force-reload {
+#force-reload, #refresh-folder {
     padding: 0;
     height: 21px;
     display: flex;
@@ -426,14 +428,14 @@ svg > g, svg > path {
     align-items: center;
     border:  0;
 }
-#force-reload svg path{
+#force-reload svg path, #refresh-folder svg path {
     fill: var(--background);
 }
-#force-reload:hover svg path{
+#force-reload:hover svg path, #refresh-folder:hover svg path {
     fill: var(--color);
     stroke: var(--background);
 }
-#force-reload.reloading svg path {
+#force-reload.reloading svg path, #refresh-folder.reloading svg path {
   animation: rotation 1s linear infinite;
   transform-origin: 50% 50%;
 }

--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -413,6 +413,10 @@ svg > g, svg > path {
     display: flex;
     gap: 5px;
 }
+::selection {
+  background: var(--color);
+  color: var(--background);
+}
 #force-reload {
     padding: 0;
     height: 21px;

--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -31,6 +31,14 @@
     </div>
     <div class="action-content">
       <span class="breadcrumb">
+        <button class="icon-action" id="refresh-folder" title="Refresh folder"
+          onclick="fetchFiles(currentDrive, currentPath);">
+          <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 24 24">
+            <path
+              d="M21 12C21 16.9706 16.9706 21 12 21C9.69494 21 7.59227 20.1334 6 18.7083L3 16M3 12C3 7.02944 7.02944 3 12 3C14.3051 3 16.4077 3.86656 18 5.29168L21 8M3 21V16M3 16H8M21 3V8M21 8H16"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
         <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="13" height="13" viewBox="0,0,256,256">
           <g fill="#02de02" fill-rule="nonzero" stroke="none" stroke-width="1" stroke-linecap="butt"
             stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="none"
@@ -45,8 +53,8 @@
         <span class="current-path">LittleFS://</span>
       </span>
       <div class="body-actions">
-        <button class="icon-action" title="Upload files to current folder">
-          <input type='file' class="inp-uploader" multiple>
+        <button class="icon-action ml-10">
+          <input type='file' class="inp-uploader" title="Upload files to current folder" multiple>
           <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 24 24">
             <path fill="#02de02" fill-rule="evenodd"
               d="M4.25 5A2.75 2.75 0 0 1 7 2.25h7.987a1.75 1.75 0 0 1 1.421.73l3.014 4.197c.213.298.328.655.328 1.02V19A2.75 2.75 0 0 1 17 21.75H7A2.75 2.75 0 0 1 4.25 19V5ZM7 3.75c-.69 0-1.25.56-1.25 1.25v14c0 .69.56 1.25 1.25 1.25h10c.69 0 1.25-.56 1.25-1.25V8.897H15a.75.75 0 0 1-.75-.75V3.75H7Z"
@@ -55,14 +63,15 @@
               d="M15.086 13.219a.75.75 0 0 1-1.055.117l-1.28-1.026v3.44a.75.75 0 0 1-1.5 0v-3.44l-1.282 1.026a.75.75 0 0 1-.937-1.172l2.497-1.998a.747.747 0 0 1 .465-.166h.008c.18 0 .344.064.473.17l2.494 1.994a.75.75 0 0 1 .117 1.055Z" />
           </svg>
         </button>
-        <button class="icon-action" title="Upload folder to current folder">
-          <input type='file' class="inp-uploader" webkitdirectory directory multiple>
+        <button class="icon-action">
+          <input type='file' class="inp-uploader" title="Upload folder to current folder" webkitdirectory directory
+            multiple>
           <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 24 24">
             <path fill="#02de02"
               d="M12.71 10.79a1 1 0 0 0-.33-.21a1 1 0 0 0-.76 0a1 1 0 0 0-.33.21l-2 2a1 1 0 0 0 1.42 1.42l.29-.3v2.59a1 1 0 0 0 2 0v-2.59l.29.3a1 1 0 0 0 1.42 0a1 1 0 0 0 0-1.42ZM19 5.5h-6.28l-.32-1a3 3 0 0 0-2.84-2H5a3 3 0 0 0-3 3v13a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-10a3 3 0 0 0-3-3Zm1 13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-13a1 1 0 0 1 1-1h4.56a1 1 0 0 1 .95.68l.54 1.64a1 1 0 0 0 .95.68h7a1 1 0 0 1 1 1Z" />
           </svg>
         </button>
-        <button class="icon-action act-oinput" data-action="createFile" title="Create new file">
+        <button class="icon-action act-oinput ml-10" data-action="createFile" title="Create new file">
           <svg width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <g id="SVGRepo_iconCarrier" fill="#02de02" fill-rule="nonzero" stroke="none" stroke-width="1">
               <path
@@ -292,8 +301,8 @@
           your fin, sharky.</p>
         <p>Sincerely, Bruce.</p>
         <p>You can help develop the WebUI interface using <a
-            href="https://github.com/pr3y/Bruce/wiki/Files#customizing-the-webui" target="_blank">Custom&nbsp;WebUI</a> or <a
-            href="https://github.com/lshaf/bruce-web-interface" target="_blank">Local Bruce WebUI</a> by <a
+            href="https://github.com/pr3y/Bruce/wiki/Files#customizing-the-webui" target="_blank">Custom&nbsp;WebUI</a>
+          or <a href="https://github.com/lshaf/bruce-web-interface" target="_blank">Local Bruce WebUI</a> by <a
             href="https://github.com/lshaf" target="_blank">lshaf</a>.
         </p>
       </div>

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -956,7 +956,7 @@ $(".act-save-oinput-file").addEventListener("click", async (e) => {
     let urlQuery = new URLSearchParams({
       fs: currentDrive,
       action: "create",
-      name: path.trimEnd("/") + "/" + fileName,
+      name: path.replace(/\/+$/, '') + '/' + fileName,
     });
     await requestGet("/file?" + urlQuery.toString());
   } else if (actionType === "createFile") {
@@ -964,7 +964,7 @@ $(".act-save-oinput-file").addEventListener("click", async (e) => {
     let urlQuery = new URLSearchParams({
       fs: currentDrive,
       action: "createfile",
-      name: path.trimEnd("/") + "/" + fileName,
+      name: path.replace(/\/+$/, '') + '/' + fileName,
     });
     await requestGet("/file?" + urlQuery.toString());
   } else if (actionType === "serial") {

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -1100,67 +1100,141 @@ window.addEventListener("keydown", async (e) => {
 });
 
 $(".file-content").addEventListener("keydown", function (e) {
-  if ($(".dialog.editor:not(.hidden)")) {
-    // Handle Tab key insert 2 spaces
-    if (e.key === "Tab" || e.keyCode === 9) {
-      e.preventDefault();
+  if (!$(".dialog.editor:not(.hidden)")) return;
 
-      const start = this.selectionStart;
-      const end = this.selectionEnd;
-      const value = this.value;
-      const selectedText = value.slice(start, end);
+  const textarea = this;
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  const TAB_SIZE = 2;
+  const tabSpaces = " ".repeat(TAB_SIZE);
 
-      const spaces = "  ";
+  const leadingSpacesRegex = /^ */;
+  const closingCharRegex = /^[\}\)\]]/;
 
-      if (selectedText.includes("\n")) {
-        // Multi-line: add spaces at the start of each line
-        const lines = selectedText.split("\n");
-        const newText = lines.map(line => spaces + line).join("\n");
-
-        // Replace selection with new text
-        this.setRangeText(newText, start, end, "end");
-
-        // Keep selection covering the new lines
-        this.selectionStart = start;
-        this.selectionEnd = start + newText.length;
-      } else {
-        // Single line: insert spaces
-        this.setRangeText(spaces, start, end, "end");
-
-        // Move cursor after inserted spaces
-        this.selectionStart = this.selectionEnd = start + spaces.length;
-      }
+  const insertText = (text, newStart, newEnd, preserveSelection = true) => {
+    textarea.setSelectionRange(start, end);
+    document.execCommand("insertText", false, text);
+    if (preserveSelection) {
+      textarea.setSelectionRange(newStart, newEnd);
+    } else {
+      textarea.setSelectionRange(newStart, newStart);
     }
+  };
+
+  const getCurrentLine = (pos) => {
+    const lineStart = textarea.value.lastIndexOf("\n", pos - 1) + 1;
+    const lineEnd = textarea.value.indexOf("\n", pos);
+    const line = textarea.value.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+    return { line, lineStart, lineEnd: lineEnd === -1 ? textarea.value.length : lineEnd };
+  };
+
+  const handleTab = (shift) => {
+    if (start === end) {
+      const { line, lineStart, lineEnd } = getCurrentLine(start);
+      if (shift) {
+        const remove = Math.min(line.match(leadingSpacesRegex)[0].length, TAB_SIZE);
+        textarea.setSelectionRange(lineStart, lineEnd);
+        document.execCommand("insertText", false, line.slice(remove));
+        textarea.setSelectionRange(start - remove, start - remove);
+      } else {
+        insertText(tabSpaces, start + TAB_SIZE, start + TAB_SIZE, false);
+      }
+      return;
+    }
+
+    // Expand selection to full first and last lines
+    const { lineStart: firstLineStart } = getCurrentLine(start);
+    const { lineEnd: lastLineEnd } = getCurrentLine(end === start ? end : end - 1);
+
+    const selectedFullText = textarea.value.slice(firstLineStart, lastLineEnd);
+    const fullLines = selectedFullText.split("\n");
+
+    let totalChange = 0;
+    const newTextLines = fullLines.map((line, idx) => {
+      const isLast = idx === fullLines.length - 1;
+      const skipLast = isLast && /^\s*$/.test(line);
+
+      if (skipLast) return line;
+
+      const leadingSpaces = line.match(leadingSpacesRegex)[0].length;
+
+      if (shift) {
+        const remove = Math.min(leadingSpaces, TAB_SIZE);
+        totalChange -= remove;
+        return line.slice(remove);
+      } else {
+        const add = TAB_SIZE - (leadingSpaces % TAB_SIZE);
+        totalChange += add;
+        return " ".repeat(add) + line;
+      }
+    });
+
+    // Replace the expanded selection using execCommand to preserve undo
+    // This may become an issue when execCommand is removed since it's deprecated but only way to preserve undo for now
+    textarea.setSelectionRange(firstLineStart, lastLineEnd);
+    document.execCommand("insertText", false, newTextLines.join("\n"));
+    textarea.setSelectionRange(firstLineStart, firstLineStart + newTextLines.join("\n").length);
+  };
+
+  const handleEnter = () => {
+    const { line } = getCurrentLine(start);
+    const indentation = line.match(leadingSpacesRegex)[0] || "";
+
+    const nextChar = start < textarea.value.length ? textarea.value[start] : "";
+    const prevChar = start > 0 ? textarea.value[start - 1] : "";
+    const pairs = { "{": "}", "(": ")", "[": "]" };
+
+    if (pairs[prevChar] === nextChar) {
+      const extraIndent = " ".repeat(TAB_SIZE);
+      const insert = `\n${indentation + extraIndent}\n${indentation}`;
+      insertText(insert, start + indentation.length + extraIndent.length + 1, start + indentation.length + extraIndent.length + 1);
+    } else {
+      const closingLine = closingCharRegex.test(nextChar) ? "\n" + indentation : "";
+      insertText("\n" + indentation + closingLine, start + indentation.length + 1, start + indentation.length + 1);
+    }
+  };
+
+  const handleAutoPair = (key) => {
+    const pairs = { "(": ")", "{": "}", "[": "]", '"': '"', "'": "'", "`": "`", "<": ">" };
+    insertText(key + pairs[key], start + 1, start + 1, false);
+  };
+
+  const handleSkipCloser = () => {
+    textarea.setSelectionRange(start + 1, start + 1);
+  };
+
+  switch (e.key) {
+    case "Tab":
+      e.preventDefault();
+      handleTab(e.shiftKey);
+      return;
+    case "Enter":
+      e.preventDefault();
+      handleEnter();
+      return;
+  }
+
+  const nextChar = start < textarea.value.length ? textarea.value[start] : "";
+  const closers = [")", "}", "]", ">", '"', "'", "`"];
+  if (closers.includes(e.key) && nextChar === e.key) {
+    e.preventDefault();
+    handleSkipCloser();
+    return;
+  }
+
+  const pairs = { "(": ")", "{": "}", "[": "]", '"': '"', "'": "'", "`": "`", "<": ">" };
+  if (e.key in pairs) {
+    e.preventDefault();
+    handleAutoPair(e.key);
+    return;
   }
 });
 
 $(".file-content").addEventListener("keyup", function (e) {
   if ($(".dialog.editor:not(.hidden)")) {
-    // Map special characters to their closing pair
-    map_chars = {
-      "(": ")",
-      "{": "}",
-      "[": "]",
-      '"': '"',
-      "'": "'",
-      "`": "`",
-      "<": ">"
-    };
-
-    // if the key pressed is a special character, insert the closing pair
-    if (e.key in map_chars) {
-      var cursorPos = this.selectionStart;
-      var textBefore = this.value.substring(0, cursorPos);
-      var textAfter = this.value.substring(cursorPos);
-      this.value = textBefore + map_chars[e.key] + textAfter;
-      this.selectionStart = cursorPos;
-      this.selectionEnd = cursorPos;
-    }
-
     $(".act-save-edit-file").disabled = !isModified(e.target);
   }
 });
-
 
 $(".oinput-text-submit").addEventListener("keyup", function (e) {
   // Submit using default button on Enter key

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -340,19 +340,21 @@ function renderFileRow(fileList) {
 let sdCardAvailable = false;
 let currentDrive;
 let currentPath;
+const btnRefreshFolder = $("#refresh-folder");
 async function fetchFiles(drive, path) {
+  btnRefreshFolder.classList.add("reloading");
+  $("table.explorer tbody").innerHTML = '<tr><td colspan="3" style="text-align:center">Loading...</td></tr>';
   currentDrive = drive;
   currentPath = path;
   $(`.act-browse.active`)?.classList.remove("active");
   $(`.act-browse[data-drive='${drive}']`).classList.add("active");
   $(".current-path").textContent = drive + ":/" + path;
-  Dialog.loading.show('Fetching files...');
   let req = await requestGet("/listfiles", {
     fs: drive,
     folder: path
   });
   renderFileRow(req);
-  Dialog.loading.hide();
+  btnRefreshFolder.classList.remove("reloading");
 }
 
 async function fetchSystemInfo() {

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -104,7 +104,7 @@ const Dialog = {
     dialog.querySelector("#oinput-input").value = inputVal;
     dialog.querySelector(".act-save-oinput-file").textContent = config.action;
     this.show('oinput');
-    dialog.querySelector("#oinput-input").focus();
+    dialog.querySelector("#oinput-input").select();
     return dialog;
   }
 };

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -1196,7 +1196,16 @@ $(".file-content").addEventListener("keydown", function (e) {
 
   const handleAutoPair = (key) => {
     const pairs = { "(": ")", "{": "}", "[": "]", '"': '"', "'": "'", "`": "`", "<": ">" };
-    insertText(key + pairs[key], start + 1, start + 1, false);
+
+    if (start === end) {
+      // No selection - insert pair at cursor
+      insertText(key + pairs[key], start + 1, start + 1, false);
+    } else {
+      // Has selection - wrap selected text with pair
+      const selectedText = textarea.value.slice(start, end);
+      const wrappedText = key + selectedText + pairs[key];
+      insertText(wrappedText, start + 1, start + 1 + selectedText.length, true);
+    }
   };
 
   const handleSkipCloser = () => {


### PR DESCRIPTION
#### Proposed Changes ####

Since I have been doing a lot of development on JS scripts recently the editor was causing me some headaches!

* The WebUI file editor now behaves much more like VSCode and other IDEs
  * Tab indending on one or multiple lines
  * Auto indent on enter
  * Improved auto pairing of special characters
  * Undo history preserved, however this relies on a deprecated function `execCommand` all browsers still support it and no modern methods keep undo - if it becomes an issue then it can be reworked
  * Add comments with CTRL+/ or #
* Added Refresh button for refreshing folder listing
* The single text input box now selects all text on open, very useful when renaming files
* Text selection now follows theme colours
* Fixed an issue with double // in paths - discovered similar issue in Launcher

#### Types of Changes ####

New Feature/Bugfix

#### Verification ####

**Tabbing/Shift+Tabbing and Undo**

![firefox_2025-10-19_03-59-25](https://github.com/user-attachments/assets/4eac06a0-612c-48a2-81d6-f754199ed75c)


**Special Character Pairing**

![firefox_2025-10-19_03-43-10](https://github.com/user-attachments/assets/5d8e5841-b4d3-4cbe-9248-46c01ee5f3d6)

**Themed text selection**

<img width="277" height="88" alt="image" src="https://github.com/user-attachments/assets/b230f362-be34-478a-9a0c-bd7b52cc7ccf" />

**Add comments with CTRL+/ or #**

![firefox_2025-10-23_18-12-48](https://github.com/user-attachments/assets/2c3b437a-9512-42c7-8b3f-05e61b03875f)

**Added Refresh button for refreshing folder listing**

![firefox_2025-10-23_18-49-30](https://github.com/user-attachments/assets/97e40714-b646-4a2c-83b3-d390aacf0148)


#### Testing ####


<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
WebUI file editor improvements to feel more like using VSCode/other IDEs
```

#### Further Comments ####

