### PR TITLE
Improve handling of MAX_IMAGE_WIDTH to work on bigger screens

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -1640,7 +1640,11 @@ bool drawImg(FS &fs, String filename, int x, int y, bool center, int playDuratio
 /// Draw PNG files
 
 #include <PNGdec.h>
-#define MAX_IMAGE_WIDTH 320
+#if TFT_WIDTH > TFT_HEIGHT
+#define MAX_IMAGE_WIDTH TFT_WIDTH
+#else
+#define MAX_IMAGE_WIDTH TFT_HEIGHT
+#endif
 PNG *png;
 // Functions to access a file on the SD card
 File myfile;
@@ -1667,7 +1671,7 @@ int32_t mySeek(PNGFILE *handle, int32_t position) {
 int16_t xpos = 0;
 int16_t ypos = 0;
 int PNGDraw(PNGDRAW *pDraw) {
-    uint16_t usPixels[320];
+    uint16_t usPixels[MAX_IMAGE_WIDTH];
     // static uint16_t dmaBuffer[MAX_IMAGE_WIDTH]; // static so buffer persists after fn exit
     uint8_t r = ((uint16_t)bruceConfig.bgColor & 0xF800) >> 8;
     uint8_t g = ((uint16_t)bruceConfig.bgColor & 0x07E0) >> 3;


### PR DESCRIPTION
#### Proposed Changes ####

* Improve handling of `MAX_IMAGE_WIDTH` to work on bigger screens

I was having issues using theme images on a Lilygo T-LoRa Pager since it has a screen that is 480px wide/high. The default was 320px.

This change will cause issues on devices with screens smaller than the old `MAX_IMAGE_WIDTH` of 320 if they try and render PNGs larger than their max screen height/width.

I could update this to use 320 as the minimum.

#### Types of Changes ####

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

