### PR TITLE
File handling tidy up

### DIFF
--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -321,7 +321,7 @@ function renderFileRow(fileList) {
 
       let serialCmd = getSerialCommand(name);
       if (serialCmd) {
-        e.querySelector(".act-play").setAttribute("data-cmd", serialCmd + " " + dPath);
+        e.querySelector(".act-play").setAttribute("data-cmd", serialCmd + " \"" + dPath + "\"");
         e.querySelector(".col-action").classList.add("executable");
       }
     } else if (type === "Fo") {

--- a/src/core/menu_items/ScriptsMenu.cpp
+++ b/src/core/menu_items/ScriptsMenu.cpp
@@ -33,20 +33,23 @@ std::vector<Option> getScriptsOptionsList() {
 
     File root = fs->open(folder);
     if (!root || !root.isDirectory()) return opt; // not a dir
-    File file2;
 
-    while (file2 = root.openNextFile()) {
-        if (file2.isDirectory()) continue;
+    while (true) {
+        bool isDir;
+        String fullPath = root.getNextFileName(&isDir);
+        String nameOnly = fullPath.substring(fullPath.lastIndexOf("/") + 1);
+        if (fullPath == "") { break; }
+        // Serial.printf("Path: %s (isDir: %d)\n", fullPath.c_str(), isDir);
 
-        String fileName = String(file2.name());
-        if (!fileName.endsWith(".js") && !fileName.endsWith(".bjs")) continue;
+        if (isDir) continue;
 
-        String entry_title = String(file2.name());
-        entry_title = entry_title.substring(0, entry_title.lastIndexOf(".")); // remove the extension
-        String filePath = String(file2.path());
-        opt.push_back({entry_title.c_str(), [=]() { run_bjs_script_headless(*fs, filePath); }});
+        int dotIndex = nameOnly.lastIndexOf(".");
+        String ext = dotIndex >= 0 ? nameOnly.substring(dotIndex + 1) : "";
+        ext.toUpperCase();
+        if (ext != "JS" && ext != "BJS") continue;
 
-        file2.close();
+        String entry_title = nameOnly.substring(0, nameOnly.lastIndexOf(".")); // remove the extension
+        opt.push_back({entry_title.c_str(), [=]() { run_bjs_script_headless(*fs, fullPath); }});
     }
 
     root.close();

--- a/src/core/menu_items/ScriptsMenu.cpp
+++ b/src/core/menu_items/ScriptsMenu.cpp
@@ -4,6 +4,7 @@
 #include "core/settings.h"
 #include "core/utils.h"
 #include "modules/bjs_interpreter/interpreter.h" // for JavaScript interpreter
+#include <algorithm>                             // for std::sort
 
 String getScriptsFolder(FS *&fs) {
     String folder;
@@ -49,6 +50,15 @@ std::vector<Option> getScriptsOptionsList() {
     }
 
     root.close();
+
+    std::sort(opt.begin(), opt.end(), [](const Option &a, const Option &b) {
+        String fa = String(a.label);
+        fa.toUpperCase();
+        String fb = String(b.label);
+        fb.toUpperCase();
+        return fa < fb;
+    });
+
 #endif
     return opt;
 }

--- a/src/core/menu_items/ScriptsMenu.cpp
+++ b/src/core/menu_items/ScriptsMenu.cpp
@@ -42,10 +42,12 @@ std::vector<Option> getScriptsOptionsList() {
 
         String entry_title = String(file2.name());
         entry_title = entry_title.substring(0, entry_title.lastIndexOf(".")); // remove the extension
-        opt.push_back({entry_title.c_str(), [=]() { run_bjs_script_headless(*fs, file2.path()); }});
+        String filePath = String(file2.path());
+        opt.push_back({entry_title.c_str(), [=]() { run_bjs_script_headless(*fs, filePath); }});
+
+        file2.close();
     }
 
-    file2.close();
     root.close();
 #endif
     return opt;

--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -449,13 +449,13 @@ String crc32File(FS &fs, String filepath) {
 
 /***************************************************************************************
 ** Function name: sortList
-** Description:   sort files for name
+** Description:   sort files/folders by name
 ***************************************************************************************/
 bool sortList(const FileList &a, const FileList &b) {
     if (a.folder != b.folder) {
         return a.folder > b.folder; // true if a is a folder and b is not
     }
-    // Order items alfabetically
+    // Order items alphabetically
     String fa = a.filename.c_str();
     fa.toUpperCase();
     String fb = b.filename.c_str();
@@ -488,8 +488,8 @@ bool checkExt(String ext, String pattern) {
 }
 
 /***************************************************************************************
-** Function name: sortList
-** Description:   sort files for name
+** Function name: readFs
+** Description:   read files/folders from a folder
 ***************************************************************************************/
 void readFs(FS fs, String folder, String allowed_ext) {
     int allFilesCount = 0;

--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -124,26 +124,22 @@ bool ToggleSDCard() {
 ***************************************************************************************/
 bool deleteFromSd(FS fs, String path) {
     File dir = fs.open(path);
-    if (!dir.isDirectory()) {
-        dir.close();
-        return fs.remove(path);
-    }
+    if (!dir.isDirectory()) { return fs.remove(path); }
 
     dir.rewindDirectory();
     bool success = true;
 
-    File file = dir.openNextFile();
-    while (file) {
-        if (file.isDirectory()) {
-            success &= deleteFromSd(fs, file.path());
+    bool isDir;
+    String fileName = dir.getNextFileName(&isDir);
+    while (fileName != "") {
+        String fullPath = path + "/" + fileName;
+        if (isDir) {
+            success &= deleteFromSd(fs, fullPath);
         } else {
-            String path2 = file.path();
-            file.close();
-            success &= fs.remove(path2);
+            success &= fs.remove(fullPath.c_str());
         }
-        file = dir.openNextFile();
+        fileName = dir.getNextFileName(&isDir);
     }
-    file.close();
 
     dir.close();
     // Apaga a própria pasta depois de apagar seu conteúdo
@@ -498,26 +494,30 @@ void readFs(FS fs, String folder, String allowed_ext) {
 
     File root = fs.open(folder);
     if (!root || !root.isDirectory()) { return; }
-    File file = root.openNextFile();
-    while (file && fileList.size() < 250) {
-        String fileName = file.name();
-        if (file.isDirectory()) {
-            object.filename = fileName.substring(fileName.lastIndexOf("/") + 1);
+
+    while (true) {
+        bool isDir;
+        String fullPath = root.getNextFileName(&isDir);
+        String nameOnly = fullPath.substring(fullPath.lastIndexOf("/") + 1);
+        if (fullPath == "") { break; }
+        // Serial.printf("Path: %s (isDir: %d)\n", fullPath.c_str(), isDir);
+
+        if (isDir) {
+            object.filename = nameOnly;
             object.folder = true;
             object.operation = false;
             fileList.push_back(object);
         } else {
-            String ext = fileName.substring(fileName.lastIndexOf(".") + 1);
+            int dotIndex = nameOnly.lastIndexOf(".");
+            String ext = dotIndex >= 0 ? nameOnly.substring(dotIndex + 1) : "";
             if (allowed_ext == "*" || checkExt(ext, allowed_ext)) {
-                object.filename = fileName.substring(fileName.lastIndexOf("/") + 1);
+                object.filename = nameOnly;
                 object.folder = false;
                 object.operation = false;
                 fileList.push_back(object);
             }
         }
-        file = root.openNextFile();
     }
-    file.close();
     root.close();
 
     // Sort folders/files

--- a/src/core/wifi/webInterface.cpp
+++ b/src/core/wifi/webInterface.cpp
@@ -84,38 +84,33 @@ String listFiles(FS fs, String folder) {
     _webFS = fs;
 
     File root = fs.open(folder);
-    File foundfile = root.openNextFile();
-    if (folder == "//") folder = "/";
     uploadFolder = folder;
-    String PreFolder = folder;
-    PreFolder = PreFolder.substring(0, PreFolder.lastIndexOf("/"));
-    if (PreFolder == "") PreFolder = "/";
 
-    if (folder == "/") folder = "";
-    while (foundfile) {
-        if (esp_get_free_heap_size() > (String("Fo:" + String(foundfile.name()) + ":0\n").length()) + 1024) {
-            if (foundfile.isDirectory()) returnText += "Fo:" + String(foundfile.name()) + ":0\n";
+    while (true) {
+        bool isDir;
+        String fullPath = root.getNextFileName(&isDir);
+        String nameOnly = fullPath.substring(fullPath.lastIndexOf("/") + 1);
+        if (fullPath == "") { break; }
+        // Serial.printf("Path: %s (isDir: %d)\n", fullPath.c_str(), isDir);
+
+        if (esp_get_free_heap_size() > (String("Fo:" + nameOnly + ":0\n").length()) + 1024) {
+            if (isDir) {
+                // Serial.printf("Directory: %s\n", fullPath.c_str());
+                returnText += "Fo:" + nameOnly + ":0\n";
+            } else {
+                // For files, we need to get the size, so we open the file briefly
+                // Serial.printf("Opening file for size check: %s\n", fullPath.c_str());
+                File file = fs.open(fullPath);
+                // Serial.printf("File size: %llu bytes\n", file.size());
+                if (file) {
+                    returnText += "Fi:" + nameOnly + ":" + humanReadableSize(file.size()) + "\n";
+                    file.close();
+                }
+            }
         } else break;
-        foundfile = root.openNextFile();
         esp_task_wdt_reset();
     }
     root.close();
-    foundfile.close();
-
-    if (folder == "") folder = "/";
-    root = fs.open(folder);
-    foundfile = root.openNextFile();
-    while (foundfile) {
-        if (esp_get_free_heap_size() > (String("Fo:" + String(foundfile.name()) + ":0\n").length()) + 1024) {
-            if (!(foundfile.isDirectory()))
-                returnText +=
-                    "Fi:" + String(foundfile.name()) + ":" + humanReadableSize(foundfile.size()) + "\n";
-        } else break;
-        foundfile = root.openNextFile();
-        esp_task_wdt_reset();
-    }
-    root.close();
-    foundfile.close();
 
     // log_i("ListFiles End");
     return returnText;

--- a/src/core/wifi/webInterface.cpp
+++ b/src/core/wifi/webInterface.cpp
@@ -291,8 +291,6 @@ void serveWebUIFile(
         fs = &LittleFS;
     }
     if (fs) {
-        // try to read the custom file
-        File custom_webui_file = fs->open("/BruceWebUI/" + filename, FILE_READ);
         response = request->beginResponse(*fs, "/BruceWebUI/" + filename, contentType);
     } else {
         if (filename == "theme.css") {

--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -1208,7 +1208,7 @@ static duk_ret_t native_require(duk_context *ctx) {
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "write", native_storageWrite, 4, 0);
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "rename", native_storageRename, 2);
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "remove", native_storageRemove, 1);
-        bduk_put_prop_c_lightfunc(ctx, obj_idx, "readdir", native_storageReaddir, 1);
+        bduk_put_prop_c_lightfunc(ctx, obj_idx, "readdir", native_storageReaddir, 2);
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "mkdir", native_storageMkdir, 1);
         bduk_put_prop_c_lightfunc(ctx, obj_idx, "rmdir", native_storageRmdir, 1);
 
@@ -1498,7 +1498,7 @@ void interpreterHandler(void *pvParameters) {
     bduk_register_c_lightfunc(ctx, "keyboard", native_keyboard, 3);
 
     // Storage
-    bduk_register_c_lightfunc(ctx, "storageReaddir", native_storageReaddir, 1);
+    bduk_register_c_lightfunc(ctx, "storageReaddir", native_storageReaddir, 2);
     bduk_register_c_lightfunc(ctx, "storageRead", native_storageRead, 2);
     bduk_register_c_lightfunc(ctx, "storageWrite", native_storageWrite, 4);
     bduk_register_c_lightfunc(ctx, "storageRename", native_storageRename, 2);

--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -275,27 +275,31 @@ static duk_ret_t native_exit(duk_context *ctx) {
 */
 
 // helper: throw unless i2c.begin(...) was called in this Duktape context
-static void i2c_require_ready(duk_context* ctx) {
+static void i2c_require_ready(duk_context *ctx) {
     duk_push_global_stash(ctx);
-    duk_get_prop_string(ctx, -1, "\xff""i2c_ready");
+    duk_get_prop_string(
+        ctx,
+        -1,
+        "\xff"
+        "i2c_ready"
+    );
     bool ready = duk_get_boolean_default(ctx, -1, false);
     duk_pop_2(ctx);
-    if (!ready) {
-        duk_error(ctx, DUK_ERR_ERROR, "i2c not initialized: call i2c.begin(sda,scl,hz) first");
-    }
+    if (!ready) { duk_error(ctx, DUK_ERR_ERROR, "i2c not initialized: call i2c.begin(sda,scl,hz) first"); }
 }
 
 static duk_ret_t native_i2c_begin(duk_context *ctx) {
     // REQUIRE: begin(sda:int, scl:int, hz:int)
-    if (!duk_is_number(ctx,0) || !duk_is_number(ctx,1) || !duk_is_number(ctx,2)) {
+    if (!duk_is_number(ctx, 0) || !duk_is_number(ctx, 1) || !duk_is_number(ctx, 2)) {
         return duk_error(ctx, DUK_ERR_TYPE_ERROR, "i2c.begin(sda:int, scl:int, hz:int) is required");
     }
-    int sda = duk_require_int(ctx,0);
-    int scl = duk_require_int(ctx,1);
-    uint32_t hz = (uint32_t)duk_require_uint(ctx,2);
+    int sda = duk_require_int(ctx, 0);
+    int scl = duk_require_int(ctx, 1);
+    uint32_t hz = (uint32_t)duk_require_uint(ctx, 2);
 
-    if (sda < 0 || scl < 0)   return duk_error(ctx, DUK_ERR_RANGE_ERROR, "i2c.begin: pins must be >= 0");
-    if (hz  < 1000 || hz > 1000000) return duk_error(ctx, DUK_ERR_RANGE_ERROR, "i2c.begin: hz must be 1k..1MHz");
+    if (sda < 0 || scl < 0) return duk_error(ctx, DUK_ERR_RANGE_ERROR, "i2c.begin: pins must be >= 0");
+    if (hz < 1000 || hz > 1000000)
+        return duk_error(ctx, DUK_ERR_RANGE_ERROR, "i2c.begin: hz must be 1k..1MHz");
 
     Wire.begin(sda, scl, hz);
     Wire.setClock(hz);
@@ -304,7 +308,12 @@ static duk_ret_t native_i2c_begin(duk_context *ctx) {
     // mark ready in context stash
     duk_push_global_stash(ctx);
     duk_push_boolean(ctx, true);
-    duk_put_prop_string(ctx, -2, "\xff""i2c_ready");
+    duk_put_prop_string(
+        ctx,
+        -2,
+        "\xff"
+        "i2c_ready"
+    );
     duk_pop(ctx);
 
     duk_push_true(ctx);
@@ -312,8 +321,14 @@ static duk_ret_t native_i2c_begin(duk_context *ctx) {
 }
 
 static bool duk_get_bytes_arg(duk_context *ctx, duk_idx_t idx, const uint8_t **p, duk_size_t *n) {
-    if (duk_is_buffer_data(ctx, idx)) { *p = (const uint8_t*)duk_get_buffer_data(ctx, idx, n); return true; }
-    if (duk_is_string(ctx, idx))      { *p = (const uint8_t*)duk_get_lstring(ctx, idx, n);   return true; }
+    if (duk_is_buffer_data(ctx, idx)) {
+        *p = (const uint8_t *)duk_get_buffer_data(ctx, idx, n);
+        return true;
+    }
+    if (duk_is_string(ctx, idx)) {
+        *p = (const uint8_t *)duk_get_lstring(ctx, idx, n);
+        return true;
+    }
     return false;
 }
 
@@ -321,7 +336,7 @@ static duk_ret_t native_i2c_scan(duk_context *ctx) {
     i2c_require_ready(ctx);
     duk_idx_t arr = duk_push_array(ctx);
     int idx = 0;
-    for (uint8_t a=1; a<127; a++) {
+    for (uint8_t a = 1; a < 127; a++) {
         Wire.beginTransmission(a);
         if (Wire.endTransmission(true) == 0) {
             duk_push_int(ctx, a);
@@ -335,7 +350,8 @@ static duk_ret_t native_i2c_write(duk_context *ctx) {
     // write(addr:int, data:Uint8Array|string, [sendStop:boolean=true]) -> err(0=ok)
     i2c_require_ready(ctx);
     int addr = duk_require_int(ctx, 0);
-    const uint8_t *buf; duk_size_t len;
+    const uint8_t *buf;
+    duk_size_t len;
     if (!duk_get_bytes_arg(ctx, 1, &buf, &len))
         return duk_error(ctx, DUK_ERR_TYPE_ERROR, "i2c.write: arg1 must be Uint8Array or string");
     bool sendStop = duk_get_boolean_default(ctx, 2, true);
@@ -351,10 +367,10 @@ static duk_ret_t native_i2c_read(duk_context *ctx) {
     // read(addr:int, len:int) -> Uint8Array
     i2c_require_ready(ctx);
     int addr = duk_require_int(ctx, 0);
-    int len  = duk_require_int(ctx, 1);
+    int len = duk_require_int(ctx, 1);
     size_t got = Wire.requestFrom((uint8_t)addr, (uint8_t)len, (uint8_t)true);
     void *buf = duk_push_fixed_buffer(ctx, got);
-    for (size_t i=0; i<got && Wire.available(); i++) ((uint8_t*)buf)[i] = Wire.read();
+    for (size_t i = 0; i < got && Wire.available(); i++) ((uint8_t *)buf)[i] = Wire.read();
     duk_push_buffer_object(ctx, -1, 0, got, DUK_BUFOBJ_UINT8ARRAY);
     return 1;
 }
@@ -363,7 +379,8 @@ static duk_ret_t native_i2c_write_read(duk_context *ctx) {
     // writeRead(addr:int, wbuf:Uint8Array|string, rlen:int, [delayMs:int=0]) -> Uint8Array
     i2c_require_ready(ctx);
     int addr = duk_require_int(ctx, 0);
-    const uint8_t *wbuf; duk_size_t wlen;
+    const uint8_t *wbuf;
+    duk_size_t wlen;
     if (!duk_get_bytes_arg(ctx, 1, &wbuf, &wlen))
         return duk_error(ctx, DUK_ERR_TYPE_ERROR, "i2c.writeRead: arg1 must be Uint8Array or string");
     int rlen = duk_require_int(ctx, 2);
@@ -372,13 +389,16 @@ static duk_ret_t native_i2c_write_read(duk_context *ctx) {
     Wire.beginTransmission((uint8_t)addr);
     Wire.write(wbuf, (size_t)wlen);
     uint8_t err = Wire.endTransmission(false); // repeated START
-    if (err != 0) { duk_push_int(ctx, -err); return 1; }
+    if (err != 0) {
+        duk_push_int(ctx, -err);
+        return 1;
+    }
 
     if (wait > 0) delay(wait);
 
     size_t got = Wire.requestFrom((uint8_t)addr, (uint8_t)rlen, (uint8_t)true);
     void *buf = duk_push_fixed_buffer(ctx, got);
-    for (size_t i=0; i<got && Wire.available(); i++) ((uint8_t*)buf)[i] = Wire.read();
+    for (size_t i = 0; i < got && Wire.available(); i++) ((uint8_t *)buf)[i] = Wire.read();
     duk_push_buffer_object(ctx, -1, 0, got, DUK_BUFOBJ_UINT8ARRAY);
     return 1;
 }


### PR DESCRIPTION
#### Proposed Changes ####

* Fix for 'no free file descriptors' on Interpreter menu
* Added A-Z sorting of script on Interpreter menu
* Change `openNextFile` to `getNextFileName` for speed
* Removed redundant file read relating to custom WebUI
* ~~Update storageReaddir function to accept an missing additional parameter, the `options` parameter was never passed to the function so `withFileTypes=true` would have never worked~~ Now in #1763 

#### Types of Changes ####

New Feature/Bugfix

#### Verification ####

The biggest change related to `getNextFileName`, I have tested each place it was changed and everything still works.
This change was also made in Launcher https://github.com/bmorcelli/Launcher/pull/230

#### Testing ####

None

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

