### PR TITLE
Fix T-Deck Pro name

### DIFF
--- a/src/lib/data/manifests.json
+++ b/src/lib/data/manifests.json
@@ -10,8 +10,8 @@
 		{ "id": "m5stack-cplus2", "name": "StickCPlus2", "family": "ESP32" }
 	],
 	"Lilygo": [
-		{ "id": "lilygo-t-deck-pro", "name": "Lilygo T-Deck-Plus", "family": "ESP32-S3" },
-		{ "id": "lilygo-t-deck", "name": "Lilygo T-Deck", "family": "ESP32-S3" },
+		{ "id": "lilygo-t-deck-pro", "name": "Lilygo T-Deck Pro", "family": "ESP32-S3" },
+		{ "id": "lilygo-t-deck", "name": "Lilygo T-Deck (and Plus)", "family": "ESP32-S3" },
 		{ "id": "lilygo-t-display-S3-pro", "name": "Lilygo T-Display-S3 PRO", "family": "ESP32-S3" },
 		{ "id": "lilygo-t-display-s3-mmc", "name": "Lilygo T-Display-S3 (SD_MMC)", "family": "ESP32-S3" },
 		{ "id": "lilygo-t-display-s3-touch-mmc", "name": "Lilygo T-Display-S3 Touch (SD_MMC)", "family": "ESP32-S3" },
@@ -22,7 +22,7 @@
 		{ "id": "lilygo-t-embed", "name": "Lilygo T-Embed", "family": "ESP32-S3" },
 		{ "id": "lilygo-t-watch-s3", "name": "Lilygo T-Watch S3", "family": "ESP32-S3" },
 		{ "id": "lilygo-t-hmi", "name": "Lilygo T-HMI", "family": "ESP32-S3" },
-		{ "id": "lilygo-t-lora-pager", "name": "Lilygo T-Lora Pager", "family": "ESP32-S3" }
+		{ "id": "lilygo-t-lora-pager", "name": "Lilygo T-LoRa Pager", "family": "ESP32-S3" }
 	],
 	"CYD": [
 		{ "id": "CYD-2432S028", "name": "CYD-2432S028", "family": "ESP32" },


### PR DESCRIPTION
#### Proposed Changes ####

Fix name of T-Deck Pro firmware.
Add `(and Plus)` to standard `T-Deck`

#### Types of Changes ####

Bugfix

#### Verification ####

<img width="468" height="146" alt="image" src="https://github.com/user-attachments/assets/9e4e757f-0821-4ee9-ab0c-d5632a9b390e" />

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

