### PR TITLE
Fix Ethernet theme image + clearing of screen when theme is active but image not available

### DIFF
--- a/include/MenuItemInterface.h
+++ b/include/MenuItemInterface.h
@@ -17,6 +17,10 @@ public:
     void draw(float scale = 1) {
         if (rotation != bruceConfig.rotation) resetCoordinates();
         if (!getTheme()) {
+            if (bruceConfig.themePath != "") {
+                // Image is not available for active theme, clear larger area
+                tft.fillRect(0, 27, tftWidth, tftHeight - 27, bruceConfig.bgColor);
+            }
             drawIcon(scale);
             drawArrows(scale);
             drawTitle(scale);

--- a/src/core/menu_items/EthernetMenu.cpp
+++ b/src/core/menu_items/EthernetMenu.cpp
@@ -43,7 +43,11 @@ void EthernetMenu::optionsMenu() {
 
 void EthernetMenu::drawIconImg() {
     drawImg(
-        *bruceConfig.themeFS(), bruceConfig.getThemeItemImg(bruceConfig.theme.paths.rfid), 0, imgCenterY, true
+        *bruceConfig.themeFS(),
+        bruceConfig.getThemeItemImg(bruceConfig.theme.paths.ethernet),
+        0,
+        imgCenterY,
+        true
     );
 }
 void EthernetMenu::drawIcon(float scale) {

--- a/src/core/menu_items/EthernetMenu.h
+++ b/src/core/menu_items/EthernetMenu.h
@@ -17,7 +17,10 @@ public:
     void optionsMenu(void);
     void drawIcon(float scale);
     void drawIconImg();
-    bool getTheme() { return bruceConfig.theme.rfid; }
+    bool getTheme() {
+        Serial.println("Ethernet theme: " + String(bruceConfig.theme.ethernet));
+        return bruceConfig.theme.ethernet;
+    }
 };
 
 #endif

--- a/src/core/menu_items/EthernetMenu.h
+++ b/src/core/menu_items/EthernetMenu.h
@@ -17,10 +17,7 @@ public:
     void optionsMenu(void);
     void drawIcon(float scale);
     void drawIconImg();
-    bool getTheme() {
-        Serial.println("Ethernet theme: " + String(bruceConfig.theme.ethernet));
-        return bruceConfig.theme.ethernet;
-    }
+    bool getTheme() { return bruceConfig.theme.ethernet; }
 };
 
 #endif


### PR DESCRIPTION
#### Proposed Changes ####

* Fix Ethernet theme image
Fixes #1621 and closes #1623 since this PR is the same but needs conflicts solving.

* Clearing screen when theme is active but image not available

#### Types of Changes ####

Bugfix

#### Verification ####

**Current**

![25-10-25 13-55-41 1162](https://github.com/user-attachments/assets/9c087a72-abf5-4fcc-91a4-c8cff0e40f98)


**New**
![25-10-25 14-11-20 1163](https://github.com/user-attachments/assets/16cd399a-f388-48f5-a1b9-dbce0086958d)

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

