### PR TITLE
Add EMV Reader

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -126,6 +126,7 @@ lib_deps =
 	https://github.com/bmorcelli/ESPping
 	Adafruit BusIO=https://github.com/emericklaw/Adafruit-BusIO_Bruce
 	Adafruit PN532=https://github.com/emericklaw/Adafruit-PN532_Bruce
+	https://github.com/huckor/BER-TLV.git
 	https://github.com/rennancockles/Arduino_MFRC522v2.git
 	https://github.com/bmorcelli/ESP-ChameleonUltra
 	https://github.com/bmorcelli/ESP-Amiibolink

--- a/src/core/menu_items/RFIDMenu.cpp
+++ b/src/core/menu_items/RFIDMenu.cpp
@@ -5,6 +5,7 @@
 #include "modules/rfid/PN532KillerTools.h"
 #include "modules/rfid/amiibo.h"
 #include "modules/rfid/chameleon.h"
+#include "modules/rfid/emv_reader.hpp"
 #include "modules/rfid/pn532ble.h"
 #include "modules/rfid/rfid125.h"
 #include "modules/rfid/tag_o_matic.h"
@@ -12,6 +13,7 @@
 void RFIDMenu::optionsMenu() {
     options = {
         {"Read tag",    [=]() { TagOMatic(); }                          },
+        {"Read EMV",    [=]() { EMVReader(); }                          },
         {"Read 125kHz", [=]() { RFID125(); }                            },
         {"Scan tags",   [=]() { TagOMatic(TagOMatic::SCAN_MODE); }      },
         {"Load file",   [=]() { TagOMatic(TagOMatic::LOAD_MODE); }      },

--- a/src/modules/rfid/emv_reader.cpp
+++ b/src/modules/rfid/emv_reader.cpp
@@ -1,0 +1,293 @@
+#include "emv_reader.hpp"
+#include "BerTlv.h"
+#include "core/display.h"
+#include <globals.h>
+
+void EMVReader::setup() {
+    switch (bruceConfig.rfidModule) {
+        case PN532_I2C_MODULE: _rfid = new PN532(PN532::CONNECTION_TYPE::I2C); break;
+#ifdef M5STICK
+        case PN532_I2C_SPI_MODULE: _rfid = new PN532(PN532::CONNECTION_TYPE::I2C_SPI); break;
+#endif
+        case PN532_SPI_MODULE: _rfid = new PN532(PN532::CONNECTION_TYPE::SPI); break;
+        default: {
+            Serial.println("EMVReader: Unsupported RFID module for EMV reading.");
+            return;
+        }
+    }
+
+    _rfid->begin();
+    nfc = &(_rfid->nfc);
+
+    EMVCard card = read_emv_card();
+    display_emv(card);
+}
+
+void EMVReader::parse_pan(std::vector<uint8_t> *afl_content, EMVCard *card) {
+    auto pos = find(afl_content->begin(), afl_content->end(), 0x5A);
+    uint8_t len = *(pos + 1);
+    uint8_t pan_begin = distance(afl_content->begin(), pos) + 2;
+    card->pan = (uint8_t *)malloc(len);
+    memcpy(card->pan, &afl_content->data()[pan_begin], len);
+    card->pan_len = len;
+}
+
+void EMVReader::parse_validfrom(std::vector<uint8_t> *afl_content, EMVCard *card) {
+    bool found = false;
+    for (size_t i = 0; i < afl_content->size() && !found; i++) {
+        if (afl_content->at(i) == 0x5F && afl_content->at(i + 1) == 0x25) {
+            size_t begin = i + 3; // The format is 0x5F 0x25 SIZE DATA so skip 3 bytes
+            card->validfrom = (uint8_t *)malloc(2);
+            // The format in card is YEAR/MONTH but I want MONTH/YEAR since is the standard format
+            card->validfrom[0] = afl_content->at(begin + 1);
+            card->validfrom[1] = afl_content->at(begin);
+            found = true;
+        }
+    }
+}
+
+void EMVReader::parse_validto(std::vector<uint8_t> *afl_content, EMVCard *card) {
+    bool found = false;
+    for (size_t i = 0; i < afl_content->size() && !found; i++) {
+        if (afl_content->at(i) == 0x5F && afl_content->at(i + 1) == 0x24) {
+            size_t begin = i + 3; // The format is 0x5F 0x24 SIZE DATA so skip 3 bytes
+            card->validto = (uint8_t *)malloc(2);
+            // The format in card is YEAR/MONTH but I want MONTH/YEAR since is the standard format
+            card->validto[0] = afl_content->at(begin + 1);
+            card->validto[1] = afl_content->at(begin);
+            found = true;
+        }
+    }
+}
+
+std::vector<uint8_t> EMVReader::emv_ask_for_aid() {
+    uint8_t uid[7];
+    uint8_t len;
+    uint8_t response[240];
+    uint8_t response_len = 0;
+    std::vector<uint8_t> aid;
+    if (nfc->readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &len)) {
+        /* Select Application */
+        uint8_t ask_for_aid_apdu[] = {0x00, 0xA4, 0x04, 0x00, 0x0e, 0x32, 0x50, 0x41, 0x59, 0x2e,
+                                      0x53, 0x59, 0x53, 0x2e, 0x44, 0x44, 0x46, 0x30, 0x31, 0x00};
+        if (nfc->EMVinDataExchange(ask_for_aid_apdu, sizeof(ask_for_aid_apdu), response, &response_len)) {
+            std::vector<uint8_t> response_vector(&response[0], &response[response_len]);
+            BerTlv Tlv;
+            Tlv.SetTlv(response_vector);
+            if (Tlv.GetValue("4F", &aid) != OK) { // Application ID
+                Serial.println("Can't get aidFeliCa");
+                aid.clear();
+            }
+            Serial.println("Success AID");
+        }
+    }
+    return aid;
+}
+
+std::vector<uint8_t> EMVReader::emv_ask_for_app_name() {
+    uint8_t uid[7];
+    uint8_t len;
+    uint8_t response[240];
+    uint8_t response_len = 0;
+    std::vector<uint8_t> app_name;
+    uint8_t ask_for_aid_apdu[] = {0x00, 0xA4, 0x04, 0x00, 0x0e, 0x32, 0x50, 0x41, 0x59, 0x2e,
+                                  0x53, 0x59, 0x53, 0x2e, 0x44, 0x44, 0x46, 0x30, 0x31, 0x00};
+    if (nfc->EMVinDataExchange(ask_for_aid_apdu, sizeof(ask_for_aid_apdu), response, &response_len)) {
+        std::vector<uint8_t> response_vector(&response[0], &response[response_len]);
+        BerTlv Tlv;
+        Tlv.SetTlv(response_vector);
+        if (Tlv.GetValue("50", &app_name) != OK) { // Card name
+            Serial.println("Can't get app name");
+            app_name.clear();
+        }
+        Serial.println("Success app_name");
+    }
+    return app_name;
+}
+
+std::vector<uint8_t> EMVReader::emv_ask_for_pdol(std::vector<uint8_t> *aid) {
+    uint8_t uid[7];
+    uint8_t len;
+    uint8_t response[240];
+    uint8_t response_len = 0;
+    std::vector<uint8_t> pdol;
+    /* ------------------- AID -----------------*/
+    uint8_t ask_for_pdol[] = {0x00, 0xa4, 0x04, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00};
+    memcpy(ask_for_pdol + 5, aid->data(), 7);
+
+    if (nfc->EMVinDataExchange(ask_for_pdol, sizeof(ask_for_pdol), response, &response_len)) {
+        std::vector<uint8_t> response_vector(&response[0], &response[response_len]);
+        BerTlv Tlv;
+        Tlv.SetTlv(response_vector);
+        if (Tlv.GetValue("9F38", &pdol) != OK) { // PDOL(Some card doesn't have it)
+            Serial.println("Can't get PDOL");
+            pdol.clear();
+        }
+    }
+    return pdol;
+}
+
+std::vector<uint8_t> EMVReader::emv_ask_for_afl() {
+    uint8_t uid[7];
+    uint8_t len;
+    uint8_t response[240];
+    uint8_t response_len = 0;
+    std::vector<uint8_t> afl;
+    uint8_t ask_for_afl[] = {0x80, 0xa8, 0x00, 0x00, 0x02, 0x83, 0x00, 0x00}; // Get AFL
+
+    if (nfc->EMVinDataExchange(ask_for_afl, sizeof(ask_for_afl), response, &response_len)) {
+        std::vector<uint8_t> response_vector(&response[0], &response[response_len]);
+        BerTlv Tlv;
+        Tlv.SetTlv(response_vector);
+        if (Tlv.GetValue("94", &afl) != OK) { // AFL
+            Serial.println("Can't get AFL");
+            afl.clear();
+        }
+    }
+    return afl;
+}
+
+std::vector<uint8_t> EMVReader::emv_read_afl(uint8_t p2) {
+    uint8_t uid[7];
+    uint8_t len;
+    uint8_t response[240];
+    uint8_t response_len = 0;
+    std::vector<uint8_t> result;
+
+    uint8_t read_afl[] = {0x00, 0xB2, 0x01, 0x00, 0x00};
+    read_afl[3] = p2;
+
+    if (nfc->EMVinDataExchange(read_afl, sizeof(read_afl), response, &response_len)) {
+        result = std::vector<uint8_t>(&response[0], &response[response_len]);
+    }
+    return result;
+}
+
+void EMVReader::get_afl(EMVCard *card, uint8_t *afl) {
+    uint8_t P2 = (afl[0] >> 3) << 3 | 0b00000100; // Calculate P2 from afl
+    std::vector<uint8_t> afl_content = emv_read_afl(P2);
+    if (!afl_content.empty()) {
+        BerTlv Tlv;
+        Tlv.SetTlv(afl_content);
+        std::vector<uint8_t> container;
+        if (Tlv.GetValue("5A", &container) !=
+            OK) { // Get PAN(Credit Card Number). If TLV is corrupted(happens often with PN532 fallback to a
+                  // workaround to find information)
+            parse_pan(&afl_content, card);
+            parse_validfrom(&afl_content, card);
+            parse_validto(&afl_content, card);
+        } else {
+            memcpy(card->pan, container.data(), container.size()); // Copy data from TLV to struct
+            container.clear();
+            if (Tlv.GetValue("5F25", &container) != OK) { // Get ValidFrom date
+                parse_validfrom(&afl_content, card);
+                parse_validto(&afl_content, card);
+            } else {
+                memcpy(card->validfrom, container.data(), container.size());
+                if (Tlv.GetValue("5F24", &container) != OK) { // Get ValidTo date
+                    parse_validto(&afl_content, card);
+                } else {
+                    memcpy(card->validto, container.data(), container.size());
+                }
+            }
+        }
+    } else {
+        Serial.println("Can't parse AFL data");
+    }
+}
+
+EMVCard EMVReader::read_emv_card() {
+    EMVCard res;
+    std::vector<uint8_t> aid = emv_ask_for_aid(); // Perform Application Selection
+    if (aid.empty()) {                            // If we can't get AID, we can't read the card
+        res.parsed = false;
+        Serial.println("Can't read card");
+    } else {
+        // Copy AID to result card
+        res.aid = (uint8_t *)malloc(aid.size());
+        memcpy(res.aid, aid.data(), aid.size());
+
+        // Initialize Application Process
+        std::vector<uint8_t> pdol = emv_ask_for_pdol(&aid); // Check if card require PDOL(for example, VISA)
+
+        if (pdol.empty()) {                               // No PDOL(for example Mastercard)
+            std::vector<uint8_t> afl = emv_ask_for_afl(); // Try to get AFL without PDOL
+
+            if (!afl.empty()) {
+                // Read Application data
+                get_afl(&res, afl.data()); // Read AFL
+            } else {
+                Serial.println("Can't get AFL ID");
+            }
+        } else {
+            // TODO: Implement PDOL reading
+        }
+    }
+    return res;
+}
+
+// From https://github.com/huckor/BER-TLV
+std::string BinToAscii(uint8_t *BinData, size_t size)
+
+{
+    char AsciiHexNo[5];
+    std::string Return;
+    for (int i = 0; i < size; i++) {
+        sprintf(AsciiHexNo, "%02X", BinData[i]);
+        Return += AsciiHexNo;
+    }
+
+    return Return;
+}
+
+void EMVReader::display_emv(EMVCard card) {
+    drawMainBorderWithTitle("Read EMV Card");
+    if (card.parsed) {
+        bool found = false;
+        for (size_t i = 0; i < AID_DICT_SIZE && !found; i++) {
+            if (memcmp(card.aid, known_aid[i].aid, 7) == 0) {
+                found = true;
+                padprintln(known_aid[i].name);
+                break;
+            }
+        }
+
+        if (!found) { padprintln("Unknown card vendor"); }
+
+        if (card.pan != nullptr) {
+            std::string pan = BinToAscii(card.pan, card.pan_len);
+            /* Add some spacing */
+            size_t pad = 0;
+            for (size_t i = 0; i < pan.size(); i++) {
+                if (i % 4 == 0 && i != 0) { pan.insert(pan.begin() + i + (pad++), ' '); }
+            }
+
+            padprintln(pan.c_str());
+        } else {
+            padprintln("Unknown PAN");
+        }
+
+        if (card.validfrom != nullptr) {
+            std::string issuedate = BinToAscii(card.validfrom, 2);
+            issuedate.insert(issuedate.begin() + 2, '/');
+            padprintln(issuedate.c_str());
+        } else {
+            padprintln("Unknown issue date");
+        }
+
+        if (card.validto != nullptr) {
+            std::string validto = BinToAscii(card.validto, 2);
+            validto.insert(validto.begin() + 2, '/');
+            padprintln(validto.c_str());
+        } else {
+            padprintln("Unknown valid to date");
+        }
+
+    } else {
+        padprintln("Failed to read EMV Card.");
+    }
+
+    padprintln("Press any key to continue...");
+
+    while (!AnyKeyPress) { delay(100); }
+}

--- a/src/modules/rfid/emv_reader.hpp
+++ b/src/modules/rfid/emv_reader.hpp
@@ -57,6 +57,7 @@ private:
     Adafruit_PN532 *nfc = nullptr;
     EMVCard read_emv_card();
     void display_emv(EMVCard card);
+    void save_emv(const char *aid, const char *pan, const char *validfrom, const char *validto);
 
 public:
     EMVReader() { setup(); };

--- a/src/modules/rfid/emv_reader.hpp
+++ b/src/modules/rfid/emv_reader.hpp
@@ -1,0 +1,67 @@
+#ifndef EMV_READER_H
+#define EMV_READER_H
+
+#include "PN532.h"
+#include <Arduino.h>
+
+typedef struct EMVCard {
+    bool parsed = true;
+    uint8_t *aid = nullptr;
+    size_t pan_len = 0;
+    uint8_t *pan = nullptr;
+    uint8_t *afl_raw = nullptr;
+    uint8_t *validfrom = nullptr;
+    uint8_t *validto = nullptr;
+} EMVCard;
+
+typedef struct EMVAID {
+    uint8_t aid[7];
+    const char *name;
+} EMVAID;
+
+#define AID_DICT_SIZE 11
+
+// http://hartleyenterprises.com/listAID.html
+const EMVAID known_aid[AID_DICT_SIZE] = {
+    // MasterCard
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x04, 0x10, 0x10}, .name = "MasterCard" },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x04, 0x22, 0x03}, .name = "U.S Maestro"},
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x04, 0x30, 0x60}, .name = "Maestro"    },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x04, 0x60, 0x00}, .name = "Cirrus"     },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x04, 0x99, 0x99}, .name = "MasterCard" },
+    // Visa
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x03, 0x10, 0x10}, .name = "Visa"       },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x03, 0x20, 0x10}, .name = "Electron"   },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x03, 0x20, 0x20}, .name = "V-Pay"      },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x03, 0x30, 0x10}, .name = "Visa"       },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x03, 0x80, 0x10}, .name = "Visa"       },
+    {.aid = {0xA0, 0x00, 0x00, 0x00, 0x98, 0x08, 0x40}, .name = "Visa"       }
+};
+
+class EMVReader {
+private:
+    // EMV methods created with the help of https://werner.rothschopf.net/201703_arduino_esp8266_nfc.htm
+    void parse_pan(std::vector<uint8_t> *afl_content, EMVCard *card);
+    void parse_validfrom(std::vector<uint8_t> *afl_content, EMVCard *card);
+    void parse_validto(std::vector<uint8_t> *afl_content, EMVCard *card);
+    void get_afl(EMVCard *card, uint8_t *afl);
+
+    // EMV methods created with the help of https://werner.rothschopf.net/201703_arduino_esp8266_nfc.htm
+    std::vector<uint8_t> emv_ask_for_aid();
+    std::vector<uint8_t> emv_ask_for_app_name();
+    std::vector<uint8_t> emv_ask_for_pdol(std::vector<uint8_t> *aid);
+    std::vector<uint8_t> emv_ask_for_afl();
+    std::vector<uint8_t> emv_read_afl(uint8_t p2);
+
+    PN532 *_rfid;
+    Adafruit_PN532 *nfc = nullptr;
+    EMVCard read_emv_card();
+    void display_emv(EMVCard card);
+
+public:
+    EMVReader() { setup(); };
+    ~EMVReader() {};
+    void setup();
+};
+
+#endif


### PR DESCRIPTION
This PR adds credit card reader for devices that has a compatible PN532 module.

In order to works, this PR needs a modified PN532 library, I opened the PR [here](https://github.com/emericklaw/Adafruit-PN532_Bruce/pull/1)

This feature works only for Elechouse PN532 module(the red one). It doesn't work with Lilygo NFC module due to antenna design that doesn't communicate with EMV chip.

Only MasterCard can be fully read at the moment, VISA can be detected but not read. I don't have other card to test, probably other will works(like AMEX)