### PR TITLE
Rework encoder logic for better performance/response

### DIFF
--- a/boards/lilygo-t-lora-pager/interface.cpp
+++ b/boards/lilygo-t-lora-pager/interface.cpp
@@ -7,11 +7,8 @@
 // Rotary encoder
 #include <RotaryEncoder.h>
 extern RotaryEncoder *encoder;
-IRAM_ATTR void checkPosition();
 RotaryEncoder *encoder = nullptr;
-IRAM_ATTR void checkPosition() {
-    encoder->tick(); // just call tick() to check the state.
-}
+IRAM_ATTR void checkPosition() { encoder->tick(); }
 
 // GPIO expander
 #include <ExtensionIOXL9555.hpp>
@@ -284,7 +281,8 @@ void _setBrightness(uint8_t brightval) {
 **********************************************************************/
 void InputHandler(void) {
     static unsigned long tm = millis();
-    static int _last_dir = 0;
+    static int posDifference = 0;
+    static int lastPos = 0;
     bool sel = !BTN_ACT;
     bool esc = !BTN_ACT;
 
@@ -293,7 +291,12 @@ void InputHandler(void) {
 
     if (millis() - tm < 500) return;
 
-    _last_dir = (int)encoder->getDirection();
+    int newPos = encoder->getPosition();
+    if (newPos != lastPos) {
+        posDifference += (newPos - lastPos);
+        lastPos = newPos;
+    }
+
     sel = digitalRead(SEL_BTN);
     esc = digitalRead(BK_BTN);
 
@@ -328,7 +331,7 @@ void InputHandler(void) {
         }
     } else KeyStroke.Clear();
 
-    if (_last_dir != 0 || sel == BTN_ACT || esc == BTN_ACT || KeyStroke.enter) {
+    if (posDifference != 0 || sel == BTN_ACT || esc == BTN_ACT || KeyStroke.enter) {
         if (!wakeUpScreen()) {
             AnyKeyPress = true;
 
@@ -337,8 +340,14 @@ void InputHandler(void) {
             drv.setWaveform(1, 0);
             drv.run();
 
-            if (_last_dir < 0) PrevPress = true;
-            if (_last_dir > 0) NextPress = true;
+            if (posDifference < 0) {
+                PrevPress = true;
+                posDifference++;
+            }
+            if (posDifference > 0) {
+                NextPress = true;
+                posDifference--;
+            }
             if (sel == BTN_ACT) SelPress = true;
             if (esc == BTN_ACT) EscPress = true;
         } else goto END;


### PR DESCRIPTION
#### Proposed Changes ####

* Reworked the encoder logic to be more responsive to user input

This should avoid weird behaviour when the scolling going in reverse or appearing to skip steps.

#### Types of Changes ####

Bugfix

#### Verification ####

No pictures this time, it needs to be experienced.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improved encoder response on T-Embed and T-LoRa Pager
```

#### Further Comments ####

