### PR TITLE
Web UI Sessions Persist In Settings - Editor Line Numbers - State Management in URL

### DIFF
--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -7,7 +7,7 @@
   -webkit-box-sizing: border-box;
      -moz-box-sizing: border-box;
           box-sizing: border-box;
-    font-family: "DejaVu Sans Mono", "Consolas", "Menlo";
+    font-family: "DejaVu Sans Mono", "Consolas", "Menlo", "Courier New", "Lucida Console", monospace;
     color: var(--color);
 }
 html {
@@ -349,11 +349,42 @@ svg > g, svg > path {
 }
 .dialog.editor .dialog-body {
     width: 100%;
+    height: calc(100% - 70px);
+    padding: 0;
+    overflow: hidden;
+}
+.dialog.editor .editor-container {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    background-color: var(--background);
+    font-family: "DejaVu Sans Mono", "Consolas", "Menlo", "Courier New", "Lucida Console", monospace;
+    font-size: 14px;
+    line-height: 1.4;
+}
+.dialog.editor .line-numbers {
+    background-color: color-mix(in srgb, var(--background) 95%, var(--color) 5%);
+    border-right: 1px solid var(--light-color);
+    color: var(--light-color);
+    padding: 7px 8px;
+    text-align: right;
+    user-select: none;
+    white-space: pre;
+    overflow: hidden;
+}
+.dialog.editor .file-content {
+    flex: 1;
     background-color: var(--background);
     border: 0;
-    height: calc(100% - 70px);
     padding: 5px;
     outline: 0;
+    resize: none;
+    font-family: "DejaVu Sans Mono", "Consolas", "Menlo", "Courier New", "Lucida Console", monospace;
+    font-size: 14px;
+    line-height: 1.4;
+    white-space: pre;
+    overflow-wrap: normal;
+    overflow: auto;
 }
 .dialog.upload .dialog-body {
     padding: 10px;

--- a/embedded_resources/web_interface/index.html
+++ b/embedded_resources/web_interface/index.html
@@ -343,7 +343,12 @@
       <div class="dialog-head">
         Edit: <span class="editor-file-name"></span>
       </div>
-      <textarea class="dialog-body file-content" style="resize: none;"></textarea>
+      <div class="dialog-body">
+        <div class="editor-container">
+          <div class="line-numbers"></div>
+          <textarea class="file-content" style="resize: none;"></textarea>
+        </div>
+      </div>
       <div class="dialog-footer">
         <button class="btn-action act-save-edit-file" title="CTRL + S">Save</button>
         <button class="btn-action act-run-edit-file" title="ALT + ENTER">Run</button>

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -109,6 +109,14 @@ const Dialog = {
   }
 };
 
+function handleAuthError() {
+  if (confirm("Session expired or unauthorized. Would you like to go to the login page?")) {
+    window.location.href = "/";
+  } else {
+    Dialog.loading.hide();
+  }
+}
+
 async function requestGet(url, data) {
   return new Promise((resolve, reject) => {
     let req = new XMLHttpRequest();
@@ -122,6 +130,9 @@ async function requestGet(url, data) {
     req.onload = () => {
       if (req.status >= 200 && req.status < 300) {
         resolve(req.responseText);
+      } else if (req.status === 401) {
+        handleAuthError();
+        reject(new Error(`Unauthorized access (401)`));
       } else {
         reject(new Error(`Request failed with status ${req.status}`));
       }
@@ -147,6 +158,9 @@ async function requestPost(url, data) {
     req.onload = () => {
       if (req.status >= 200 && req.status < 300) {
         resolve(req.responseText);
+      } else if (req.status === 401) {
+        handleAuthError();
+        reject(new Error(`Unauthorized access (401)`));
       } else {
         reject(new Error(`Request failed with status ${req.status}`));
       }

--- a/embedded_resources/web_interface/index.js
+++ b/embedded_resources/web_interface/index.js
@@ -293,6 +293,34 @@ function calcHash(str) {
   return hash.toString(16).padStart(8, '0');
 }
 
+// Line numbers functionality
+function updateLineNumbers() {
+  const textarea = $(".dialog.editor .file-content");
+  const lineNumbers = $(".dialog.editor .line-numbers");
+
+  if (!textarea || !lineNumbers) return;
+
+  const lines = textarea.value.split('\n');
+  const lineCount = lines.length;
+
+  // Generate line numbers
+  let lineNumbersHTML = '';
+  for (let i = 1; i <= lineCount; i++) {
+    lineNumbersHTML += i + '\n';
+  }
+
+  lineNumbers.textContent = lineNumbersHTML;
+}
+
+function syncScrolling() {
+  const textarea = $(".dialog.editor .file-content");
+  const lineNumbers = $(".dialog.editor .line-numbers");
+
+  if (!textarea || !lineNumbers) return;
+
+  lineNumbers.scrollTop = textarea.scrollTop;
+}
+
 function renderFileRow(fileList) {
   $("table.explorer tbody").innerHTML = "";
   fileList.split("\n").sort((a, b) => {
@@ -863,6 +891,9 @@ $(".container").addEventListener("click", async (e) => {
     editor.value = r;
     editor.setAttribute("data-hash", calcHash(r));
 
+    // Update line numbers
+    updateLineNumbers();
+
     $(".act-save-edit-file").disabled = true;
 
     let serial = getSerialCommand(file);
@@ -1342,6 +1373,22 @@ $(".file-content").addEventListener("keydown", function (e) {
 $(".file-content").addEventListener("keyup", function (e) {
   if ($(".dialog.editor:not(.hidden)")) {
     $(".act-save-edit-file").disabled = !isModified(e.target);
+    // Update line numbers when content changes
+    updateLineNumbers();
+  }
+});
+
+$(".file-content").addEventListener("scroll", function (e) {
+  if ($(".dialog.editor:not(.hidden)")) {
+    // Sync scrolling between textarea and line numbers
+    syncScrolling();
+  }
+});
+
+$(".file-content").addEventListener("input", function (e) {
+  if ($(".dialog.editor:not(.hidden)")) {
+    // Update line numbers on any input change
+    updateLineNumbers();
   }
 });
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -70,6 +70,7 @@ public:
 
     // Wifi
     Credential webUI = {"admin", "bruce"};
+    std::vector<String> webUISessions = {}; // FIFO queue of session tokens
     WiFiCredential wifiAp = {"BruceNet", "brucenet"};
     std::map<String, String> wifi = {};
     std::set<String> evilWifiNames = {};
@@ -234,6 +235,10 @@ public:
     void validateColorInverted();
     void addDisabledMenu(String value);
     // TODO: removeDisabledMenu(String value);
+
+    void addWebUISession(const String &token);
+    void removeWebUISession(const String &token);
+    bool isValidWebUISession(const String &token);
 };
 
 #endif


### PR DESCRIPTION
#### Proposed Changes ####

* Authentiation
  * Move sessions to settings to allow them to persist through device restarts
  * Pop message when request fails due to authentication issues
* Add line numbers to editor
* Implement URL state management for file navigation and editing

#### Types of Changes ####

New Feature

#### Verification ####

**Pop message when request fails due to authentication issues**
<img width="483" height="217" alt="image" src="https://github.com/user-attachments/assets/1de921c2-ce2d-4982-8df4-592b5f085d47" />


**Add line numbers to editor**
<img width="499" height="345" alt="image" src="https://github.com/user-attachments/assets/3f57c169-5653-4a87-9cdd-658f86b90a8f" />


**Implement URL state management for file navigation and editing**
<img width="955" height="163" alt="image" src="https://github.com/user-attachments/assets/c4c6d57e-180f-4e06-818a-24c7e7e4ff71" />

<img width="502" height="440" alt="image" src="https://github.com/user-attachments/assets/d04acb23-0692-40ab-b913-84ece8321749" />



#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added line numbers to WebUI file editor
Added state management to WebUI so page refreshes keep the folder/file being edited
```

#### Further Comments ####

