### PR TITLE
Update Bruce specific libraries to have release version numbers

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -124,8 +124,8 @@ lib_deps =
 	Time
 	LibSSH-ESP32
 	https://github.com/bmorcelli/ESPping
-	Adafruit BusIO=https://github.com/emericklaw/Adafruit-BusIO_Bruce
-	Adafruit PN532=https://github.com/emericklaw/Adafruit-PN532_Bruce
+	Adafruit BusIO=https://github.com/emericklaw/Adafruit-BusIO_Bruce@1.17.2-bruce.1
+	Adafruit PN532=https://github.com/emericklaw/Adafruit-PN532_Bruce@1.3.3-bruce.1
 	https://github.com/huckor/BER-TLV.git
 	https://github.com/rennancockles/Arduino_MFRC522v2.git
 	https://github.com/bmorcelli/ESP-ChameleonUltra
@@ -196,8 +196,8 @@ lib_deps =
 	Time
 	;LibSSH-ESP32
 	https://github.com/bmorcelli/ESPping
-	Adafruit BusIO=https://github.com/emericklaw/Adafruit-BusIO_Bruce
-	Adafruit PN532=https://github.com/emericklaw/Adafruit-PN532_Bruce
+	Adafruit BusIO=https://github.com/emericklaw/Adafruit-BusIO_Bruce@1.17.2-bruce.1
+	Adafruit PN532=https://github.com/emericklaw/Adafruit-PN532_Bruce@1.3.3-bruce.1
 	https://github.com/rennancockles/Arduino_MFRC522v2.git
 	https://github.com/bmorcelli/ESP-ChameleonUltra
 	;https://github.com/bmorcelli/ESP-Amiibolink


### PR DESCRIPTION
#### Proposed Changes ####

* Update Bruce specific libraries to have release version numbers
  * Applies to
    * emericklaw/Adafruit-BusIO_Bruce@1.17.2-bruce.1
    * emericklaw/Adafruit-PN532_Bruce@1.3.3-bruce.1

#### Types of Changes ####

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

