### PR TITLE
Added logic to ensure text cannot overlap on smaller screen sizes

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -723,12 +723,24 @@ void drawSubmenu(int index, std::vector<Option> &options, const char *title) {
     // Previous item
     const char *firstOption =
         index - 1 >= 0 ? options[index - 1].label.c_str() : options[menuSize - 1].label.c_str();
+
+    if ((tftWidth - 18) / (LW * FM) >= strlen(firstOption)) { //Checks if text fits on screen by 
+        tft.setTextSize(FM);                                 //getting a number of characters that
+    } else {                                                 //can fit on screen at the current font size and comparing it to the length of the string
+        tft.setTextSize(FP);
+    }
+
     tft.setTextColor(bruceConfig.secColor);
     tft.fillRect(6, middle_up, tftWidth - 12, 8 * FM, bruceConfig.bgColor);
     tft.drawCentreString(firstOption, tftWidth / 2, middle_up, SMOOTH_FONT);
 
     // Selected item
-    int selectedTextSize = options[index].label.length() <= tftWidth / (LW * FG) - 1 ? FG : FM;
+    int selectedTextSize = FP;
+    if ((tftWidth - 18) / (LW * FG) >= options[index].label.length()) { //Same as above but allows FG font sizing
+        selectedTextSize = FG;
+    } else if ((tftWidth - 18) / (LW * FM) >= options[index].label.length()) {
+        selectedTextSize = FM;
+    }
     tft.setTextSize(selectedTextSize);
     tft.setTextColor(bruceConfig.priColor);
     tft.fillRect(6, middle - FG * LH / 2 - 1, tftWidth - 12, FG * LH + 5, bruceConfig.bgColor);
@@ -740,9 +752,16 @@ void drawSubmenu(int index, std::vector<Option> &options, const char *title) {
         bruceConfig.priColor
     );
     // Next Item
+
     const char *thirdOption =
         index + 1 < menuSize ? options[index + 1].label.c_str() : options[0].label.c_str();
-    tft.setTextSize(FM);
+
+    if ((tftWidth - 18) / (LW * FM) >= strlen(thirdOption)) {
+        tft.setTextSize(FM);
+    } else {
+        tft.setTextSize(FP);
+    }
+
     tft.setTextColor(bruceConfig.secColor);
     tft.fillRect(6, middle_down, tftWidth - 12, 8 * FM, bruceConfig.bgColor);
     tft.drawCentreString(thirdOption, tftWidth / 2, middle_down, SMOOTH_FONT);


### PR DESCRIPTION
Adjust text size based on the number of characters that can fit on the screen at a given font size with a string's length

#### Proposed Changes ####
I kept getting text overflow on my 160x128 screen so I made font sizes more dynamic to a display string length.

#### Types of Changes ####
New feature 

#### Verification ####

 You would probably need to run the script on a smaller display although you might still be able to see a difference on larger variants

#### Testing ####
I did test the changes on my esp32 s3 n16r8 using the settings menu

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
"NONE"
```

#### Further Comments ####
Made this to stop my text from overflowing on my display
My display has sparkles on 2 sides of the screen but I am unsure if its related to my additions
This change may ruin some aesthetic due to the jarring difference between the text sizes
The problem this solves could also be solved with a scrolling text system (as used in "displayscrollingtext()") but I don't have the knowledge of c++ to do it.