### PR TITLE
Adding a fillRect to flush the Title+Version string before draw clock

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -800,14 +800,15 @@ void drawStatusBar() {
     }
 
     if (clock_set) {
-        setTftDisplay(12, 12, bruceConfig.priColor, 1, bruceConfig.bgColor);
+        int clock_fontsize = 1;     // Font size of the clock / BRUCE + BRUCE_VERSION
+        setTftDisplay(12, 12, bruceConfig.priColor, clock_fontsize, bruceConfig.bgColor);
 #if defined(HAS_RTC)
         _rtc.GetTime(&_time);
         snprintf(timeStr, sizeof(timeStr), "%02d:%02d", _time.Hours, _time.Minutes);
         tft.print(timeStr);
 #else
         updateTimeStr(rtc.getTimeStruct());
-        tft.fillRect(12, 12, 100, 15, bruceConfig.bgColor);
+        tft.fillRect(12, 12, 100, clock_fontsize * LH, bruceConfig.bgColor);
         tft.print(timeStr);
 #endif
     } else {

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -807,6 +807,7 @@ void drawStatusBar() {
         tft.print(timeStr);
 #else
         updateTimeStr(rtc.getTimeStruct());
+        tft.fillRect(12, 12, 100, 15, bruceConfig.bgColor);
         tft.print(timeStr);
 #endif
     } else {


### PR DESCRIPTION
#### Proposed Changes ####

Adding a flushing fillRect to the clock area to flush out the BRUCE + $version title.

#### Types of Changes ####

Minor screen refresh tweaks

#### Verification ####

I think this problem only exists if you don't have the RTC Module. Every single time you connect Bruce to the internet, it syncs the time online and change the "Bruce + $version" at the top of the screen to a clock. When that happens, and the bruce + version string is longer than the clock, it shows for example "13:45:13.11.1" with "11.1" being a part of the version string.
I don't have an RTC Module and have it set up with startup wifi, so it always shows bruce title first, then after a few seconds it changes to clock and I have to go into a menu and back out again to "refresh" the clock area to get rid of the version number.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####
I am using a modified version of the Bruce firmware with my own custom borders etc. I am not sure if the height of 15 pixels is correct for the standard top banner or not, please change it if needed. 