### PR TITLE
Added "default" folder for Themes (SD Card). Same behaviour as loading custom IR files

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1532,7 +1532,7 @@ void setTheme() {
     loopOptions(options);
     if (fs == nullptr) return;
 
-    String filepath = loopSD(*fs, true, "JSON");
+    String filepath = loopSD(*fs, true, "JSON", "/Themes");
     if (bruceConfig.openThemeFile(fs, filepath, true)) {
         bruceConfig.themePath = filepath;
         if (fs == &LittleFS) bruceConfig.theme.fs = 1;

--- a/src/modules/wifi/evil_portal.cpp
+++ b/src/modules/wifi/evil_portal.cpp
@@ -289,7 +289,7 @@ void EvilPortal::printDeauthStatus() {
 void EvilPortal::loadCustomHtml() {
     getFsStorage(fsHtmlFile);
 
-    htmlFileName = loopSD(*fsHtmlFile, true, "HTML");
+    htmlFileName = loopSD(*fsHtmlFile, true, "HTML", "/BruceHTMLs");    // Default folder for custom HTML files
     String fileBaseName =
         htmlFileName.substring(htmlFileName.lastIndexOf("/") + 1, htmlFileName.length() - 5);
     fileBaseName.toLowerCase();


### PR DESCRIPTION
#### Proposed Changes ####

Added the parameter for the default folder for selecting themes instead of always starting off at root.
Same behaviour as loading custom IR files.

#### Types of Changes ####
Minor QoL change.

#### Verification ####

Go to config -> UI Theme -> SD Card -> File explorer starts inside /Themes folder instead of at root.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Action required. Kinda. If users didn't already have all their themes inside the root/Themes folder, then they will have to move them there.
```

#### Further Comments ####
I don't know if it was intentional or not that the parameter was left out, but I was testing out a lot of themes and had to always navigate into the themes folder that was already there when I copied the sd_files from the repo onto my SD Card. So I thought why not make it the default folder like when I load a custom IR file?

Unrelated notes: should I have created an issue first before making a pull request? It's my first time contributing on GitHub and don't want to be a bother :grimacing:  


