### PR TITLE
Fixes the WiFi getting stuck in STA mode when exiting back to menu wi…

### DIFF
--- a/src/core/wifi/wifi_common.cpp
+++ b/src/core/wifi/wifi_common.cpp
@@ -195,7 +195,11 @@ bool wifiConnectMenu(wifi_mode_t mode) {
             break;
     }
 
-    if (returnToMenu) return false;
+    if (returnToMenu)
+    {
+        wifiDisconnect();   // Forced turning off the wifi module if exiting back to the menu
+        return false;
+    }
     return wifiConnected;
 }
 

--- a/src/modules/wifi/ap_info.cpp
+++ b/src/modules/wifi/ap_info.cpp
@@ -82,7 +82,8 @@ void fillInfo(ScrollableTextArea &area) {
             default: err = "failed with" + String(res); break;
         }
 
-        tft.print(err);
+        area.addLine(err);
+        area.show();
 
         while (check(SelPress)) yield();
         while (!check(SelPress)) yield();


### PR DESCRIPTION
…thout connecting to any AP. Fixes the error message display in AP-Info clipping the border

#### Proposed Changes ####

WiFi Mode: 
Added wifiDisconnect() to the logic for exiting back to menu from "Connect to WiFi".
When you back out of connecting to wifi, the wifi module is stuck in station mode.

AP-Info: 
Added a fix for the error message display inside AP-Info. It calls for tft.print without setting the cursor first, so the message starts at X = 0 and clips the border.
Changed it to area.addLine() and area.show() instead to keep the formatting of this page

#### Types of Changes ####

Bugfix

#### Verification ####

Wifi -» Connect to Wifi -» Scroll down to Main Menu -» Select -» Wifi is still turned on with small wifi icon status and the ability to turn off wifi.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->
None

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

