### PR TITLE
Smarter capture_handshake logic. Waits for usable EAPOL frames

### DIFF
--- a/src/modules/wifi/sniffer.cpp
+++ b/src/modules/wifi/sniffer.cpp
@@ -120,6 +120,7 @@ struct FrameInfo {
     bool isBeacon = false;
     bool isDeauth = false;
     bool isEapol = false;
+    int eapolMsgNum = -1;
     uint8_t apAddr[6] = {0};
     uint64_t apKey = 0;
     String ssid;
@@ -197,6 +198,40 @@ bool isItEAPOL(const wifi_promiscuous_pkt_t *packet) {
 
     return false;
 }
+
+HandshakeTracker hsTracker;
+
+bool handshakeUsable(const HandshakeTracker& hs) {  // EAPOL Messages needed: 1+2 or 3+4
+    return (hs.msg1 && hs.msg2) || (hs.msg3 && hs.msg4);
+}
+
+// Analyze the EAPOL Message Number
+int classifyEapolMessage(const wifi_promiscuous_pkt_t *pkt) {
+    const uint8_t *payload = pkt->payload;
+    // QoS frames add 2 bytes to MAC header
+    int qosOffset = ((payload[0] & 0x0F) == 0x08) ? 2 : 0;
+
+    // Offset to Key Information field:
+    // MAC header (24 + qosOffset) + LLC/SNAP (8) + EAPOL header (4) + Descriptor Type (1)
+    int keyInfoOffset = 24 + qosOffset + 8 + 4 + 1;
+
+    if (pkt->rx_ctrl.sig_len < keyInfoOffset + 2) return -1; // safety check
+
+    uint16_t keyInfo = (payload[keyInfoOffset] << 8) | payload[keyInfoOffset+1];
+
+    bool install = keyInfo & (1 << 6);
+    bool ack     = keyInfo & (1 << 7);
+    bool mic     = keyInfo & (1 << 8);
+    bool secure  = keyInfo & (1 << 9);
+
+    if (ack && !mic && !install) return 1;              // Message 1
+    if (!ack && mic && !install && !secure) return 2;   // Message 2
+    if (ack && mic && install) return 3;                // Message 3
+    if (!ack && mic && !install && secure) return 4;    // Message 4
+
+    return -1; // Unknown
+}
+
 // Définition de l'en-tête d'un paquet PCAP
 typedef struct pcaprec_hdr_s {
     uint32_t ts_sec;   /* timestamp secondes */
@@ -421,6 +456,18 @@ static FrameInfo analyzeFrame(wifi_promiscuous_pkt_t *pkt) {
     info.isBeacon = (frameType == 0x00 && frameSubType == 0x08);
     info.isDeauth = (frameType == 0x00) && (frameSubType == 0x0C || frameSubType == 0x0A);
     info.isEapol = isItEAPOL(pkt);
+
+    if (info.isEapol) {
+        int msg = classifyEapolMessage(pkt);
+        info.eapolMsgNum = msg;
+        // Update handshake tracker
+        switch (msg) {
+            case 1: hsTracker.msg1 = true; break;
+            case 2: hsTracker.msg2 = true; break;
+            case 3: hsTracker.msg3 = true; break;
+            case 4: hsTracker.msg4 = true; break;
+        }
+    }
 
     info.ssid = resolveSsidForFrame(info, pkt);
     if (info.isBeacon) {

--- a/src/modules/wifi/sniffer.h
+++ b/src/modules/wifi/sniffer.h
@@ -5,6 +5,17 @@
 #include <WiFi.h>
 #include <set>
 
+struct HandshakeTracker {
+    bool msg1 = false;
+    bool msg2 = false;
+    bool msg3 = false;
+    bool msg4 = false;
+};
+
+extern HandshakeTracker hsTracker;
+
+bool handshakeUsable(const HandshakeTracker& hs);
+
 struct BeaconList {
     char MAC[6];
     uint8_t channel;

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -450,6 +450,8 @@ ScanNets:
 ** @brief: Capture handshake for a selected network
 **          (redraws only when deauth is sent or when a handshake/EAPOL is captured)
 ***************************************************************************************/
+uint8_t targetBssid[6]; // Just the target AP MAC to pass onto sniff.cpp to filter out EAPOL frames of unrelated APs
+
 void capture_handshake(String tssid, String mac, uint8_t channel) {
 
     hsTracker = HandshakeTracker();     // Reset tracker for each new capture
@@ -468,6 +470,7 @@ void capture_handshake(String tssid, String mac, uint8_t channel) {
 
     // Set the target record for deauth
     memcpy(ap_record.bssid, bssid_array, 6);
+    memcpy(targetBssid, bssid_array, 6);
     ap_record.primary = channel;
 
     String encryptionTypeStr = "Unknown";

--- a/src/modules/wifi/wifi_atks.h
+++ b/src/modules/wifi/wifi_atks.h
@@ -12,6 +12,8 @@ const uint8_t deauth_frame_default[] = {0xc0, 0x00, 0x3a, 0x01, 0xff, 0xff, 0xff
 
 extern uint8_t deauth_frame[]; // 26 = [sizeof(deauth_frame_default[])]
 
+extern uint8_t targetBssid[6];
+
 /**
  * @brief Sends frame in frame_buffer using esp_wifi_80211_tx but bypasses blocking mechanism
  *


### PR DESCRIPTION

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Changing the "Captured" logic from just EAPOL frames existing to actually distinguishing between message 1,2,3 and 4. Only finish capturing when either message 1+2 or 3+4 have been captured.

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->
Improvement on feature "Capture Handshake"

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional 

information necessary to help verify the proposed changes. -->
By capturing handshake of targeted AP.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
Tested this on my custom ESP32-S3 build.

![IMG_20251204_163456358](https://github.com/user-attachments/assets/7d8d3b4a-3bf3-4dd8-876a-40c19086533e)

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->
None

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

I tried out this feature when 1.12 dropped and most of the time i get pcap files either completely without any EAPOL frames for some reason or when there would be EAPOL frames, they would more often than not be only message 1 and 3. Which is unusable.