### PR TITLE
fix(input): correct pin mappings for T-Lora Pager

### DIFF
--- a/boards/lilygo-t-lora-pager/pins_arduino.h
+++ b/boards/lilygo-t-lora-pager/pins_arduino.h
@@ -170,8 +170,8 @@ static const uint8_t RX = SERIAL_RX;
 #define CAPS_LOCK 0x00
 #define KEY_SHIFT 0x1c
 #define KEY_FN 0x14
-#define KEY_BACKSPACE 0x1d
-#define KEY_ENTER 0x13
+#define KEY_BACKSPACE 0x08
+#define KEY_ENTER 0x0D
 
 // Interrupt IO
 #define RTC_INT 1


### PR DESCRIPTION
#### Proposed Changes ####

Found key mapping issue when using ssh client.

#### Types of Changes ####

Updated keyboard mappings for T-Lora Pager's Enter and Backspace keys in pins_arduino.h .

#### Verification ####

Manually tested on T-Lora Pager with LR1121, using the ssh client.

#### Testing ####

Manually tested on T-Lora Pager with LR1121, using the ssh client.

#### Linked Issues ####

None

#### User-Facing Change ####

NONE

```release-note

```

#### Further Comments ####

