### PR TITLE
feat(wifi): add toggle to disable record deduplication for triangulation

### DIFF
--- a/src/modules/gps/wardriving.h
+++ b/src/modules/gps/wardriving.h
@@ -12,7 +12,13 @@
 #include <TinyGPS++.h>
 #include <esp_wifi_types.h>
 #include <globals.h>
+#include <map>
 #include <set>
+
+struct MACLocationData {
+    double lat;
+    double lng;
+};
 
 class Wardriving {
 public:
@@ -36,14 +42,18 @@ private:
     double distance = 0;
     String filename = "";
     TinyGPSPlus gps;
-    HardwareSerial GPSserial = HardwareSerial(2); // Uses UART2 for GPS
-    std::set<String> registeredMACs;              // Store and track registered MAC
-    int wifiNetworkCount = 0;                     // Counter fo wifi networks
+
+    HardwareSerial GPSserial = HardwareSerial(2);     // Uses UART2 for GPS
+    std::map<String, MACLocationData> registeredMACs; // Store MAC with last recorded location
+    int wifiNetworkCount = 0;                         // Counter for wifi networks
     bool rxPinReleased = false;
+    bool enableTriangulation = true;        // Enable multiple records per MAC for triangulation
+    double triangulationMinDistance = 10.0; // Minimum distance (meters) to record same MAC again
 
     /////////////////////////////////////////////////////////////////////////////////////
     // Setup
     /////////////////////////////////////////////////////////////////////////////////////
+    void show_config_menu(void);
     void begin_wifi(void);
     bool begin_gps(void);
     void end(void);


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Added a configuration for wardriving to allow preventing the deduplication of wifi access points. 
The deduplication is better for Wifi discovery, but is insufficient for Wifi AP triangulation.
#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->
* Added options for preventing deduplication, as well as setting a minimum distance for recording a new point (to mitigate power consumption and filespace)
* added config menu for new options.
* changed storage containers and output to 

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

