### PR TITLE
Fix: Shared SPI Deadlock on M5StickC Plus 2

### DIFF
--- a/boards/m5stack-cplus2/interface.cpp
+++ b/boards/m5stack-cplus2/interface.cpp
@@ -18,6 +18,23 @@ void _setup_gpio() {
     pinMode(33, OUTPUT);
     digitalWrite(32, LOW);
     digitalWrite(33, HIGH);
+    //=========================================================================
+    //Issue: During startup, the SD card might keep the MISO line at a high level continuously, causing RF initialization to fail.
+    //Solution：Forcing switch to SD card and sending dummy clocks
+    //=========================================================================
+    int pin_shared_ctrl = 33; // Controls CS: HIGH=SD_Select, LOW=RF_Select
+    int pin_sck = 0;          // SCK Pin for M5StickC Plus 2
+    pinMode(pin_shared_ctrl, OUTPUT); 
+    pinMode(pin_sck, OUTPUT);
+    digitalWrite(pin_shared_ctrl, HIGH); //Force Select SD Card
+    delay(10);
+    for (int i = 0; i < 80; i++) {
+        digitalWrite(pin_sck, HIGH);
+        delayMicroseconds(10);
+        digitalWrite(pin_sck, LOW);
+        delayMicroseconds(10);
+    } //send dummy clocks
+    digitalWrite(pin_shared_ctrl, HIGH);  //Keep the SD card selected.
 }
 
 /***************************************************************************************


### PR DESCRIPTION
#### Proposed Changes ####
This PR resolves the initialization failure issue on M5StickC Plus 2 devices when using transistor circuits (via GPIO pins for SPI sharing).
**The Fix:**
Moved a fix logic into `boards/m5stack-cplus2/interface.cpp` inside the `_setup_gpio()` function:
1. Force select the SD card via gpio33 and send a virtual clock to clear the SD card, releasing the MISO line
2. Keep the SD card in a HIGH state to ensure subsequent 'begin_storage()'

#### Types of Changes ####
Bugfix
#### Verification ####
**Verified on Hardware:** M5StickC Plus 2 + CC1101 Hat (Transistor-XOR Circuit).

**Test Steps:**
1.  Flash the firmware.
2.  Perform a cold boot (power cycle).
3.  Verify SD Card icon appears (SD Mount success).
4.  Enter RF Menu -> Monitor/Send.
5.  Verify CC1101 initializes correctly (No "Not Found" error) and transmits signal.

#### Testing ####

I manually tested it on my machine and found no issues after testing

#### Linked Issues ####

Relates to Issue #249 (CC1101 + SD card support for M5stick C Plus2)

#### User-Facing Change ####

```release-note
Fixed M5StickC Plus 2 boot deadlock and RF initialization failure when using Shared SPI hardware.
```

#### Further Comments ####
Thanks for the guidance on moving the implementation to `interface.cpp`!
