### PR TITLE
Double-press encoder back functionality for T-EMBED CC1101

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -573,6 +573,12 @@ int loopOptions(
         /* Select and run function
         forceMenuOption is set by a SerialCommand to force a selection within the menu
         */
+        
+        // CHECK FOR BACK/EXIT FIRST (prioritizes EscPress for double-press handling) - MODIFIED
+#if defined(T_EMBED) || defined(HAS_TOUCH) || !defined(HAS_SCREEN)
+        if (menuType != MENU_TYPE_MAIN && check(EscPress)) break;
+#endif
+        
         if (check(SelPress) || forceMenuOption >= 0) {
             uint16_t chosen = index;
             if (forceMenuOption >= 0) {
@@ -608,7 +614,8 @@ int loopOptions(
         }*/
 
 #elif defined(T_EMBED) || defined(HAS_TOUCH) || !defined(HAS_SCREEN)
-        if (menuType != MENU_TYPE_MAIN && check(EscPress)) break;
+        // EscPress check moved above to prioritize over SelPress for double-press handling
+        // Original line removed: if (menuType != MENU_TYPE_MAIN && check(EscPress)) break;
 #endif
     }
     return index;


### PR DESCRIPTION
#### Proposed Changes ####

1. **interface.cpp**: Added double-press detection (500ms window) for encoder middle button
2. **Display.cpp**: Reordered button checks to prioritize EscPress over SelPress

#### Types of Changes ####



#### Verification ####

Open any menu and then double press the encoder center button to get back t the main menu

#### Testing ####

Tested on t-embed cc1101 and working.
Shall preserve the existing functionalities on other devices, but needs testing on other devices to make sure.

#### Linked Issues ####

None

#### User-Facing Change ####

Now pressing the encoder center button on the t-embed cc1101 works as back button

```release-note

```

#### Further Comments ####

- Changes are gated by `#if defined(T_EMBED)` / `T_EMBED_1101` checks so shouldn't affect other devices
- Double-press timeout: 500ms
- Single-press timeout: 600ms (prevents single press from firing too early)
- Works alongside existing dedicated back button
-A 500-600ms delay on screen wakeup is expected when pressing the encoder middle button due to the detection delays implemented. On back button press or encoder turning it shall wake up instantly as before.