### PR TITLE
Smaller Show hidden wifi + automatic clear of deauth sent text and re positioning on the text

### DIFF
--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -132,18 +132,14 @@ void WifiMenu::configMenu() {
                                loopOptions(evilOptions, MENU_TYPE_SUBMENU, "Evil Wifi Settings");
                            }});
 
-    // NEW: Show Hidden Networks toggle
     {
-        // build the label showing current state
-        std::string label = std::string("Show Hidden Networks: ") + (showHiddenNetworks ? "ON" : "OFF");
+
+        String hidden__wifi_option = String("Hidden Networks:") + (showHiddenNetworks ? "ON" : "OFF");
 
         // construct Option explicitly using char* label
-        Option opt(label.c_str(), [this]() {
-            // toggle the global flag
+        Option opt(hidden__wifi_option.c_str(), [this]() {
             showHiddenNetworks = !showHiddenNetworks;
-            // immediate feedback
-            displayInfo(String("Show Hidden Networks: ") + (showHiddenNetworks ? "ON" : "OFF"), true);
-            // refresh menu so the label updates
+            displayInfo(String("Hidden Networks:") + (showHiddenNetworks ? "ON" : "OFF"), true);
             configMenu();
         });
 


### PR DESCRIPTION
#### Proposed Changes ####

smaller show hidden wifi , i changed it because on smaller devices like m5stickcplus2 the text was too big and it bugged me out , the other thing basically autoclears the deauth sent text in sniffer , i also changed the location of Deauth sent so its seened clearer now 


#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

tested on m5stickcplus2

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

