### PR TITLE
Refactor getBattery function for voltage reading

### DIFF
--- a/boards/m5stack-cardputer/interface.cpp
+++ b/boards/m5stack-cardputer/interface.cpp
@@ -140,14 +140,14 @@ void _post_setup_gpio() {
 ** Description:   Delivers the battery value from 1-100
 ***************************************************************************************/
 int getBattery() {
-    pinMode(GPIO_NUM_10, INPUT);
-    uint8_t percent;
-    uint32_t volt = analogReadMilliVolts(GPIO_NUM_10);
-
-    float mv = volt;
-    percent = (mv - 3300) * 100 / (float)(4150 - 3350);
-
-    return (percent >= 100) ? 100 : percent;
+    uint16_t adcReading = analogReadMilliVolts(GPIO_NUM_10);
+    float actualVoltage = adcReading * 2.0f;
+    const float MIN_VOLTAGE = 3300.0f;
+    const float MAX_VOLTAGE = 4150.0f;
+    float percent = ((actualVoltage - MIN_VOLTAGE) / (MAX_VOLTAGE - MIN_VOLTAGE)) * 100.0f;
+    if (percent < 0) percent = 0;
+    if (percent > 100) percent = 100;
+    return (int)percent;
 }
 
 /*********************************************************************


### PR DESCRIPTION
Refactor getBattery function to improve voltage calculation and ensure percent is clamped between 0 and 100.

#### Proposed Changes ####

Changed battery calculation math/logic

#### Types of Changes ####

added voltage divider compensation per the m5unified library, both upper and lower ends bound

#### Testing ####

I have not tested it yet, but I will in a few hours

#### Linked Issues ####

None yet

#### User-Facing Change ####

Should drastically increase battery percentage accuracy, as it stands now Bruce is very innacurate often being 30-40% off what the power function of M5Unified returns

#### Further Comments ####

None atm