### PR TITLE
Fix for LoRa menu not showing custom theme image when a theme is set

### DIFF
--- a/src/core/menu_items/LoRaMenu.cpp
+++ b/src/core/menu_items/LoRaMenu.cpp
@@ -16,10 +16,21 @@ void LoRaMenu::optionsMenu() {
 }
 
 void LoRaMenu::drawIconImg() {
-    drawImg(
-        *bruceConfig.themeFS(), bruceConfig.getThemeItemImg(bruceConfig.theme.paths.lora), 0, imgCenterY, true
-    );
+    // Load custom theme image if available, otherwise draw default icon
+    if (bruceConfig.theme.lora && bruceConfig.theme.paths.lora != "") {
+        drawImg(
+            *bruceConfig.themeFS(),
+            bruceConfig.getThemeItemImg(bruceConfig.theme.paths.lora),
+            0,
+            imgCenterY,
+            true
+        );
+    } else {
+        // Fallback to default drawn icon
+        drawIcon(1.0);
+    }
 }
+
 void LoRaMenu::drawIcon(float scale) {
     clearIconArea();
     scale *= 0.75;


### PR DESCRIPTION
Fixes LoRa menu custom theme images not loading. The `drawIconImg()` function was only calling the default icon drawer instead of loading theme images like other menus.

#### Proposed Changes ####

- Updated `LoRaMenu::drawIconImg()` to check if LoRa theme is enabled
- Added proper theme image loading using `bruceConfig.getThemeItemImg()`
- Maintains fallback to default drawn icon when no theme image configured

#### Types of Changes ####

Changes in the way custom images are handled and loaded and fall back to default icon if no theme is selected or no image is assigned to LoRa menu on the theme .json

#### Verification ####

-set a custom theme in settings
-go to main menu and navigate to LoRa menu
-the custom image should show

#### Testing ####

- Tested with `"lora": "LoRa.png"` - custom image loads correctly
- Tested with `"lora": true` - default drawn icon shows
- Consistent with other menu implementations (EthernetMenu, NRF24Menu)

#### Linked Issues ####


#### User-Facing Change ####
LoRa custom theme image should now show when a theme is selected and it includes an image for the LoRa menu
```release-note

```

#### Further Comments ####

- JSON key must be lowercase `"lora"` to match theme struct field
- Fixes issue where LoRa menu was the only menu not loading custom theme images