### PR TITLE
Add microphone support for js scripting

### DIFF
--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -304,6 +304,8 @@ duk_ret_t native_require(duk_context *ctx) {
         putPropKeyboardFunctions(ctx, obj_idx, 0);
     } else if (filepath == "math") {
         putPropMathFunctions(ctx, obj_idx, 0);
+    } else if (filepath == "mic") {
+        putPropMicFunctions(ctx, obj_idx, 0);
     } else if (filepath == "notification") {
         putPropNotificationFunctions(ctx, obj_idx, 0);
     } else if (filepath == "serial") {

--- a/src/modules/bjs_interpreter/interpreter.h
+++ b/src/modules/bjs_interpreter/interpreter.h
@@ -23,6 +23,7 @@ extern char *scriptName;
 #include "ir_js.h"
 #include "keyboard_js.h"
 #include "math_js.h"
+#include "mic_js.h"
 #include "notification_js.h"
 #include "serial_js.h"
 #include "storage_js.h"

--- a/src/modules/bjs_interpreter/mic_js.cpp
+++ b/src/modules/bjs_interpreter/mic_js.cpp
@@ -1,0 +1,81 @@
+#if !defined(LITE_VERSION) && !defined(DISABLE_INTERPRETER)
+#include "mic_js.h"
+
+#include "helpers_js.h"
+#include "modules/others/mic.h"
+
+duk_ret_t putPropMicFunctions(duk_context *ctx, duk_idx_t obj_idx, uint8_t magic) {
+    bduk_put_prop_c_lightfunc(ctx, obj_idx, "recordWav", native_micRecordWav, 2, magic);
+    return 0;
+}
+
+duk_ret_t registerMic(duk_context *ctx) {
+    bduk_register_c_lightfunc(ctx, "micRecordWav", native_micRecordWav, 2);
+    return 0;
+}
+
+// mic.recordWav(pathOrPathObj?, options?)
+// - pathOrPathObj: string ("/BruceMIC/rec.wav") OR { fs: "SD"|"LittleFS", path: "/..." } (same as storage)
+// - options:
+//    - maxMs: number (0 = unlimited)
+//    - stopOnSel: boolean (default true)
+// Returns: { ok: boolean, path: string, bytes: number, sampleRateHz: number, channels: number }
+duk_ret_t native_micRecordWav(duk_context *ctx) {
+    FileParamsJS fileParams;
+    if (duk_is_undefined(ctx, 0) || duk_is_null(ctx, 0)) {
+        // default path
+        fileParams.fs = nullptr;
+        fileParams.path = "/BruceMIC/recording.wav";
+        fileParams.exist = false;
+        fileParams.paramOffset = 0;
+    } else {
+        fileParams = js_get_path_from_params(ctx, false);
+    }
+
+    uint32_t maxMs = 8000;
+    bool stopOnSel = true;
+
+    if (duk_is_object(ctx, 1)) {
+        if (duk_get_prop_string(ctx, 1, "maxMs")) {
+            if (duk_is_number(ctx, -1)) maxMs = (uint32_t)duk_to_uint(ctx, -1);
+        }
+        duk_pop(ctx);
+
+        if (duk_get_prop_string(ctx, 1, "stopOnSel")) {
+            stopOnSel = duk_get_boolean_default(ctx, -1, true);
+        }
+        duk_pop(ctx);
+    }
+
+    // Choose FS if not specified
+    FS *fs = fileParams.fs;
+    if (fs == nullptr) {
+        if (!getFsStorage(fs) || fs == nullptr) {
+            duk_idx_t obj = duk_push_object(ctx);
+            bduk_put_prop(ctx, obj, "ok", duk_push_boolean, false);
+            bduk_put_prop(ctx, obj, "path", duk_push_string, "");
+            bduk_put_prop(ctx, obj, "bytes", duk_push_uint, 0);
+            bduk_put_prop(ctx, obj, "sampleRateHz", duk_push_uint, 48000);
+            bduk_put_prop(ctx, obj, "channels", duk_push_uint, 1);
+            return 1;
+        }
+    }
+
+    String path = fileParams.path;
+    if (!path.startsWith("/")) path = "/" + path;
+
+    uint32_t outBytes = 0;
+    bool ok = mic_record_wav_to_path(fs, path, maxMs, stopOnSel, &outBytes);
+
+    duk_idx_t obj = duk_push_object(ctx);
+    bduk_put_prop(ctx, obj, "ok", duk_push_boolean, ok);
+    bduk_put_prop(ctx, obj, "path", duk_push_string, path.c_str());
+    bduk_put_prop(ctx, obj, "bytes", duk_push_uint, outBytes);
+    bduk_put_prop(ctx, obj, "sampleRateHz", duk_push_uint, 48000);
+    bduk_put_prop(ctx, obj, "channels", duk_push_uint, 1);
+    return 1;
+}
+
+#endif
+
+

--- a/src/modules/bjs_interpreter/mic_js.h
+++ b/src/modules/bjs_interpreter/mic_js.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#if !defined(LITE_VERSION) && !defined(DISABLE_INTERPRETER)
+#include <duktape.h>
+
+duk_ret_t putPropMicFunctions(duk_context *ctx, duk_idx_t obj_idx, uint8_t magic);
+duk_ret_t registerMic(duk_context *ctx);
+
+duk_ret_t native_micRecordWav(duk_context *ctx);
+
+#endif
+
+

--- a/src/modules/others/mic.h
+++ b/src/modules/others/mic.h
@@ -43,5 +43,6 @@ void mic_function() {
 void mic_test();
 void mic_test_one_task();
 void mic_record();
+bool mic_record_wav_to_path(FS *fs, const String &path, uint32_t max_ms, bool stop_on_sel, uint32_t *out_bytes);
 
 #endif


### PR DESCRIPTION
#### Proposed Changes ####

- Added microphone support to the JS interpreter via require("mic"), exposing a mic.recordWav(...) API.
- Refactored microphone recording into a reusable helper mic_record_wav_to_path(...) that writes a proper WAV file to a specified filesystem/path with configurable stop conditions.
- Kept the existing interactive mic recording UI (mic_record()) but reimplemented it using the new helper to reduce duplication and centralize recording logic/cleanup.

#### Types of Changes ####

- Feature: New interpreter module/API (mic for BJS/Duktape).
- Refactor: Shared recording implementation extracted for reuse.
- No breaking changes intended: Existing mic recording flow preserved.

#### Verification ####

- Board tested: LilyGO T-Embed CC1101.
- Behavior verified:
  - New JS mic recording path works and produces a playable .wav.
  - Existing microphone features continue to behave as before (no regressions observed).

#### Testing ####

- Manual testing on device:
  - Recorded audio using the new JS mic API (script used during validation, not included in PR).
  - Re-ran the existing microphone recording functionality from the UI to confirm it still works.

#### Linked Issues ####

- N/A 

#### User-Facing Change ####
- None

```release-note
Interpreter scripts can now record microphone audio to WAV files using require("mic") and mic.recordWav(...).
```



