### PR TITLE
Fix startup app default index

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1149,9 +1149,10 @@ void setStartupApp() {
         {"None", [=]() { bruceConfig.setStartupApp(""); }, bruceConfig.startupApp == ""}
     };
 
-    int index = 1;
+    int index = 0;
     for (String appName : startupApp.getAppNames()) {
-        if (bruceConfig.startupApp == appName) idx = index++;
+        index++;
+        if (bruceConfig.startupApp == appName) idx = index;
 
         options.push_back(
             {appName.c_str(),


### PR DESCRIPTION
#### Proposed Changes ####

Fix startup app default index, it was always selecting the second menu item.

#### Types of Changes ####

Bugfix

#### Verification ####

Menu now correctly defaults to the current setting.

#### Testing ####

No

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

