### PR TITLE
Fix null being added to the end of httpFetch responses

### DIFF
--- a/src/modules/bjs_interpreter/wifi_js.cpp
+++ b/src/modules/bjs_interpreter/wifi_js.cpp
@@ -346,14 +346,22 @@ duk_ret_t native_httpFetch(duk_context *ctx) {
         }
         startMillis = millis();
     }
-    if (payload != NULL) { payload[bytesRead] = '\0'; }
 
     if (returnResponseType == 0) {
-        duk_buffer_to_string(ctx, -1);
+        void *buffer_data = duk_get_buffer_data(ctx, -1, NULL);
+        if (buffer_data != NULL && bytesRead > 0) {
+            // Create string from buffer data while buffer is still on stack
+            duk_push_lstring(ctx, (const char *)buffer_data, bytesRead);
+            duk_remove(ctx, -2); // Remove the buffer, keep the string
+        } else {
+            duk_pop(ctx);             // Remove buffer from stack
+            duk_push_string(ctx, ""); // Empty string if no data
+        }
     } else {
-        duk_push_buffer_object(ctx, -1, 0, payloadSize, DUK_BUFOBJ_UINT8ARRAY);
+        duk_push_buffer_object(ctx, -1, 0, bytesRead, DUK_BUFOBJ_UINT8ARRAY);
     }
     duk_put_prop_string(ctx, obj_idx, "body");
+    bduk_put_prop(ctx, obj_idx, "length", duk_push_int, contentLength);
     bduk_put_prop(ctx, obj_idx, "response", duk_push_int, httpResponseCode);
     bduk_put_prop(ctx, obj_idx, "status", duk_push_int, httpResponseCode);
     bduk_put_prop(ctx, obj_idx, "ok", duk_push_boolean, httpResponseCode >= 200 && httpResponseCode < 300);


### PR DESCRIPTION
#### Proposed Changes ####

For a while now I have had issues getting 'invalid JSON' responses when using httpFetch. This change fixes it.
In the past I was having to add `.slice(0, -1)`.

* Fix null being added to the end of httpFetch responses
* Add length to return response

#### Types of Changes ####

Bugfix and new feature

#### Verification ####

JSON can now be downloaded and successfully parsed by JSON.parse().

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

