### PR TITLE
Add gcc-multilib libc6-dev-i386 to github workflows

### DIFF
--- a/.github/workflows/PR_All_envs.yml
+++ b/.github/workflows/PR_All_envs.yml
@@ -75,6 +75,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install build deps (multilib)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-multilib libc6-dev-i386
+
       # - name: Cache pip
       #   uses: actions/cache@v4
       #   with:

--- a/.github/workflows/PR_check.yml
+++ b/.github/workflows/PR_check.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install build deps (multilib)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-multilib libc6-dev-i386
+
       # - name: Cache pip
       #   uses: actions/cache@v4
       #   with:

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -75,6 +75,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install build deps (multilib)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-multilib libc6-dev-i386
+
       - name: Cache pip
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
#### Proposed Changes ####

- Add gcc-multilib libc6-dev-i386 to github workflows

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

This PR is needed for the MicroQuickJS