### PR TITLE
Fix flashing for ESP32-C5 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Vendor files
+static/vendor/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
 		"": {
 			"name": "bruce",
 			"version": "0.0.1",
+			"hasInstallScript": true,
 			"dependencies": {
 				"@sveltejs/adapter-static": "^3.0.10",
-				"@types/w3c-web-serial": "^1.0.8"
+				"@types/w3c-web-serial": "^1.0.8",
+				"bruce-esp-web-tools": "https://github.com/BruceDevices/esp-web-tools/releases/download/1.1.0a/bruce-esp-web-tools.tgz"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^2.0.0",
@@ -19,11 +21,14 @@
 				"@sveltejs/vite-plugin-svelte": "^6.2.3",
 				"@tailwindcss/typography": "^0.5.15",
 				"@tailwindcss/vite": "^4.0.0",
+				"cpx": "^1.5.0",
+				"cross-env": "^10.1.0",
 				"eslint": "^9.18.0",
 				"eslint-config-prettier": "^10.0.1",
 				"eslint-plugin-svelte": "^3.0.0",
 				"globals": "^17.0.0",
 				"mdsvex": "^0.12.6",
+				"mkdirp": "^3.0.1",
 				"prettier": "^3.4.2",
 				"prettier-plugin-svelte": "^3.3.3",
 				"prettier-plugin-tailwindcss": "^0.7.2",
@@ -34,6 +39,13 @@
 				"typescript-eslint": "^8.20.0",
 				"vite": "^7.3.1"
 			}
+		},
+		"node_modules/@epic-web/invariant": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+			"integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.27.2",
@@ -494,13 +506,13 @@
 			}
 		},
 		"node_modules/@eslint/compat": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.0.tgz",
-			"integrity": "sha512-T9AfE1G1uv4wwq94ozgTGio5EUQBqAVe1X9qsQtSNVEYW6j3hvtZVm8Smr4qL1qDPFg+lOB2cL5RxTRMzq4CTA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.1.tgz",
+			"integrity": "sha512-yl/JsgplclzuvGFNqwNYV4XNPhP3l62ZOP9w/47atNAdmDtIFCx6X7CSk/SlWUuBGkT4Et/5+UD+WyvX2iiIWA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.0.0"
+				"@eslint/core": "^1.0.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
@@ -512,19 +524,6 @@
 				"eslint": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@eslint/compat/node_modules/@eslint/core": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.0.tgz",
-			"integrity": "sha512-PRfWP+8FOldvbApr6xL7mNCw4cJcSTq4GA7tYbgq15mRb0kWKO/wEB2jr+uwjFH3sZvEZneZyCUGTxsv4Sahyw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/json-schema": "^7.0.15"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/config-array": {
@@ -555,7 +554,7 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/@eslint/core": {
+		"node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
 			"version": "0.17.0",
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
 			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
@@ -566,6 +565,19 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-r18fEAj9uCk+VjzGt2thsbOmychS+4kxI14spVNibUO2vqKX7obOG+ymZljAwuPZl+S3clPGwCwTDtrdqTiY6Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -637,6 +649,19 @@
 			"dependencies": {
 				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -737,6 +762,1309 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@lit-labs/ssr-dom-shim": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+			"integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@lit/reactive-element": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+			"integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.5.0"
+			}
+		},
+		"node_modules/@material/animation": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-GBuR4VmcTQW1D0lPXEosf5Giho72LLbyGIydWGtaEUtLJoive/D9kFkwTN4Fsyt9Kkl7hbhs35vrNe6QkAH4/Q==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/base": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-UJKbXwZtkrA3sfQDmj8Zbw1Q3Tqtl6KdfVFws95Yf7TCUgTFzbZI/FSx1w7dVugQPOEnIBuZnzqZam/MtHkx4w==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/button": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/button/-/button-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-IPBAByKpQjrWNVmAWx5VCTCLnOw4ymbLsbHmBkLiDgcLPs1EtwYnKKIwQ+/t3bV02OShUdMiyboL8V/C0gMS1A==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/density": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/elevation": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/shape": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/tokens": "14.0.0-canary.53b3cad2f.0",
+				"@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+				"@material/typography": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/circular-progress": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-4A+HMgp66b45Fvbcbh9qb1j0vRFjKESbE2fHFkSMMNDPqFiKcvq4tJFBxKG2szYzpAnXdWLYaB+DeQ2+wSu9hg==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/progress-indicator": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/density": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/density/-/density-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-Eh/vZ3vVyqtpylg5Ci33qlgtToS4H1/ppd450Ib3tcdISIoodgijYY0w4XsRvrnZgbI/h/1STFdLxdzS0UNuFw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-yiG2nlVKTW0Ro3CF8Z/MVpTwSyG/8Kio3AaTUbeQdbjt5r692s4x5Yhd8m1IjEQKUeulY4CndvIbCUwZ8/G2PA==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/button": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/elevation": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/icon-button": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/shape": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/tokens": "14.0.0-canary.53b3cad2f.0",
+				"@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+				"@material/typography": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dom": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-aR+rfncF6oi2ivdOlKSJI4UXwNzWV5rXM88MLDoSJF1D7lXxhAKhge+tMUBodWGV/q0+FnXLuVAa0WYTrKjo+A==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/elevation": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-3h+EkR588RMZ5TSNQ4UeXD1FOBnL3ABQix0DQIGwtNJCqSMoPndT/oJEFvwQbTkZNDbFIKN9p1Q7/KuFPVY8Pw==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/feature-targeting": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/floating-label": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-gHZUTTVKnP+Zjz4l9IT/G89NPmypn5FlTGLWKKqXbuQphr37rsKFR3Y80SJxULRyMDnAdKSxuZwiXLFKQz9KlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/typography": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/focus-ring": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-exPX5VrjQimipBwgcFDGRiEE783sOBgpkFui59A6i6iGvS2UrLHlYY2E65fyyyQnD1f/rv4Po1OOnCesE1kulg==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0"
+			}
+		},
+		"node_modules/@material/icon-button": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-BFdj3CP0JXHC/F2bDmpmzWhum4fkzIDgCCavvnpE/KcCbr0AaoSULRde+LtqvbdLIYW20cXhvjinIOlRhSOshA==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/density": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/elevation": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/line-ripple": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-k8f8uuDwnSqZZ98CzbYtQVtxlp1ryUup9nd2uobo3kiqQNlQfXdGkVjuCXcla0OPiKFizNn7dS6Kl/j6L09XUA==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/list": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-mkMpltSKAYLBtFnTTCk/mQIDzwxF/VLh1gh59ehOtmRXt7FvTz83RoAa4tqe53hpVrbX4HoLDBu+vILhq/wkjw==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/density": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/shape": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/typography": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/menu": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/menu/-/menu-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-MmYKVrMIqOtP3TN4vdrrnQrS8P81+tMaA6bKiT9V79R1U6+mKsBYTzaLtLbzyem5vF8O0q7bSwyPwhWPtJr75Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/elevation": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/list": "14.0.0-canary.53b3cad2f.0",
+				"@material/menu-surface": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/menu-surface": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-IQWb/n15FpLnn+kHp0EqzLE+UoWSPumq3eze2QifiowvGb37bNFR9oSe7CaOzPMrHdkrZ5SBWnDU41wPZN5kOg==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/elevation": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/shape": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/mwc-base": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.27.0.tgz",
+			"integrity": "sha512-oCWWtjbyQ52AaUbzINLGBKScIPyqhps2Y7c8t6Gu6fcFeDxhKXMV1Cqvtj/OMhtAt53XjHfD2XruWwYv3cYYUA==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/base": "=14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-base/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-base/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-base/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-base/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-button": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.27.0.tgz",
+			"integrity": "sha512-t5m2zfE93RNKHMjdsU67X6csFzuSG08VJKKvXVQ+BriGE3xBgzY5nZdmZXomFpaWjDENPAlyS4ppCFm6o+DILw==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/mwc-icon": "^0.27.0",
+				"@material/mwc-ripple": "^0.27.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-button/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-button/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-button/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-button/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-checkbox": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-checkbox/-/mwc-checkbox-0.27.0.tgz",
+			"integrity": "sha512-EY0iYZLwo8qaqMwR5da4fdn0xI0BZNAvKTcwoubYWpDDHlGxDcqwvjp/40ChGo3Q/zv8/4/A0Qp7cwapI82EkA==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/mwc-base": "^0.27.0",
+				"@material/mwc-ripple": "^0.27.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-checkbox/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-checkbox/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-checkbox/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-checkbox/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-circular-progress": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-circular-progress/-/mwc-circular-progress-0.27.0.tgz",
+			"integrity": "sha512-7DkqMb5pUrHfLus5EZ7IT2HUMoE+uPpjGzu3MnDpIzDlfYo6I8p+ifWtEytI0NtXdY5UmITNuCv0RC77mhJrgQ==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/circular-progress": "=14.0.0-canary.53b3cad2f.0",
+				"@material/mwc-base": "^0.27.0",
+				"@material/theme": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-circular-progress/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-circular-progress/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-circular-progress/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-circular-progress/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-dialog": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-dialog/-/mwc-dialog-0.27.0.tgz",
+			"integrity": "sha512-rkOEmCroVs0wBQbj87vH79SvSHHZ61QRCTUYsU2rHGZCvdzlmvHjWdoyKjJER6WwwM3rrT8xthfecmjICI28CA==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/dialog": "=14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "=14.0.0-canary.53b3cad2f.0",
+				"@material/mwc-base": "^0.27.0",
+				"@material/mwc-button": "^0.27.0",
+				"blocking-elements": "^0.1.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1",
+				"wicg-inert": "^3.0.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-floating-label": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-floating-label/-/mwc-floating-label-0.27.0.tgz",
+			"integrity": "sha512-uLleloTxQ6dDShcZzqgqfC8otQY8DtGMO9HFQbAEncoFAWpAehcEonsuT/IUhMORN+c5un0P5WXwcZsInJb7og==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-floating-label/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-floating-label/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-floating-label/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-floating-label/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-icon": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.27.0.tgz",
+			"integrity": "sha512-Sul44I37M9Ewynn0A9DjkEBrmll2VtNbth6Pxj7I1A/EAwEfaCrPvryyGqfIu1T2hTsRcaojzQx6QjF+B5QW9A==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-icon-button": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-icon-button/-/mwc-icon-button-0.27.0.tgz",
+			"integrity": "sha512-wReiPa1UkLaCSPtpkAs1OGKEBtvqPnz9kzuY+RvN5ZQnpo3Uh7n3plHV4y/stsUBfrWtBCcOgYnCdNRaR/r2nQ==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/mwc-ripple": "^0.27.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-icon-button/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-icon-button/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-icon-button/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-icon-button/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-icon/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-icon/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-icon/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-icon/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-line-ripple": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-line-ripple/-/mwc-line-ripple-0.27.0.tgz",
+			"integrity": "sha512-n9Xpt5g3RJEl9rvk14OP6dUNJUtsJA46beTQiep7ppO7IPVFLC1v/5sPpUzfNPUBsclSPxdBuNlCxsgcIYueUw==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-line-ripple/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-line-ripple/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-line-ripple/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-line-ripple/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-list": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-list/-/mwc-list-0.27.0.tgz",
+			"integrity": "sha512-oAhNQsBuAOgF3ENOIY8PeWjXsl35HoYaUkl0ixBQk8jJP2HIEf+MdbS5688y/UXxFbSjr0m//LfwR5gauEashg==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/base": "=14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "=14.0.0-canary.53b3cad2f.0",
+				"@material/list": "=14.0.0-canary.53b3cad2f.0",
+				"@material/mwc-base": "^0.27.0",
+				"@material/mwc-checkbox": "^0.27.0",
+				"@material/mwc-radio": "^0.27.0",
+				"@material/mwc-ripple": "^0.27.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-list/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-list/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-list/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-list/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-menu": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-menu/-/mwc-menu-0.27.0.tgz",
+			"integrity": "sha512-K+L/t267ZGrlhjK/iSKUVZQKRMkWELArKVglfS5of93ALP4in0RGnj1sOG2u3IFI2F/mEZxRi+wr7HgNxpe0wA==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/menu": "=14.0.0-canary.53b3cad2f.0",
+				"@material/menu-surface": "=14.0.0-canary.53b3cad2f.0",
+				"@material/mwc-base": "^0.27.0",
+				"@material/mwc-list": "^0.27.0",
+				"@material/shape": "=14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-menu/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-menu/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-menu/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-menu/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-notched-outline": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-notched-outline/-/mwc-notched-outline-0.27.0.tgz",
+			"integrity": "sha512-IlqfQVaEd1RAHqhOG0Xk5JhTDgBe/P9og0pnACglK6bPE0vUhYKwibJiHcr4ACTPtGWHO9o92aktR+7AIEAKtQ==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/mwc-base": "^0.27.0",
+				"@material/notched-outline": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-notched-outline/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-notched-outline/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-notched-outline/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-notched-outline/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-radio": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-radio/-/mwc-radio-0.27.0.tgz",
+			"integrity": "sha512-+rSO9a373BgyMgQOM0Z8vVkuieobBylPJ8qpltytM+yGPj8+n+MtwRZyg+ry3WwEjYYDMP6GxZPHwLgWs6lMpQ==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/mwc-base": "^0.27.0",
+				"@material/mwc-ripple": "^0.27.0",
+				"@material/radio": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-radio/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-radio/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-radio/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-radio/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-ripple": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.27.0.tgz",
+			"integrity": "sha512-by0O8d8g3Rd96/sUB8hxy6MrDx1QTstqOsA64vqypWd526hMTBGRik08jTNap5sVIyrN9Vq17jb4NJLWQLnNHQ==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/dom": "=14.0.0-canary.53b3cad2f.0",
+				"@material/mwc-base": "^0.27.0",
+				"@material/ripple": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-ripple/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-ripple/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-ripple/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-ripple/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-select": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-select/-/mwc-select-0.27.0.tgz",
+			"integrity": "sha512-LTr2nl7gAYq8ung4eWfUz24mey4/K9vAlqJBo/uu6w0122C9X64szBS9kHAb87aD1oxLkxAJCDuv/wwlXV1i2w==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/dom": "=14.0.0-canary.53b3cad2f.0",
+				"@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
+				"@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
+				"@material/list": "=14.0.0-canary.53b3cad2f.0",
+				"@material/mwc-base": "^0.27.0",
+				"@material/mwc-floating-label": "^0.27.0",
+				"@material/mwc-icon": "^0.27.0",
+				"@material/mwc-line-ripple": "^0.27.0",
+				"@material/mwc-list": "^0.27.0",
+				"@material/mwc-menu": "^0.27.0",
+				"@material/mwc-notched-outline": "^0.27.0",
+				"@material/select": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-select/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-select/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-select/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-select/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/mwc-textfield": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-textfield/-/mwc-textfield-0.27.0.tgz",
+			"integrity": "sha512-4/OEeEVAWWQ1DzpjeMLYLsa9HMlifOPjAvi0681Yj1g/RYJs5ONZS80HZ8HOT+efAOlZDugshgM4gdNS3I0XFQ==",
+			"deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
+				"@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
+				"@material/mwc-base": "^0.27.0",
+				"@material/mwc-floating-label": "^0.27.0",
+				"@material/mwc-line-ripple": "^0.27.0",
+				"@material/mwc-notched-outline": "^0.27.0",
+				"@material/textfield": "=14.0.0-canary.53b3cad2f.0",
+				"lit": "^2.0.0",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-textfield/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/@material/mwc-textfield/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-textfield/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/@material/mwc-textfield/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/@material/notched-outline": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-3ByiPOC/wWQmFKfgJS98kb5/6v92n7uIfJ6v6sryKJlJCJn39qfpGcCM5RpRIws1RET1s1zBJT2JDwYeu/hM5A==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/floating-label": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/shape": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/progress-indicator": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-vW0oZK70QOpAarip95ueCQ/I3kBClcWjxsc0F0QjkqT76DOVXpjnZ4XoRRyq9eMpwLqlKLTecrsSNpmqwwF1Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/radio": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/radio/-/radio-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-V/AgWEOuHFoh9d4Gq1rqBZnKSGtMLQNh23Bwrv0c1FhPqFvUpwt9jR3SVwhJk5gvQQWGy9p3iiGc9QCJ+0+P8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/density": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/ripple": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-6g2G62vd8DsMuIUSXlRrzb98qkZ4o8ZREknNwNP2zaLQEOkJ//4j9HaqDt98/3LIjUTY9UIVFTQENiMmlwKHYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/rtl": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/select": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/select/-/select-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-fAiTaHZ1PIEmCUbufS+IZvsWO0hDxtbU8rOsbmSu1oupAboP7jSgOVgcCGdT9KY5WacrniIIMO6jZjhnvrC0Lg==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/density": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/elevation": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/floating-label": "14.0.0-canary.53b3cad2f.0",
+				"@material/line-ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/list": "14.0.0-canary.53b3cad2f.0",
+				"@material/menu": "14.0.0-canary.53b3cad2f.0",
+				"@material/menu-surface": "14.0.0-canary.53b3cad2f.0",
+				"@material/notched-outline": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/shape": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/tokens": "14.0.0-canary.53b3cad2f.0",
+				"@material/typography": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/shape": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-RyjInLCNe+nI/ulKea0ZLHphXQDiDqYazS25SRn18g8Hoa5qGNaY5oOBncDXUYn3jm5oI5kFc9oif//kulkbjg==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/textfield": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-Pla9Tr94Is18o97E/mqHKdkR24rPES9atGm3BlXrNzyr5tu6+h++RBbxy7V6IExcfl0MX+v9Gyqz7sPZzFtwMA==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/animation": "14.0.0-canary.53b3cad2f.0",
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/density": "14.0.0-canary.53b3cad2f.0",
+				"@material/dom": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/floating-label": "14.0.0-canary.53b3cad2f.0",
+				"@material/line-ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/notched-outline": "14.0.0-canary.53b3cad2f.0",
+				"@material/ripple": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"@material/shape": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"@material/tokens": "14.0.0-canary.53b3cad2f.0",
+				"@material/typography": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/theme": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-S06XAevDCDWMe+GgsEpITMS07imUidzadNaTbJsqssFajBLr53QWVZsG84BpjXKXoYvyEJvb0hX5U0lq6ip9UQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/tokens": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-myHFB7vac8zErA3qgkqmV+kpE+i9JEwc/6Yf0MOumDSpylJGw28QikpNC6eAVBK2EmPQTaFn20mqUxyud8dGqw==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/elevation": "14.0.0-canary.53b3cad2f.0"
+			}
+		},
+		"node_modules/@material/touch-target": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-d83e5vbqoLyL542yOTTp4TLVltddWiqbI/j1w/D9ipE30YKfe2EDN+CNJc32Zufh5IUfK41DsZdrN8fI9cL99A==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/base": "14.0.0-canary.53b3cad2f.0",
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/rtl": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/typography": {
+			"version": "14.0.0-canary.53b3cad2f.0",
+			"resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0-canary.53b3cad2f.0.tgz",
+			"integrity": "sha512-9J0k2fq7uyHsRzRqJDJLGmg3YzRpfRPtFDVeUH/xBcYoqpZE7wYw5Mb7s/l8eP626EtR7HhXhSPjvRTLA6NIJg==",
+			"license": "MIT",
+			"dependencies": {
+				"@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+				"@material/theme": "14.0.0-canary.53b3cad2f.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/web": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@material/web/-/web-2.4.1.tgz",
+			"integrity": "sha512-0sk9t25acJ72Qv3r0n9r0lgDbPaAKnpm0p+QmEAAwYyZomHxuVbgrrAdtNXaRm7jFyGh+WsTr8bhtvCnpPRFjw==",
+			"license": "Apache-2.0",
+			"workspaces": [
+				"catalog"
+			],
+			"dependencies": {
+				"lit": "^2.8.0 || ^3.0.0",
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -1147,9 +2475,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.3.tgz",
-			"integrity": "sha512-a+uxqQ9j6Lxmq4plbGaNdM9hgDCZyxAv/yvuyF5iWoA2H5icZkqD3rdK155ZQgFLX2lc3NvahHG4OgKpYqYPiQ==",
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
+			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
@@ -1497,6 +2825,12 @@
 				"@types/unist": "*"
 			}
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/unist": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -1821,6 +3155,17 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"micromatch": "^2.1.5",
+				"normalize-path": "^2.0.0"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1837,6 +3182,85 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arr-flatten": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/async-each": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
+			"integrity": "sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true,
+			"license": "(MIT OR Apache-2.0)",
+			"bin": {
+				"atob": "bin/atob.js"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1846,12 +3270,92 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/base/node_modules/define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/base/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/binary-extensions": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/blocking-elements": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/blocking-elements/-/blocking-elements-0.1.1.tgz",
+			"integrity": "sha512-/SLWbEzMoVIMZACCyhD/4Ya2M1PWP1qMKuiymowPcI+PdWDARqeARBjhj73kbUBCxEmTZCUu5TAqxtwUO9C1Ig==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -1862,6 +3366,66 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bruce-esp-web-tools": {
+			"name": "esp-web-tools",
+			"version": "10.1.1",
+			"resolved": "https://github.com/BruceDevices/esp-web-tools/releases/download/1.1.0a/bruce-esp-web-tools.tgz",
+			"integrity": "sha512-jOuCBWohdXCwYlYNCtklQYOzmRdKroBDcTLId4QWuuGyXBiSRxkszoaJ2hDGn1iqsQ2VFA1UpePPBfGqCgvNwA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/web": "^2.2.0",
+				"improv-wifi-serial-sdk": "^2.5.0",
+				"lit": "^3.2.1",
+				"pako": "^2.1.0",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/cache-base/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/callsites": {
@@ -1892,19 +3456,76 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"readdirp": "^4.0.1"
+				"anymatch": "^1.3.0",
+				"async-each": "^1.0.0",
+				"glob-parent": "^2.0.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^2.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^1.0.0"
+			}
+		},
+		"node_modules/class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"engines": {
-				"node": ">= 14.16.0"
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/class-utils/node_modules/define-property": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^0.1.0"
 			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/class-utils/node_modules/is-descriptor": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
+			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-accessor-descriptor": "^1.0.1",
+				"is-data-descriptor": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/class-utils/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/clsx": {
@@ -1914,6 +3535,20 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/color-convert": {
@@ -1936,6 +3571,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/component-emitter": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+			"integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1954,6 +3599,86 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/core-js": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+			"deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT"
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cpx": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+			"integrity": "sha512-jHTjZhsbg9xWgsP2vuNW2jnnzBX+p4T+vNI9Lbjzs1n4KhOfa22bQppiFYLsWQKd8TzmL5aSP/Me3yfsCwXbDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "^6.9.2",
+				"chokidar": "^1.6.0",
+				"duplexer": "^0.1.1",
+				"glob": "^7.0.5",
+				"glob2base": "^0.0.12",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.1",
+				"resolve": "^1.1.7",
+				"safe-buffer": "^5.0.1",
+				"shell-quote": "^1.6.1",
+				"subarg": "^1.0.0"
+			},
+			"bin": {
+				"cpx": "bin/index.js"
+			}
+		},
+		"node_modules/cpx/node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/cross-env": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+			"integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@epic-web/invariant": "^1.0.0",
+				"cross-spawn": "^7.0.6"
+			},
+			"bin": {
+				"cross-env": "dist/bin/cross-env.js",
+				"cross-env-shell": "dist/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -2002,6 +3727,16 @@
 				}
 			}
 		},
+		"node_modules/decode-uri-component": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2013,6 +3748,30 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/define-property/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2032,6 +3791,13 @@
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
 			"integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
+			"license": "MIT"
+		},
+		"node_modules/duplexer": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
@@ -2255,6 +4021,55 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/eslint/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/eslint/node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint/node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -2334,6 +4149,72 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-posix-bracket": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend-shallow/node_modules/is-extendable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-plain-object": "^2.0.4"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2385,6 +4266,48 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/find-index": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+			"integrity": "sha512-uJ5vWrfBKMcE6y2Z8834dwEZj9mNGxYa3t3I53OwFeuZ8D9oc2E5zcsrkuhX6h4iYrjhiv0T3szQmxlAV9uxDg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2423,31 +4346,145 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"for-in": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"map-cache": "^0.2.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+			"deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"nan": "^2.12.1"
+			},
 			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+				"node": ">= 4.0"
 			}
 		},
-		"node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"is-glob": "^4.0.3"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^2.0.0"
+			}
+		},
+		"node_modules/glob2base": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+			"integrity": "sha512-ZyqlgowMbfj2NPjxaZZ/EtsXlOch28FRXgMd64vqZWk1bT9+wvSRLYD1om9M7QfQru51zJPAT17qXm4/zd+9QA==",
+			"dev": true,
+			"dependencies": {
+				"find-index": "^0.1.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/globals": {
@@ -2480,6 +4517,97 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/has-value/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/has-values/node_modules/is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kind-of": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-buffer": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/has-values/node_modules/kind-of": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+			"integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-buffer": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2507,6 +4635,63 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/improv-wifi-serial-sdk": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.5.0.tgz",
+			"integrity": "sha512-aX8rHil24CD1avnB7Tzw5p/xnG7D8LJBDLT9pkCqPLxQQNp1F+EtZo+3wI6loaZUPp6IkMxM/1oRflvLM1aMUg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@material/mwc-button": "^0.27.0",
+				"@material/mwc-circular-progress": "^0.27.0",
+				"@material/mwc-dialog": "^0.27.0",
+				"@material/mwc-icon-button": "^0.27.0",
+				"@material/mwc-list": "^0.27.0",
+				"@material/mwc-select": "^0.27.0",
+				"@material/mwc-textfield": "^0.27.0",
+				"lit": "^2.5.0",
+				"tslib": "^2.4.1"
+			}
+		},
+		"node_modules/improv-wifi-serial-sdk/node_modules/@lit/reactive-element": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+			"integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.0.0"
+			}
+		},
+		"node_modules/improv-wifi-serial-sdk/node_modules/lit": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+			"integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^1.6.0",
+				"lit-element": "^3.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/improv-wifi-serial-sdk/node_modules/lit-element": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+			"integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.1.0",
+				"@lit/reactive-element": "^1.3.0",
+				"lit-html": "^2.8.0"
+			}
+		},
+		"node_modules/improv-wifi-serial-sdk/node_modules/lit-html": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+			"integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2517,10 +4702,138 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/is-accessor-descriptor": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.1.tgz",
+			"integrity": "sha512-YBUanLI8Yoihw923YeFUS5fs0fF2f5TSFTNiYAAzhhDscDa3lEqYuz1pDOEP5KvX94I9ey3vsqjJcLVFVU+3QA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"binary-extensions": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-data-descriptor": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
+			"integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-descriptor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.3.tgz",
+			"integrity": "sha512-JCNNGbwWZEVaSPtS45mdtrneRWJFp07LLmykxeFV5F6oBvNF8vHSfJuJgoT472pSfk+Mf8VnlrspaFBHWM8JAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-accessor-descriptor": "^1.0.1",
+				"is-data-descriptor": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-primitive": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2528,14 +4841,70 @@
 			}
 		},
 		"node_modules/is-glob": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-extglob": "^2.1.1"
+				"is-extglob": "^1.0.0"
 			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kind-of": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-plain-object/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2549,12 +4918,42 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/jiti": {
 			"version": "2.6.1",
@@ -2608,6 +5007,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-buffer": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/kleur": {
@@ -2900,6 +5312,37 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/lit": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^2.1.0",
+				"lit-element": "^4.2.0",
+				"lit-html": "^3.3.0"
+			}
+		},
+		"node_modules/lit-element": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+			"integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.5.0",
+				"@lit/reactive-element": "^2.1.0",
+				"lit-html": "^3.3.0"
+			}
+		},
+		"node_modules/lit-html": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+			"integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -2938,6 +5381,36 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"object-visit": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/math-random": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/mdsvex": {
 			"version": "0.12.6",
 			"resolved": "https://registry.npmjs.org/mdsvex/-/mdsvex-0.12.6.tgz",
@@ -2956,6 +5429,31 @@
 				"svelte": "^3.56.0 || ^4.0.0 || ^5.0.0-next.120"
 			}
 		},
+		"node_modules/micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2967,6 +5465,59 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/mixin-deep": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/mixin-deep/node_modules/is-extendable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-plain-object": "^2.0.4"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mri": {
@@ -2994,6 +5545,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nan": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
+			"integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3012,12 +5571,180 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nanomatch/node_modules/arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nanomatch/node_modules/array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nanomatch/node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"remove-trailing-separator": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-copy/node_modules/define-property": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-copy/node_modules/is-descriptor": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
+			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-accessor-descriptor": "^1.0.1",
+				"is-data-descriptor": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isobject": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-visit/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object.pick/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/obug": {
 			"version": "2.1.1",
@@ -3028,6 +5755,16 @@
 				"https://opencollective.com/debug"
 			],
 			"license": "MIT"
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -3079,6 +5816,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/pako": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+			"integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+			"license": "(MIT AND Zlib)"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3092,6 +5835,32 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3100,6 +5869,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
@@ -3111,6 +5890,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -3128,6 +5914,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -3276,6 +6072,16 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/prettier": {
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
@@ -3399,6 +6205,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3409,18 +6222,436 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+		"node_modules/randomatic": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/randomatic/node_modules/is-number": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+			"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 14.18.0"
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/randomatic/node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/readdirp": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/readdirp/node_modules/arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/braces/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/expand-brackets/node_modules/define-property": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/expand-brackets/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/expand-brackets/node_modules/is-descriptor": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
+			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-accessor-descriptor": "^1.0.1",
+				"is-data-descriptor": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/readdirp/node_modules/extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/extglob/node_modules/define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/extglob/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/fill-range/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kind-of": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/is-number/node_modules/kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-buffer": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-equal-shallow": "^0.1.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/repeat-element": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -3431,6 +6662,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+			"deprecated": "https://github.com/lydell/resolve-url#deprecated",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12"
 			}
 		},
 		"node_modules/rollup": {
@@ -3477,6 +6726,20 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/rollup/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -3487,6 +6750,37 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ret": "~0.1.10"
 			}
 		},
 		"node_modules/semver": {
@@ -3507,6 +6801,35 @@
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
 			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
 			"license": "MIT"
+		},
+		"node_modules/set-value": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/set-value/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -3531,6 +6854,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/shell-quote": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -3545,6 +6881,144 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/snapdragon-node/node_modules/define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/snapdragon-node/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kind-of": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/snapdragon/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/snapdragon/node_modules/define-property": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/snapdragon/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/snapdragon/node_modules/is-descriptor": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
+			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-accessor-descriptor": "^1.0.1",
+				"is-data-descriptor": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/snapdragon/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3553,6 +7027,100 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/source-map-resolve": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+			"deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"atob": "^2.1.2",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"node_modules/source-map-url": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+			"integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+			"deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"extend-shallow": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/static-extend/node_modules/define-property": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-descriptor": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/static-extend/node_modules/is-descriptor": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
+			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-accessor-descriptor": "^1.0.1",
+				"is-data-descriptor": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
@@ -3567,6 +7135,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/subarg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+			"integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.1.0"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3578,6 +7156,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/svelte": {
@@ -3628,6 +7219,36 @@
 			"peerDependencies": {
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"typescript": ">=5.0.0"
+			}
+		},
+		"node_modules/svelte-check/node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/svelte-check/node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
@@ -3711,6 +7332,62 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kind-of": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/to-regex-range/node_modules/is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kind-of": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -3732,6 +7409,12 @@
 			"peerDependencies": {
 				"typescript": ">=4.8.4"
 			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -3782,6 +7465,22 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/union-value": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/unist-util-is": {
@@ -3840,6 +7539,68 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/unset-value/node_modules/has-value": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+			"integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-value": "^2.0.3",
+				"has-values": "^0.1.4",
+				"isobject": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/unset-value/node_modules/has-values": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+			"integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/unset-value/node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3848,6 +7609,24 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
+			"deprecated": "Please see https://github.com/lydell/urix#deprecated",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -3946,6 +7725,20 @@
 				}
 			}
 		},
+		"node_modules/vite/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/vitefu": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
@@ -3981,6 +7774,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/wicg-inert": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.3.tgz",
+			"integrity": "sha512-5L0PKK7iP+0Q/jv2ccgmkz/pfXbumZtlEyWS/xnX+L+Og3f7WjL4+iEs18k4IuldOX3PgGpza3qGndL9xUBjCQ==",
+			"license": "W3C-20150513"
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3989,6 +7788,30 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
+		"lint": "prettier --check . && eslint .",
+		"copy-dist": "mkdirp static/vendor/bruce-esp-web-tools && cpx \"node_modules/bruce-esp-web-tools/dist/**/*\" static/vendor/bruce-esp-web-tools",
+		"prebuild": "npm run copy-dist",
+		"predev": "npm run copy-dist",
+		"postinstall": "npm run copy-dist"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^2.0.0",
@@ -21,11 +25,14 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.3",
 		"@tailwindcss/typography": "^0.5.15",
 		"@tailwindcss/vite": "^4.0.0",
+		"cpx": "^1.5.0",
+		"cross-env": "^10.1.0",
 		"eslint": "^9.18.0",
 		"eslint-config-prettier": "^10.0.1",
 		"eslint-plugin-svelte": "^3.0.0",
 		"globals": "^17.0.0",
 		"mdsvex": "^0.12.6",
+		"mkdirp": "^3.0.1",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.7.2",
@@ -38,7 +45,8 @@
 	},
 	"dependencies": {
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@types/w3c-web-serial": "^1.0.8"
+		"@types/w3c-web-serial": "^1.0.8",
+		"bruce-esp-web-tools": "https://github.com/BruceDevices/esp-web-tools/releases/download/1.1.0a/bruce-esp-web-tools.tgz"
 	},
 	"overrides": {
 		"cookie": "^1.1.1"

--- a/src/routes/flasher/+page.svelte
+++ b/src/routes/flasher/+page.svelte
@@ -160,7 +160,7 @@
 </script>
 
 <svelte:head>
-	<script type="module" src="/esp-web-tools-10.1.1/dist/web/install-button.js?module"></script>
+	<script type="module" src="/vendor/bruce-esp-web-tools/web/install-button.js?module"></script>
 </svelte:head>
 
 <section class="relative flex h-[500px] w-full flex-col overflow-hidden pr-4 pl-4 md:flex-row">


### PR DESCRIPTION
#### Proposed Changes ####

* Migrate to using the custom version of esp-web-tools https://github.com/BruceDevices/esp-web-tools/
  * This version contains the Bruce themed version for better future updates
  * A custom branch https://github.com/BruceDevices/esp-web-tools/tree/manual-esp32-c5-support contains upstream fixes to esp-web-tools, esptool-js and some additional modifications to support changes made in esptool-js which have not yet been made in esp-web-tools

**Related links**

* Updates merged into esp-web-tool main branch (already part of the custom fork
  * https://github.com/esphome/esp-web-tools/commit/728d0ddcb21a0b82fa44ed76afd1b8b4486674d8
* Updates not yet merged to esptool-js
  * https://github.com/espressif/esptool-js/actions/runs/20844149196
* Updates to esp-web-tools to support esptool-js
  * Recent breaking change
    * https://github.com/espressif/esptool-js/commit/3dba2554a01f4edd6320e9953cf4bb61d21e69d5
  * My fix
    * https://github.com/BruceDevices/esp-web-tools/commit/c6573ac8e9d0cb4fa058b2eef9ba4d9b5982bb2d

When the recent upstream changes are merged I will update our custom version.

#### Types of Changes ####

Bugfix

#### Verification ####

**Flashing a C5 in progress*

<img width="658" height="548" alt="image" src="https://github.com/user-attachments/assets/d2eb9de2-b032-42a6-b18c-a99caf91f85b" />


#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
Fixes https://github.com/BruceDevices/firmware/issues/1981

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Web flasher now supports ESP32-C5 devices
```

#### Further Comments ####

