### PR TITLE
Time/Clock Updates

### DIFF
--- a/boards/lilygo-t-lora-pager/pins_arduino.h
+++ b/boards/lilygo-t-lora-pager/pins_arduino.h
@@ -39,7 +39,7 @@
 
 #define IO_EXPANDER_PCA9555
 #define IO_EXP_GPS EXPANDS_GPS_EN
-// Main I2C Bus
+// Main SPI Bus
 #define SPI_SS_PIN 21
 #define SPI_MOSI_PIN 34
 #define SPI_MISO_PIN 33
@@ -167,6 +167,13 @@ static const uint8_t RX = SERIAL_RX;
 // TODO:
 // #define PN532_RF_REST 45
 // #define PN532_IRQ 17
+
+// RTC
+#define HAS_RTC
+#define RTC_SDA GROVE_SDA
+#define RTC_SCL GROVE_SCL
+#define RTC_INTERRUPT_PIN 1
+#define HAS_RTC_PCF85063A
 
 // BadUSB
 #define USB_as_HID 1

--- a/boards/m5stack-cores3/pins_arduino.h
+++ b/boards/m5stack-cores3/pins_arduino.h
@@ -63,6 +63,7 @@ static const uint8_t ADC = 10;
 #define HAS_RTC
 #define RTC_SDA 12
 #define RTC_SCL 11
+#define HAS_RTC_BM8563
 
 #define USB_as_HID
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -20,15 +20,20 @@
 #include <LittleFS.h>
 #include <NTPClient.h>
 #include <SPI.h>
-#include <Timezone.h>
 #include <functional>
 #include <io_expander/io_expander.h> // ./lib/HAL
 #include <vector>
 extern io_expander ioExpander;
 
 #if defined(HAS_RTC)
+#if defined(HAS_RTC_BM8563)
 #include "../lib/RTC/cplus_RTC.h"
 extern cplus_RTC _rtc;
+#endif
+#if defined(HAS_RTC_PCF85063A)
+#include "../lib/RTC/pcf85063_RTC.h"
+extern pcf85063_RTC _rtc;
+#endif
 extern RTC_TimeTypeDef _time;
 extern RTC_DateTypeDef _date;
 #endif
@@ -78,7 +83,6 @@ extern time_t localTime;
 extern struct tm *timeInfo;
 extern ESP32Time rtc;
 extern NTPClient timeClient;
-extern Timezone myTZ;
 
 extern int prog_handler; // 0 - Flash, 1 - LittleFS, 2 - Download
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -70,7 +70,7 @@ extern SerialDevice *serialDevice;
 extern USBSerial USBserial;
 extern StartupApp startupApp;
 
-extern char timeStr[10];
+extern char timeStr[12];
 extern SPIClass sdcardSPI;
 extern SPIClass CC_NRF_SPI;
 extern bool clock_set;

--- a/lib/RTC/cplus_RTC.cpp
+++ b/lib/RTC/cplus_RTC.cpp
@@ -8,9 +8,7 @@
 #ifndef RTC_SCL
 #define RTC_SCL 22
 #endif
-void cplus_RTC::begin(void) {
-    wr->begin(RTC_SDA, RTC_SCL);
-}
+void cplus_RTC::begin(void) { wr->begin(RTC_SDA, RTC_SCL); }
 
 void cplus_RTC::GetBm8563Time(void) {
     wr->beginTransmission(0x51);
@@ -35,7 +33,7 @@ void cplus_RTC::GetBm8563Time(void) {
 void cplus_RTC::Str2Time(void) {
     Second = (asc[0] - 0x30) * 10 + asc[1] - 0x30;
     Minute = (asc[2] - 0x30) * 10 + asc[3] - 0x30;
-    Hour   = (asc[4] - 0x30) * 10 + asc[5] - 0x30;
+    Hour = (asc[4] - 0x30) * 10 + asc[5] - 0x30;
     /*
     uint8_t Hour;
     uint8_t Week;
@@ -46,15 +44,15 @@ void cplus_RTC::Str2Time(void) {
 }
 
 void cplus_RTC::DataMask() {
-    trdata[0] = trdata[0] & 0x7f;  //秒
-    trdata[1] = trdata[1] & 0x7f;  //分
-    trdata[2] = trdata[2] & 0x3f;  //时
+    trdata[0] = trdata[0] & 0x7f; // 秒
+    trdata[1] = trdata[1] & 0x7f; // 分
+    trdata[2] = trdata[2] & 0x3f; // 时
 
-    trdata[3] = trdata[3] & 0x3f;  //日
-    trdata[4] = trdata[4] & 0x07;  //星期
-    trdata[5] = trdata[5] & 0x1f;  //月
+    trdata[3] = trdata[3] & 0x3f; // 日
+    trdata[4] = trdata[4] & 0x07; // 星期
+    trdata[5] = trdata[5] & 0x1f; // 月
 
-    trdata[6] = trdata[6] & 0xff;  //年
+    trdata[6] = trdata[6] & 0xff; // 年
 }
 /********************************************************************
 函 数 名： void Bcd2asc(void)
@@ -67,15 +65,14 @@ void cplus_RTC::DataMask() {
 void cplus_RTC::Bcd2asc(void) {
     uint8_t i, j;
     for (j = 0, i = 0; i < 7; i++) {
-        asc[j++] =
-            (trdata[i] & 0xf0) >> 4 | 0x30; /*格式为: 秒 分 时 日 月 星期 年 */
+        asc[j++] = (trdata[i] & 0xf0) >> 4 | 0x30; /*格式为: 秒 分 时 日 月 星期 年 */
         asc[j++] = (trdata[i] & 0x0f) | 0x30;
     }
 }
 
 uint8_t cplus_RTC::Bcd2ToByte(uint8_t Value) {
     uint8_t tmp = 0;
-    tmp         = ((uint8_t)(Value & (uint8_t)0xF0) >> (uint8_t)0x4) * 10;
+    tmp = ((uint8_t)(Value & (uint8_t)0xF0) >> (uint8_t)0x4) * 10;
     return (tmp + (Value & (uint8_t)0x0F));
 }
 
@@ -90,7 +87,7 @@ uint8_t cplus_RTC::ByteToBcd2(uint8_t Value) {
     return ((uint8_t)(bcdhigh << 4) | Value);
 }
 
-void cplus_RTC::GetTime(RTC_TimeTypeDef* RTC_TimeStruct) {
+void cplus_RTC::GetTime(RTC_TimeTypeDef *RTC_TimeStruct) {
     // if()
     uint8_t buf[3] = {0};
 
@@ -105,12 +102,12 @@ void cplus_RTC::GetTime(RTC_TimeTypeDef* RTC_TimeStruct) {
         buf[2] = wr->read();
     }
 
-    RTC_TimeStruct->Seconds = Bcd2ToByte(buf[0] & 0x7f);  //秒
-    RTC_TimeStruct->Minutes = Bcd2ToByte(buf[1] & 0x7f);  //分
-    RTC_TimeStruct->Hours   = Bcd2ToByte(buf[2] & 0x3f);  //时
+    RTC_TimeStruct->Seconds = Bcd2ToByte(buf[0] & 0x7f); // 秒
+    RTC_TimeStruct->Minutes = Bcd2ToByte(buf[1] & 0x7f); // 分
+    RTC_TimeStruct->Hours = Bcd2ToByte(buf[2] & 0x3f);   // 时
 }
 
-void cplus_RTC::SetTime(RTC_TimeTypeDef* RTC_TimeStruct) {
+void cplus_RTC::SetTime(RTC_TimeTypeDef *RTC_TimeStruct) {
     if (RTC_TimeStruct == NULL) return;
 
     wr->beginTransmission(0x51);
@@ -121,7 +118,7 @@ void cplus_RTC::SetTime(RTC_TimeTypeDef* RTC_TimeStruct) {
     wr->endTransmission();
 }
 
-void cplus_RTC::GetDate(RTC_DateTypeDef* RTC_DateStruct) {
+void cplus_RTC::GetDate(RTC_DateTypeDef *RTC_DateStruct) {
     uint8_t buf[4] = {0};
 
     wr->beginTransmission(0x51);
@@ -136,9 +133,9 @@ void cplus_RTC::GetDate(RTC_DateTypeDef* RTC_DateStruct) {
         buf[3] = wr->read();
     }
 
-    RTC_DateStruct->Date    = Bcd2ToByte(buf[0] & 0x3f);
+    RTC_DateStruct->Date = Bcd2ToByte(buf[0] & 0x3f);
     RTC_DateStruct->WeekDay = Bcd2ToByte(buf[1] & 0x07);
-    RTC_DateStruct->Month   = Bcd2ToByte(buf[2] & 0x1f);
+    RTC_DateStruct->Month = Bcd2ToByte(buf[2] & 0x1f);
 
     if (buf[2] & 0x80) {
         RTC_DateStruct->Year = 1900 + Bcd2ToByte(buf[3] & 0xff);
@@ -147,7 +144,7 @@ void cplus_RTC::GetDate(RTC_DateTypeDef* RTC_DateStruct) {
     }
 }
 
-void cplus_RTC::SetDate(RTC_DateTypeDef* RTC_DateStruct) {
+void cplus_RTC::SetDate(RTC_DateTypeDef *RTC_DateStruct) {
     if (RTC_DateStruct == NULL) return;
     wr->beginTransmission(0x51);
     wr->write(0x05);
@@ -167,67 +164,83 @@ void cplus_RTC::SetDate(RTC_DateTypeDef* RTC_DateStruct) {
     wr->endTransmission();
 }
 
-
-
-
-
 void cplus_RTC::WriteReg(uint8_t reg, uint8_t data) {
-  wr->beginTransmission(0x51);
-  wr->write(reg);
-  wr->write(data);
-  wr->endTransmission();
+    wr->beginTransmission(0x51);
+    wr->write(reg);
+    wr->write(data);
+    wr->endTransmission();
 }
 
 uint8_t cplus_RTC::ReadReg(uint8_t reg) {
-  wr->beginTransmission(0x51);
-  wr->write(reg);
-  wr->endTransmission(false);
-  wr->requestFrom(0x51, 1);
-  return wr->read();
+    wr->beginTransmission(0x51);
+    wr->write(reg);
+    wr->endTransmission(false);
+    wr->requestFrom(0x51, 1);
+    return wr->read();
 }
-
 
 int cplus_RTC::SetAlarmIRQ(int afterSeconds) {
-  uint8_t reg_value = 0;
-  reg_value = ReadReg(0x01);
-  printf("read 0x%X\n", reg_value);
+    uint8_t reg_value = 0;
+    reg_value = ReadReg(0x01);
+    printf("read 0x%X\n", reg_value);
 
-  if (afterSeconds < 0) {
-    reg_value &= ~(1 << 0);
+    if (afterSeconds < 0) {
+        reg_value &= ~(1 << 0);
+        WriteReg(0x01, reg_value);
+        reg_value = 0x03;
+        WriteReg(0x0E, reg_value);
+        return -1;
+    }
+
+    uint8_t type_value = 2;
+    uint8_t div = 1;
+    if (afterSeconds > 255) {
+        div = 60;
+        type_value = 0x83;
+    } else {
+        type_value = 0x82;
+    }
+
+    afterSeconds = (afterSeconds / div) & 0xFF;
+    WriteReg(0x0F, afterSeconds);
+    WriteReg(0x0E, type_value);
+
+    reg_value |= (1 << 0);
+    reg_value &= ~(1 << 7);
     WriteReg(0x01, reg_value);
-    reg_value = 0x03;
-    WriteReg(0x0E, reg_value);
-    return -1;
-  }
-
-  uint8_t type_value = 2;
-  uint8_t div = 1;
-  if (afterSeconds > 255) {
-    div = 60;
-    type_value = 0x83;
-  } else {
-    type_value = 0x82;
-  }
-
-  afterSeconds = (afterSeconds / div) & 0xFF;
-  WriteReg(0x0F, afterSeconds);
-  WriteReg(0x0E, type_value);
-
-  reg_value |= (1 << 0);
-  reg_value &= ~(1 << 7);
-  WriteReg(0x01, reg_value);
-  return afterSeconds * div;
+    return afterSeconds * div;
 }
-
 
 void cplus_RTC::clearIRQ() {
-  uint8_t data = ReadReg(0x01);
-  WriteReg(0x01, data & 0xf3);
+    uint8_t data = ReadReg(0x01);
+    WriteReg(0x01, data & 0xf3);
 }
 void cplus_RTC::disableIRQ() {
-  clearIRQ();
-  uint8_t data = ReadReg(0x01);
-  WriteReg(0x01, data & 0xfC);
+    clearIRQ();
+    uint8_t data = ReadReg(0x01);
+    WriteReg(0x01, data & 0xfC);
 }
 
+struct tm cplus_RTC::getTimeStruct() {
+    RTC_TimeTypeDef timeStruct;
+    RTC_DateTypeDef dateStruct;
+    struct tm timeinfo = {0};
 
+    // Get current time and date from RTC
+    GetTime(&timeStruct);
+    GetDate(&dateStruct);
+
+    // Populate tm structure
+    timeinfo.tm_sec = timeStruct.Seconds;
+    timeinfo.tm_min = timeStruct.Minutes;
+    timeinfo.tm_hour = timeStruct.Hours;
+    timeinfo.tm_mday = dateStruct.Date;
+    timeinfo.tm_mon = dateStruct.Month - 1;    // tm_mon is 0-11, RTC month is 1-12
+    timeinfo.tm_year = dateStruct.Year - 1900; // tm_year is years since 1900
+    timeinfo.tm_wday = dateStruct.WeekDay;
+
+    // Calculate day of year
+    mktime(&timeinfo); // This normalizes the struct and calculates tm_yday
+
+    return timeinfo;
+}

--- a/lib/RTC/cplus_RTC.h
+++ b/lib/RTC/cplus_RTC.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Wire.h>
+#include <time.h>
 
 typedef struct {
     uint8_t Hours;
@@ -16,19 +17,20 @@ typedef struct {
 } RTC_DateTypeDef;
 
 class cplus_RTC {
-   public:
+public:
     // cplus_RTC();
 
     void begin(void);
-    void setWire(TwoWire* obj) { wr = obj; }
+    void setWire(TwoWire *obj) { wr = obj; }
     void GetBm8563Time(void);
 
-    void SetTime(RTC_TimeTypeDef* RTC_TimeStruct);
-    void SetDate(RTC_DateTypeDef* RTC_DateStruct);
+    void SetTime(RTC_TimeTypeDef *RTC_TimeStruct);
+    void SetDate(RTC_DateTypeDef *RTC_DateStruct);
 
-    void GetTime(RTC_TimeTypeDef* RTC_TimeStruct);
-    void GetDate(RTC_DateTypeDef* RTC_DateStruct);
+    void GetTime(RTC_TimeTypeDef *RTC_TimeStruct);
+    void GetDate(RTC_DateTypeDef *RTC_DateStruct);
 
+    struct tm getTimeStruct();
 
     void WriteReg(uint8_t reg, uint8_t data);
     uint8_t ReadReg(uint8_t reg);
@@ -38,7 +40,7 @@ class cplus_RTC {
     void clearIRQ();
     void disableIRQ();
 
-   public:
+public:
     uint8_t Second;
     uint8_t Minute;
     uint8_t Hour;
@@ -51,7 +53,7 @@ class cplus_RTC {
 
     uint8_t asc[14];
 
-   private:
+private:
     TwoWire *wr = &Wire1; // Default I2C bus for StickCPluses
     void Bcd2asc(void);
     void DataMask();
@@ -60,11 +62,9 @@ class cplus_RTC {
     uint8_t Bcd2ToByte(uint8_t Value);
     uint8_t ByteToBcd2(uint8_t Value);
 
-   private:
+private:
     /*定义数组用来存储读取的时间数据 */
     uint8_t trdata[7];
     /*定义数组用来存储转换的 asc 码时间数据*/
     // uint8_t asc[14];
 };
-
-

--- a/lib/RTC/pcf85063_RTC.cpp
+++ b/lib/RTC/pcf85063_RTC.cpp
@@ -1,0 +1,270 @@
+#include "pcf85063_RTC.h"
+
+#ifndef RTC_SDA
+#define RTC_SDA 21
+#endif
+#ifndef RTC_SCL
+#define RTC_SCL 22
+#endif
+
+void pcf85063_RTC::begin(void) {
+    wr->begin(RTC_SDA, RTC_SCL);
+
+    // Initialize PCF85063 with basic settings
+    // Reset oscillator stop flag and enable normal operation
+    uint8_t ctrl1 = ReadReg(PCF85063_REG_CTRL1);
+    ctrl1 &= ~0x20; // Clear OSF (Oscillator Stop Flag)
+    WriteReg(PCF85063_REG_CTRL1, ctrl1);
+}
+
+void pcf85063_RTC::GetPcf85063Time(void) {
+    wr->beginTransmission(PCF85063_ADDR);
+    wr->write(PCF85063_REG_SC);
+    wr->endTransmission();
+    wr->requestFrom(PCF85063_ADDR, 7);
+
+    while (wr->available()) {
+        trdata[0] = wr->read(); // Seconds
+        trdata[1] = wr->read(); // Minutes
+        trdata[2] = wr->read(); // Hours
+        trdata[3] = wr->read(); // Day of month
+        trdata[4] = wr->read(); // Day of week
+        trdata[5] = wr->read(); // Month
+        trdata[6] = wr->read(); // Year
+    }
+
+    DataMask();
+    Bcd2asc();
+    Str2Time();
+}
+
+void pcf85063_RTC::Str2Time(void) {
+    Second = (asc[0] - 0x30) * 10 + asc[1] - 0x30;
+    Minute = (asc[2] - 0x30) * 10 + asc[3] - 0x30;
+    Hour = (asc[4] - 0x30) * 10 + asc[5] - 0x30;
+}
+
+void pcf85063_RTC::DataMask() {
+    trdata[0] = trdata[0] & 0x7F; // Seconds (bit 7 is OS - Oscillator Stop)
+    trdata[1] = trdata[1] & 0x7F; // Minutes (bit 7 unused)
+    trdata[2] = trdata[2] & 0x3F; // Hours (bits 7-6 unused)
+    trdata[3] = trdata[3] & 0x3F; // Day of month (bits 7-6 unused)
+    trdata[4] = trdata[4] & 0x07; // Day of week (bits 7-3 unused)
+    trdata[5] = trdata[5] & 0x1F; // Month (bits 7-5 unused)
+    trdata[6] = trdata[6] & 0xFF; // Year (all bits used)
+}
+
+void pcf85063_RTC::Bcd2asc(void) {
+    uint8_t i, j;
+    for (j = 0, i = 0; i < 7; i++) {
+        asc[j++] = (trdata[i] & 0xF0) >> 4 | 0x30;
+        asc[j++] = (trdata[i] & 0x0F) | 0x30;
+    }
+}
+
+uint8_t pcf85063_RTC::Bcd2ToByte(uint8_t Value) {
+    uint8_t tmp = 0;
+    tmp = ((uint8_t)(Value & (uint8_t)0xF0) >> (uint8_t)0x4) * 10;
+    return (tmp + (Value & (uint8_t)0x0F));
+}
+
+uint8_t pcf85063_RTC::ByteToBcd2(uint8_t Value) {
+    uint8_t bcdhigh = 0;
+
+    while (Value >= 10) {
+        bcdhigh++;
+        Value -= 10;
+    }
+
+    return ((uint8_t)(bcdhigh << 4) | Value);
+}
+
+void pcf85063_RTC::GetTime(RTC_TimeTypeDef *RTC_TimeStruct) {
+    uint8_t buf[3] = {0};
+
+    wr->beginTransmission(PCF85063_ADDR);
+    wr->write(PCF85063_REG_SC);
+    wr->endTransmission();
+    wr->requestFrom(PCF85063_ADDR, 3);
+
+    while (wr->available()) {
+        buf[0] = wr->read(); // Seconds
+        buf[1] = wr->read(); // Minutes
+        buf[2] = wr->read(); // Hours
+    }
+
+    RTC_TimeStruct->Seconds = Bcd2ToByte(buf[0] & 0x7F);
+    RTC_TimeStruct->Minutes = Bcd2ToByte(buf[1] & 0x7F);
+    RTC_TimeStruct->Hours = Bcd2ToByte(buf[2] & 0x3F);
+}
+
+void pcf85063_RTC::SetTime(RTC_TimeTypeDef *RTC_TimeStruct) {
+    if (RTC_TimeStruct == NULL) return;
+
+    // Stop the clock to ensure atomic update
+    uint8_t ctrl1 = ReadReg(PCF85063_REG_CTRL1);
+    WriteReg(PCF85063_REG_CTRL1, ctrl1 | 0x20); // Set STOP bit
+
+    wr->beginTransmission(PCF85063_ADDR);
+    wr->write(PCF85063_REG_SC);
+    wr->write(ByteToBcd2(RTC_TimeStruct->Seconds) & 0x7F); // Clear OS bit
+    wr->write(ByteToBcd2(RTC_TimeStruct->Minutes));
+    wr->write(ByteToBcd2(RTC_TimeStruct->Hours));
+    wr->endTransmission();
+
+    // Restart the clock
+    WriteReg(PCF85063_REG_CTRL1, ctrl1 & 0xDF); // Clear STOP bit
+}
+
+void pcf85063_RTC::GetDate(RTC_DateTypeDef *RTC_DateStruct) {
+    uint8_t buf[4] = {0};
+
+    wr->beginTransmission(PCF85063_ADDR);
+    wr->write(PCF85063_REG_DM);
+    wr->endTransmission();
+    wr->requestFrom(PCF85063_ADDR, 4);
+
+    while (wr->available()) {
+        buf[0] = wr->read(); // Day of month
+        buf[1] = wr->read(); // Day of week
+        buf[2] = wr->read(); // Month
+        buf[3] = wr->read(); // Year
+    }
+
+    RTC_DateStruct->Date = Bcd2ToByte(buf[0] & 0x3F);
+    RTC_DateStruct->WeekDay = Bcd2ToByte(buf[1] & 0x07);
+    RTC_DateStruct->Month = Bcd2ToByte(buf[2] & 0x1F);
+    RTC_DateStruct->Year = 2000 + Bcd2ToByte(buf[3] & 0xFF); // PCF85063 only supports 2000-2099
+}
+
+void pcf85063_RTC::SetDate(RTC_DateTypeDef *RTC_DateStruct) {
+    if (RTC_DateStruct == NULL) return;
+
+    // Stop the clock to ensure atomic update
+    uint8_t ctrl1 = ReadReg(PCF85063_REG_CTRL1);
+    WriteReg(PCF85063_REG_CTRL1, ctrl1 | 0x20); // Set STOP bit
+
+    wr->beginTransmission(PCF85063_ADDR);
+    wr->write(PCF85063_REG_DM);
+    wr->write(ByteToBcd2(RTC_DateStruct->Date));
+    wr->write(ByteToBcd2(RTC_DateStruct->WeekDay));
+    wr->write(ByteToBcd2(RTC_DateStruct->Month));
+    wr->write(ByteToBcd2((uint8_t)(RTC_DateStruct->Year % 100))); // PCF85063 year is 00-99
+    wr->endTransmission();
+
+    // Restart the clock
+    WriteReg(PCF85063_REG_CTRL1, ctrl1 & 0xDF); // Clear STOP bit
+}
+
+void pcf85063_RTC::WriteReg(uint8_t reg, uint8_t data) {
+    wr->beginTransmission(PCF85063_ADDR);
+    wr->write(reg);
+    wr->write(data);
+    wr->endTransmission();
+}
+
+uint8_t pcf85063_RTC::ReadReg(uint8_t reg) {
+    wr->beginTransmission(PCF85063_ADDR);
+    wr->write(reg);
+    wr->endTransmission(false);
+    wr->requestFrom(PCF85063_ADDR, 1);
+    return wr->read();
+}
+
+int pcf85063_RTC::SetAlarmIRQ(int afterSeconds) {
+    // Clear any existing alarm interrupt
+    uint8_t ctrl2 = ReadReg(PCF85063_REG_CTRL2);
+
+    if (afterSeconds < 0) {
+        // Disable alarm
+        ctrl2 &= ~0x80; // Clear AIE (Alarm Interrupt Enable)
+        WriteReg(PCF85063_REG_CTRL2, ctrl2);
+        return -1;
+    }
+
+    // PCF85063 timer setup - use countdown timer for alarm functionality
+    // Timer can count seconds (0-255) or minutes (0-255)
+    uint8_t timer_mode;
+    uint8_t timer_value;
+
+    if (afterSeconds > 255) {
+        // Use minute timer
+        timer_value = (afterSeconds / 60) & 0xFF;
+        timer_mode = 0x92; // Timer enabled, source clock = 1/60 Hz, interrupt enabled
+        afterSeconds = timer_value * 60;
+    } else {
+        // Use second timer
+        timer_value = afterSeconds & 0xFF;
+        timer_mode = 0x91; // Timer enabled, source clock = 1 Hz, interrupt enabled
+    }
+
+    WriteReg(PCF85063_REG_TIMER_VALUE, timer_value);
+    WriteReg(PCF85063_REG_TIMER_MODE, timer_mode);
+
+    // Enable timer interrupt
+    ctrl2 |= 0x01; // Set TIE (Timer Interrupt Enable)
+    WriteReg(PCF85063_REG_CTRL2, ctrl2);
+
+    return afterSeconds;
+}
+
+void pcf85063_RTC::clearIRQ() {
+    uint8_t ctrl2 = ReadReg(PCF85063_REG_CTRL2);
+    ctrl2 &= 0x7D; // Clear TF and AF flags
+    WriteReg(PCF85063_REG_CTRL2, ctrl2);
+}
+
+void pcf85063_RTC::disableIRQ() {
+    clearIRQ();
+    uint8_t ctrl2 = ReadReg(PCF85063_REG_CTRL2);
+    ctrl2 &= 0x7E; // Clear TIE and AIE
+    WriteReg(PCF85063_REG_CTRL2, ctrl2);
+}
+
+// PCF85063 specific functions
+void pcf85063_RTC::setClockOutput(uint8_t frequency) {
+    uint8_t ctrl2 = ReadReg(PCF85063_REG_CTRL2);
+    ctrl2 &= 0xF8; // Clear COF bits
+    ctrl2 |= (frequency & 0x07);
+    WriteReg(PCF85063_REG_CTRL2, ctrl2);
+}
+
+void pcf85063_RTC::setBatteryLowDetection(bool enable) {
+    uint8_t ctrl1 = ReadReg(PCF85063_REG_CTRL1);
+    if (enable) {
+        ctrl1 |= 0x04; // Set BLF bit
+    } else {
+        ctrl1 &= 0xFB; // Clear BLF bit
+    }
+    WriteReg(PCF85063_REG_CTRL1, ctrl1);
+}
+
+void pcf85063_RTC::reset() {
+    // Software reset - clear all registers to default values
+    WriteReg(PCF85063_REG_CTRL1, 0x58); // Default value with software reset
+    delay(10);                          // Give time for reset
+}
+
+struct tm pcf85063_RTC::getTimeStruct() {
+    RTC_TimeTypeDef timeStruct;
+    RTC_DateTypeDef dateStruct;
+    struct tm timeinfo = {0};
+
+    // Get current time and date from RTC
+    GetTime(&timeStruct);
+    GetDate(&dateStruct);
+
+    // Populate tm structure
+    timeinfo.tm_sec = timeStruct.Seconds;
+    timeinfo.tm_min = timeStruct.Minutes;
+    timeinfo.tm_hour = timeStruct.Hours;
+    timeinfo.tm_mday = dateStruct.Date;
+    timeinfo.tm_mon = dateStruct.Month - 1;    // tm_mon is 0-11, RTC month is 1-12
+    timeinfo.tm_year = dateStruct.Year - 1900; // tm_year is years since 1900
+    timeinfo.tm_wday = dateStruct.WeekDay;
+
+    // Calculate day of year
+    mktime(&timeinfo); // This normalizes the struct and calculates tm_yday
+
+    return timeinfo;
+}

--- a/lib/RTC/pcf85063_RTC.h
+++ b/lib/RTC/pcf85063_RTC.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <Wire.h>
+#include <time.h>
+
+typedef struct {
+    uint8_t Hours;
+    uint8_t Minutes;
+    uint8_t Seconds;
+} RTC_TimeTypeDef;
+
+typedef struct {
+    uint8_t WeekDay;
+    uint8_t Month;
+    uint8_t Date;
+    uint16_t Year;
+} RTC_DateTypeDef;
+
+class pcf85063_RTC {
+public:
+    void begin(void);
+    void setWire(TwoWire *obj) { wr = obj; }
+    void GetPcf85063Time(void);
+
+    void SetTime(RTC_TimeTypeDef *RTC_TimeStruct);
+    void SetDate(RTC_DateTypeDef *RTC_DateStruct);
+
+    void GetTime(RTC_TimeTypeDef *RTC_TimeStruct);
+    void GetDate(RTC_DateTypeDef *RTC_DateStruct);
+
+    struct tm getTimeStruct();
+
+    void WriteReg(uint8_t reg, uint8_t data);
+    uint8_t ReadReg(uint8_t reg);
+
+    int SetAlarmIRQ(int afterSeconds);
+    void clearIRQ();
+    void disableIRQ();
+
+    // PCF85063 specific functions
+    void setClockOutput(
+        uint8_t frequency
+    ); // 0=32.768kHz, 1=16.384kHz, 2=8.192kHz, 3=4.096kHz, 4=2.048kHz, 5=1.024kHz, 6=1Hz, 7=disabled
+    void setBatteryLowDetection(bool enable);
+    void reset();
+
+public:
+    uint8_t Second;
+    uint8_t Minute;
+    uint8_t Hour;
+    uint8_t Week;
+    uint8_t Day;
+    uint8_t Month;
+    uint8_t Year;
+    uint8_t DateString[9];
+    uint8_t TimeString[9];
+
+    uint8_t asc[14];
+
+private:
+    TwoWire *wr = &Wire;
+    void Bcd2asc(void);
+    void DataMask();
+    void Str2Time(void);
+
+    uint8_t Bcd2ToByte(uint8_t Value);
+    uint8_t ByteToBcd2(uint8_t Value);
+
+private:
+    // PCF85063 I2C address
+    static constexpr uint8_t PCF85063_ADDR = 0x51;
+
+    // PCF85063 Register addresses
+    static constexpr uint8_t PCF85063_REG_CTRL1 = 0x00;
+    static constexpr uint8_t PCF85063_REG_CTRL2 = 0x01;
+    static constexpr uint8_t PCF85063_REG_OFFSET = 0x02;
+    static constexpr uint8_t PCF85063_REG_RAM_BYTE = 0x03;
+    static constexpr uint8_t PCF85063_REG_SC = 0x04; // Seconds
+    static constexpr uint8_t PCF85063_REG_MN = 0x05; // Minutes
+    static constexpr uint8_t PCF85063_REG_HR = 0x06; // Hours
+    static constexpr uint8_t PCF85063_REG_DM = 0x07; // Day of month
+    static constexpr uint8_t PCF85063_REG_DW = 0x08; // Day of week
+    static constexpr uint8_t PCF85063_REG_MO = 0x09; // Month
+    static constexpr uint8_t PCF85063_REG_YR = 0x0A; // Year
+    static constexpr uint8_t PCF85063_REG_SECOND_ALARM = 0x0B;
+    static constexpr uint8_t PCF85063_REG_MINUTE_ALARM = 0x0C;
+    static constexpr uint8_t PCF85063_REG_HOUR_ALARM = 0x0D;
+    static constexpr uint8_t PCF85063_REG_DAY_ALARM = 0x0E;
+    static constexpr uint8_t PCF85063_REG_WEEKDAY_ALARM = 0x0F;
+    static constexpr uint8_t PCF85063_REG_TIMER_VALUE = 0x10;
+    static constexpr uint8_t PCF85063_REG_TIMER_MODE = 0x11;
+
+    /*定义数组用来存储读取的时间数据 */
+    uint8_t trdata[7];
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -147,7 +147,6 @@ lib_deps =
 	https://github.com/whywilson/ESP-PN532-UART
 	https://github.com/whywilson/ESP-PN532Killer
 	NTPClient
-	Timezone
 	ESP32Time
 	FFat
 	bblanchon/ArduinoJson
@@ -218,7 +217,6 @@ lib_deps =
 	;https://github.com/whywilson/ESP-PN532-UART@^0.0.2
 	;https://github.com/whywilson/ESP-PN532Killer#079790e
 	NTPClient
-	Timezone
 	ESP32Time
 	FFat
 	bblanchon/ArduinoJson

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -14,7 +14,10 @@ JsonDocument BruceConfig::toJson() const {
 
     setting["dimmerSet"] = dimmerSet;
     setting["bright"] = bright;
+    setting["automaticTimeUpdateViaNTP"] = automaticTimeUpdateViaNTP;
     setting["tmz"] = tmz;
+    setting["dst"] = dst;
+    setting["clock24hr"] = clock24hr;
     setting["soundEnabled"] = soundEnabled;
     setting["soundVolume"] = soundVolume;
     setting["wifiAtStartup"] = wifiAtStartup;
@@ -155,8 +158,26 @@ void BruceConfig::fromFile(bool checkFS) {
         count++;
         log_e("Fail");
     }
+    if (!setting["automaticTimeUpdateViaNTP"].isNull()) {
+        automaticTimeUpdateViaNTP = setting["automaticTimeUpdateViaNTP"].as<bool>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
     if (!setting["tmz"].isNull()) {
         tmz = setting["tmz"].as<float>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
+    if (!setting["dst"].isNull()) {
+        dst = setting["dst"].as<bool>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
+    if (!setting["clock24hr"].isNull()) {
+        clock24hr = setting["clock24hr"].as<bool>();
     } else {
         count++;
         log_e("Fail");
@@ -455,6 +476,11 @@ void BruceConfig::validateBrightValue() {
     if (bright > 100) bright = 100;
 }
 
+void BruceConfig::setAutomaticTimeUpdateViaNTP(bool value) {
+    automaticTimeUpdateViaNTP = value;
+    saveFile();
+}
+
 void BruceConfig::setTmz(float value) {
     tmz = value;
     validateTmzValue();
@@ -463,6 +489,16 @@ void BruceConfig::setTmz(float value) {
 
 void BruceConfig::validateTmzValue() {
     if (tmz < -12 || tmz > 14) tmz = 0;
+}
+
+void BruceConfig::setDST(bool value) {
+    dst = value;
+    saveFile();
+}
+
+void BruceConfig::setClock24Hr(bool value) {
+    clock24hr = value;
+    saveFile();
 }
 
 void BruceConfig::setSoundEnabled(int value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -38,7 +38,10 @@ public:
     //  Settings
     int dimmerSet = 10;
     int bright = 100;
+    bool automaticTimeUpdateViaNTP = true;
     float tmz = 0;
+    bool dst = false;
+    bool clock24hr = true;
     int soundEnabled = 1;
     int soundVolume = 100;
     int wifiAtStartup = 0;
@@ -114,8 +117,11 @@ public:
     void validateDimmerValue();
     void setBright(uint8_t value);
     void validateBrightValue();
+    void setAutomaticTimeUpdateViaNTP(bool value);
     void setTmz(float value);
     void validateTmzValue();
+    void setDST(bool value);
+    void setClock24Hr(bool value);
     void setSoundEnabled(int value);
     void setSoundVolume(int value);
     void validateSoundEnabledValue();

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -793,13 +793,9 @@ void drawStatusBar() {
         setTftDisplay(12, 12, bruceConfig.priColor, clock_fontsize, bruceConfig.bgColor);
         tft.fillRect(12, 12, 100, clock_fontsize * LH, bruceConfig.bgColor);
 #if defined(HAS_RTC)
-        _rtc.GetTime(&_time);
-        snprintf(timeStr, sizeof(timeStr), "%02d:%02d", _time.Hours, _time.Minutes);
-        tft.print(timeStr);
+        updateTimeStr(_rtc.getTimeStruct());
 #else
         updateTimeStr(rtc.getTimeStruct());
-        tft.fillRect(12, 12, 100, clock_fontsize * LH, bruceConfig.bgColor);
-        tft.print(timeStr);
 #endif
         tft.print(timeStr);
     } else {

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -791,6 +791,7 @@ void drawStatusBar() {
     if (clock_set) {
         int clock_fontsize = 1; // Font size of the clock / BRUCE + BRUCE_VERSION
         setTftDisplay(12, 12, bruceConfig.priColor, clock_fontsize, bruceConfig.bgColor);
+        tft.fillRect(12, 12, 100, clock_fontsize * LH, bruceConfig.bgColor);
 #if defined(HAS_RTC)
         _rtc.GetTime(&_time);
         snprintf(timeStr, sizeof(timeStr), "%02d:%02d", _time.Hours, _time.Minutes);
@@ -800,6 +801,7 @@ void drawStatusBar() {
         tft.fillRect(12, 12, 100, clock_fontsize * LH, bruceConfig.bgColor);
         tft.print(timeStr);
 #endif
+        tft.print(timeStr);
     } else {
         setTftDisplay(12, 12, bruceConfig.priColor, 1, bruceConfig.bgColor);
         tft.print("BRUCE " + String(BRUCE_VERSION));

--- a/src/core/serial_commands/screen_commands.cpp
+++ b/src/core/serial_commands/screen_commands.cpp
@@ -84,8 +84,7 @@ uint32_t hexColorCallback(cmd *c) {
 
 uint32_t clockCallback(cmd *c) {
 #if defined(HAS_RTC)
-    _rtc.GetTime(&_time);
-    snprintf(timeStr, sizeof(timeStr), "%02d:%02d", _time.Hours, _time.Minutes);
+    updateTimeStr(_rtc.getTimeStruct());
     serialDevice->printf("\nCurrent time: %s", timeStr);
 #else
     updateTimeStr(rtc.getTimeStruct());

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -756,7 +756,12 @@ NTPClient timeClient(ntpUDP, ntpServer, 0, 0);
 void setClock() {
 #if defined(HAS_RTC)
     RTC_TimeTypeDef TimeStruct;
+#if defined(HAS_RTC_BM8563)
     _rtc.GetBm8563Time();
+#endif
+#if defined(HAS_RTC_PCF85063A)
+    _rtc.GetPcf85063Time();
+#endif
 #endif
 
     options = {
@@ -910,7 +915,12 @@ void runClockLoop() {
     int tmp = 0;
 
 #if defined(HAS_RTC)
+#if defined(HAS_RTC_BM8563)
     _rtc.GetBm8563Time();
+#endif
+#if defined(HAS_RTC_PCF85063A)
+    _rtc.GetPcf85063Time();
+#endif
     _rtc.GetTime(&_time);
 #endif
 
@@ -920,7 +930,9 @@ void runClockLoop() {
 
     for (;;) {
         if (millis() - tmp > 1000) {
-#if !defined(HAS_RTC)
+#if defined(HAS_RTC)
+            updateTimeStr(_rtc.getTimeStruct());
+#else
             updateTimeStr(rtc.getTimeStruct());
 #endif
             Serial.print("Current time: ");
@@ -943,7 +955,12 @@ void runClockLoop() {
             }
             tft.setTextSize(f_size);
 #if defined(HAS_RTC)
+#if defined(HAS_RTC_BM8563)
             _rtc.GetBm8563Time();
+#endif
+#if defined(HAS_RTC_PCF85063A)
+            _rtc.GetPcf85063Time();
+#endif
             _rtc.GetTime(&_time);
             char timeString[9]; // Buffer para armazenar a string formatada "HH:MM:SS"
             snprintf(

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -787,12 +787,14 @@ void setClock() {
     if (bruceConfig.automaticTimeUpdateViaNTP) {
         if (!wifiConnected) wifiConnectMenu();
 
+        options.clear();
+
+#ifndef LITE_VERSION
+
         struct TimezoneMapping {
             const char *name;
             float offset;
         };
-
-#ifndef LITE_VERSION
 
         constexpr TimezoneMapping timezoneMappings[] = {
             {"UTC-12 (Baker Island, Howland Island)",     -12  },
@@ -835,8 +837,7 @@ void setClock() {
             {"UTC+14 (Kiritimati)",                       14   }
         };
 
-        options.clear();
-        int idx = sizeof(timezoneMappings) / sizeof(timezoneMappings[0]);
+        int idx = 0;
         int i = 0;
         for (const auto &mapping : timezoneMappings) {
             if (bruceConfig.tmz == mapping.offset) { idx = i; }
@@ -853,16 +854,17 @@ void setClock() {
                                              4.5, 5,   5.5,  5.75, 6,   6.5,   7,  8,  8.75, 9,
                                              9.5, 10,  10.5, 11,   12,  12.75, 13, 14};
 
-        options.clear();
         int idx = 0;
+        int i = 0;
+        for (const auto &offset : timezoneOffsets) {
+            if (bruceConfig.tmz == offset) idx = i;
 
-        for (int i = 0; i < sizeof(timezoneOffsets) / sizeof(timezoneOffsets[0]); i++) {
-            float offset = timezoneOffsets[i];
-            String tzName = "UTC" + String(offset >= 0 ? "+" : "") + String(offset);
-            if (bruceConfig.tmz == offset * 3600) idx = i;
             options.emplace_back(
-                tzName.c_str(), [=]() { bruceConfig.setTmz(offset * 3600); }, bruceConfig.tmz == offset * 3600
+                ("UTC" + String(offset >= 0 ? "+" : "") + String(offset)).c_str(),
+                [=]() { bruceConfig.setTmz(offset); },
+                bruceConfig.tmz == offset
             );
+            ++i;
         }
 
 #endif

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -749,42 +749,45 @@ void addMifareKeyMenu() {
 **  Handles Menu to set timezone to NTP
 **********************************************************************/
 const char *ntpServer = "pool.ntp.org";
-long selectedTimezone;
-const int daylightOffset_sec = 0;
-int timeHour;
-
-TimeChangeRule BRST = {"BRST", Last, Sun, Oct, 0, timeHour};
-Timezone myTZ(BRST, BRST);
 
 WiFiUDP ntpUDP;
-NTPClient timeClient(ntpUDP, ntpServer, selectedTimezone, daylightOffset_sec);
+NTPClient timeClient(ntpUDP, ntpServer, 0, 0);
 
 void setClock() {
-    bool auto_mode = true;
-
 #if defined(HAS_RTC)
     RTC_TimeTypeDef TimeStruct;
     _rtc.GetBm8563Time();
 #endif
 
     options = {
-        {"NTP Timezone", [&]() { auto_mode = true; } },
-        {"Manually set", [&]() { auto_mode = false; }},
+        {"Via NTP Set Timezone",                                                 [&]() { bruceConfig.setAutomaticTimeUpdateViaNTP(true); } },
+        {"Set Time Manually",                                                    [&]() { bruceConfig.setAutomaticTimeUpdateViaNTP(false); }},
+        {("Daylight Savings " + String(bruceConfig.dst ? "On" : "Off")).c_str(),
+         [&]() {
+             bruceConfig.setDST(!bruceConfig.dst);
+             updateClockTimezone();
+             returnToMenu = true;
+         }                                                                                                                                 },
+        {(bruceConfig.clock24hr ? "24-Hour Format" : "12-Hour Format"),          [&]() {
+             bruceConfig.setClock24Hr(!bruceConfig.clock24hr);
+             returnToMenu = true;
+         }                                                          }
     };
+
     addOptionToMainMenu();
     loopOptions(options);
 
     if (returnToMenu) return;
 
-    if (auto_mode) {
+    if (bruceConfig.automaticTimeUpdateViaNTP) {
         if (!wifiConnected) wifiConnectMenu();
-
-        float selectedTimezone = bruceConfig.tmz; // Store current timezone as default
 
         struct TimezoneMapping {
             const char *name;
             float offset;
         };
+
+#ifndef LITE_VERSION
 
         constexpr TimezoneMapping timezoneMappings[] = {
             {"UTC-12 (Baker Island, Howland Island)",     -12  },
@@ -839,29 +842,32 @@ void setClock() {
             ++i;
         }
 
+#else
+        constexpr float timezoneOffsets[] = {-12, -11, -10,  -9.5, -9,  -8,    -7, -6, -5,   -4,
+                                             -3,  -2,  -1,   0,    0.5, 1,     2,  3,  3.5,  4,
+                                             4.5, 5,   5.5,  5.75, 6,   6.5,   7,  8,  8.75, 9,
+                                             9.5, 10,  10.5, 11,   12,  12.75, 13, 14};
+
+        options.clear();
+        int idx = 0;
+
+        for (int i = 0; i < sizeof(timezoneOffsets) / sizeof(timezoneOffsets[0]); i++) {
+            float offset = timezoneOffsets[i];
+            String tzName = "UTC" + String(offset >= 0 ? "+" : "") + String(offset);
+            if (bruceConfig.tmz == offset * 3600) idx = i;
+            options.emplace_back(
+                tzName.c_str(), [=]() { bruceConfig.setTmz(offset * 3600); }, bruceConfig.tmz == offset * 3600
+            );
+        }
+
+#endif
+
         addOptionToMainMenu();
 
         loopOptions(options, idx);
 
-        if (returnToMenu) return;
+        updateClockTimezone();
 
-        timeClient.setTimeOffset(bruceConfig.tmz * 3600);
-        timeClient.begin();
-        timeClient.update();
-        localTime = myTZ.toLocal(timeClient.getEpochTime());
-
-#if defined(HAS_RTC)
-        struct tm *timeinfo = localtime(&localTime);
-        TimeStruct.Hours = timeinfo->tm_hour;
-        TimeStruct.Minutes = timeinfo->tm_min;
-        TimeStruct.Seconds = timeinfo->tm_sec;
-        _rtc.SetTime(&TimeStruct);
-#else
-        rtc.setTime(timeClient.getEpochTime());
-#endif
-
-        clock_set = true;
-        runClockLoop();
     } else {
         int hr, mn, am;
         options = {};
@@ -897,7 +903,6 @@ void setClock() {
         rtc.setTime(0, mn, hr + am, 20, 06, 2024); // send me a gift, @Pirata!
 #endif
         clock_set = true;
-        runClockLoop();
     }
 }
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -74,8 +74,6 @@ int gsetRfTxPin(bool set = false);
 
 int gsetRfRxPin(bool set = false);
 
-void runClockLoop();
-
 void setSoundConfig();
 
 void setSoundVolume();

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -62,7 +62,7 @@ void updateClockTimezone() {
 
     timeClient.setTimeOffset(bruceConfig.tmz * 3600);
 
-    localTime = myTZ.toLocal(timeClient.getEpochTime());
+    localTime = myTZ.toLocal(timeClient.getEpochTime() + bruceConfig.dst ? 3600 : 0);
 
 #if !defined(HAS_RTC)
     rtc.setTime(timeClient.getEpochTime());
@@ -72,8 +72,22 @@ void updateClockTimezone() {
 }
 
 void updateTimeStr(struct tm timeInfo) {
-    // Atualiza timeStr com a hora e minuto
-    snprintf(timeStr, sizeof(timeStr), "%02d:%02d:%02d", timeInfo.tm_hour, timeInfo.tm_min, timeInfo.tm_sec);
+    if (bruceConfig.clock24hr) {
+        // Use 24 hour format
+        snprintf(
+            timeStr, sizeof(timeStr), "%02d:%02d:%02d", timeInfo.tm_hour, timeInfo.tm_min, timeInfo.tm_sec
+        );
+    } else {
+        // Use 12 hour format with AM/PM
+        int hour12 = (timeInfo.tm_hour == 0)   ? 12
+                     : (timeInfo.tm_hour > 12) ? timeInfo.tm_hour - 12
+                                               : timeInfo.tm_hour;
+        const char *ampm = (timeInfo.tm_hour < 12) ? "AM" : "PM";
+
+        snprintf(
+            timeStr, sizeof(timeStr), "%02d:%02d:%02d %s", hour12, timeInfo.tm_min, timeInfo.tm_sec, ampm
+        );
+    }
 }
 
 void showDeviceInfo() {

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -62,10 +62,18 @@ void updateClockTimezone() {
 
     timeClient.setTimeOffset(bruceConfig.tmz * 3600);
 
-    localTime = myTZ.toLocal(timeClient.getEpochTime() + bruceConfig.dst ? 3600 : 0);
+    localTime = timeClient.getEpochTime() + (bruceConfig.dst ? 3600 : 0);
 
-#if !defined(HAS_RTC)
-    rtc.setTime(timeClient.getEpochTime());
+#if defined(HAS_RTC)
+    struct tm *timeinfo = localtime(&localTime);
+    RTC_TimeTypeDef TimeStruct;
+    TimeStruct.Hours = timeinfo->tm_hour;
+    TimeStruct.Minutes = timeinfo->tm_min;
+    TimeStruct.Seconds = timeinfo->tm_sec;
+    _rtc.SetTime(&TimeStruct);
+    updateTimeStr(_rtc.getTimeStruct());
+#else
+    rtc.setTime(localTime);
     updateTimeStr(rtc.getTimeStruct());
     clock_set = true;
 #endif

--- a/src/core/wifi/wifi_common.h
+++ b/src/core/wifi/wifi_common.h
@@ -1,6 +1,5 @@
 #include "core/display.h"
 #include <NTPClient.h>
-#include <Timezone.h>
 #include <WiFi.h>
 
 #ifndef __WIFI_COMMON_H__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ bool returnToMenu;
 bool isSleeping = false;
 bool isScreenOff = false;
 bool dimmer = false;
-char timeStr[10];
+char timeStr[12];
 time_t localTime;
 struct tm *timeInfo;
 #if defined(HAS_RTC)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,7 +103,12 @@ char timeStr[12];
 time_t localTime;
 struct tm *timeInfo;
 #if defined(HAS_RTC)
+#if defined(HAS_RTC_BM8563)
 cplus_RTC _rtc;
+#endif
+#if defined(HAS_RTC_PCF85063A)
+pcf85063_RTC _rtc;
+#endif
 RTC_TimeTypeDef _time;
 RTC_DateTypeDef _date;
 bool clock_set = true;
@@ -328,9 +333,13 @@ void boot_screen_anim() {
  *********************************************************************/
 void init_clock() {
 #if defined(HAS_RTC)
-
     _rtc.begin();
+#if defined(HAS_RTC_BM8563)
     _rtc.GetBm8563Time();
+#endif
+#if defined(HAS_RTC_PCF85063A)
+    _rtc.GetPcf85063Time();
+#endif
     _rtc.GetTime(&_time);
 #endif
 }

--- a/src/modules/wifi/sniffer.cpp
+++ b/src/modules/wifi/sniffer.cpp
@@ -31,7 +31,6 @@
 #include "core/sd_functions.h"
 #include "core/wifi/wifi_common.h"
 #include <Arduino.h>
-#include <TimeLib.h>
 #include <globals.h>
 #if defined(ESP32)
 #include "FS.h"


### PR DESCRIPTION
#### Proposed Changes ####

Following up on #2023 bringing in the changes that were not related to the Time API and reverting NTP removal.

* Add 24/12 hour clock format option
* Add daylight savings setting
* Removed timezone cities to save flash only when building LITE_VERSION
* Update RTC handling
* Implement RTC for T-LoRa Pager

#### Types of Changes ####

New feature

#### Verification ####

**Standard Settings - DST Off and 24 Hour Clock**
<img width="769" height="363" alt="image" src="https://github.com/user-attachments/assets/635dff8f-f9a9-4a1c-8940-87bf5eda983d" />

**DST Oon and 12 Hour Clock**
<img width="768" height="364" alt="image" src="https://github.com/user-attachments/assets/a7266b53-72d4-40e6-898d-759907b95546" />


**Automatic Time - Timezone Selection**
The names fill the screen on the device, screenshots taken via WebUI.

<img width="772" height="367" alt="image" src="https://github.com/user-attachments/assets/addc0645-3e7c-4439-a8ca-1e1b286d89df" />

**Automatic Time - Timezone Selection on LITE_VERSION**
<img width="777" height="368" alt="image" src="https://github.com/user-attachments/assets/34f54b28-6e92-46cf-9206-e95c0a7ad754" />



#### Testing ####

No

#### Linked Issues ####

Fixes https://github.com/BruceDevices/firmware/issues/1714 https://github.com/BruceDevices/firmware/issues/1707 https://github.com/BruceDevices/firmware/issues/616

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add 24/12 hour clock format option
Add daylight savings setting
Implement RTC for T-LoRa Pager
```

#### Further Comments ####

