### PR TITLE
Add LED Strip support to IR Read button

### DIFF
--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -93,6 +93,11 @@ void IrRead::setup() {
              begin();
              return loop();
          }},
+        {"LED STRIP", [&]() {
+             quickButtons = quickButtonsLED;
+             begin();
+             return loop();
+         }},
     };
     options = {
         {"Custom Read",

--- a/src/modules/ir/ir_read.h
+++ b/src/modules/ir/ir_read.h
@@ -72,5 +72,14 @@ private:
                                              "OK",       "SOURCES", "VOL+", "VOL-",    "MUTE",
                                              "SETTINGS", "BACK",    "EQ",   "REC",     "PLAY/PAUSE",
                                              "STOP",     "NEXT",    "PREV", "SHUFFLE", "REPEAT"};
+    std::vector<String> quickButtonsLED = {
+    "ON", "OFF", "BRIGHTNESS+", "BRIGHTNESS-",
+    "RED", "GREEN", "BLUE", "WHITE",           
+    "ORANGE", "PEA_GREEN", "DARK_BLUE",
+    "DARK_YELLOW", "CYAN", "PURPLE",        
+    "YELLOW", "LIGHT_BLUE", "MAGENTA",    
+    "LIGHT_YELLOW", "SKY_BLUE", "ROSE",       
+    "MODE_FLASH", "MODE_STROBE", "MODE_FADE", "MODE_SMOOTH" 
+};
     std::vector<String> &quickButtons = quickButtonsTV;
 };


### PR DESCRIPTION
#### Proposed Changes

Adds a new "LED STRIP" option to the IR Quick Buttons menu, mapping the standard 24 key RGB remote layout (colors, brightness, and modes).

#### Types of Changes

New Feature

#### Verification

Verified by navigating to IR and selecting the new "LED STRIP" option in IR Read; ensred all 24 buttons are present in the capture sequence.

#### Testing

Manual haradwre testing.

#### Linked Issues

None

#### User-Facing Change

Users can now select "LED STRIP" when reading/saving IR signals to automatically label buttons for common RGB light strips.

#### Further Comments

None