### PR TITLE
Update mquickjs version with fake const keyword

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -161,7 +161,7 @@ lib_deps =
 	Adafruit Si4713 Library@1.2.3
 	Bodmer/JPEGDecoder
 	https://github.com/bmorcelli/SmartRC-CC1101-Driver-Lib/
-	mquickjs=https://github.com/BruceDevices/mquickjs#0.0.2
+	mquickjs=https://github.com/BruceDevices/mquickjs#0.0.3
 	;paulstoffregen/OneWire@^2.3.8
 	https://github.com/bmorcelli/OneWire#patch-1
 	;jackjansen/esp32_idf5_https_server_compat
@@ -232,7 +232,7 @@ lib_deps =
 	;Adafruit Si4713 Library@1.2.3
 	Bodmer/JPEGDecoder
 	https://github.com/bmorcelli/SmartRC-CC1101-Driver-Lib/
-	;mquickjs=https://github.com/BruceDevices/mquickjs#0.0.2
+	;mquickjs=https://github.com/BruceDevices/mquickjs#0.0.3
 	;paulstoffregen/OneWire@^2.3.8
 	;https://github.com/bmorcelli/OneWire#patch-1
 	;https://github.com/bmorcelli/ESP32-PsRamFS#patch-1


### PR DESCRIPTION
#### Proposed Changes ####

- Update mquickjs version with fake const keyword

#### Types of Changes ####

New Feature

#### Verification ####

You can run script with const keyword.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added const keyword to Interpreter (mquickjs engine)
```
