### PR TITLE
Fix build on m5stack-cplus2: rtc not defined

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -26,13 +26,12 @@
 extern io_expander ioExpander;
 
 #if defined(HAS_RTC)
-#if defined(HAS_RTC_BM8563)
-#include "../lib/RTC/cplus_RTC.h"
-extern cplus_RTC _rtc;
-#endif
 #if defined(HAS_RTC_PCF85063A)
 #include "../lib/RTC/pcf85063_RTC.h"
 extern pcf85063_RTC _rtc;
+#else
+#include "../lib/RTC/cplus_RTC.h"
+extern cplus_RTC _rtc;
 #endif
 extern RTC_TimeTypeDef _time;
 extern RTC_DateTypeDef _date;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,11 +106,10 @@ char timeStr[12];
 time_t localTime;
 struct tm *timeInfo;
 #if defined(HAS_RTC)
-#if defined(HAS_RTC_BM8563)
-cplus_RTC _rtc;
-#endif
 #if defined(HAS_RTC_PCF85063A)
 pcf85063_RTC _rtc;
+#else
+cplus_RTC _rtc;
 #endif
 RTC_TimeTypeDef _time;
 RTC_DateTypeDef _date;


### PR DESCRIPTION
#### Proposed Changes ####

- Currently dev is not compiling on m5stack, because HAS_RTC_BM8563 is not defined it did't include headers with RTC, and build is failing because of that.
- Changed if statement to include pcf85063_RTC if HAS_RTC_PCF85063A is defined, and cplus_RTC otherwise, so the behaviour is as before

#### Types of Changes ####

Bugfix

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

