### PR TITLE
Move updateTimezone to a task with delay rather than just a delay so it updates in the background

### DIFF
--- a/src/core/wifi/wifi_common.h
+++ b/src/core/wifi/wifi_common.h
@@ -58,4 +58,6 @@ bool _connectToWifiNetwork(const String &ssid, const String &pwd);
  */
 bool _setupAP();
 
+void updateTimezoneTask(void *pvParameters);
+
 #endif


### PR DESCRIPTION
#### Proposed Changes ####

Move updateTimezone to a task with delay rather than just a delay so it updates in the background.

I originally implemented this a a delay which caused a pause of 5 seconds after WiFi was connected.


#### Types of Changes ####

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

https://github.com/BruceDevices/firmware/pull/2078/commits/4e836c86d0f9e0a97eb8a887391ebb3fafd334e6 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

