### PR TITLE
Theme gifDuration Setting

### DIFF
--- a/include/MenuItemInterface.h
+++ b/include/MenuItemInterface.h
@@ -10,7 +10,15 @@ public:
     virtual void optionsMenu(void) = 0;
     virtual void drawIcon(float scale = 1) = 0;
     virtual void drawIconImg() {
-        drawImg(*bruceConfig.themeFS(), bruceConfig.getThemeItemImg(themePath()), 0, imgCenterY, true);
+        drawImg(
+            *bruceConfig.themeFS(),
+            bruceConfig.getThemeItemImg(themePath()),
+            0,
+            imgCenterY,
+            true,
+            bruceConfig.theme.gifDuration,
+            false
+        );
     }
     virtual bool hasTheme() = 0;
     virtual String themePath() = 0;

--- a/include/globals.h
+++ b/include/globals.h
@@ -219,14 +219,16 @@ extern volatile int EncoderLedChange;
 #endif
 
 extern TaskHandle_t xHandle;
-extern inline bool check(volatile bool &btn) {
+extern inline bool check(volatile bool &btn, bool resetButtonStatus = true) {
 
 #ifndef USE_TFT_eSPI_TOUCH
     if (!btn) return false;
     vTaskSuspend(xHandle);
-    btn = false;
-    AnyKeyPress = false;
-    SerialCmdPress = false;
+    if (resetButtonStatus) {
+        btn = false;
+        AnyKeyPress = false;
+        SerialCmdPress = false;
+    }
     delay(10);
     vTaskResume(xHandle);
     return true;

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -1386,7 +1386,9 @@ int Gif::getLastError() { return gif->getLastError(); }
  * >0  : Play the GIF for the specified duration in milliseconds
  *       (e.g., 1000 = play for 1 second)
  */
-bool showGif(FS *fs, const char *filename, int x, int y, bool center, int playDurationMs) {
+bool showGif(
+    FS *fs, const char *filename, int x, int y, bool center, int playDurationMs, bool resetButtonStatus
+) {
     if (!fs->exists(filename)) return false;
 
     Gif gif;
@@ -1404,7 +1406,7 @@ bool showGif(FS *fs, const char *filename, int x, int y, bool center, int playDu
         result = gif.playFrame(x, y);
         if (result == -1) log_e("GIF playFrame error: %d\n", gif.getLastError());
 
-        if (check(AnyKeyPress)) break;
+        if (check(AnyKeyPress, resetButtonStatus)) break;
 
         if (playDurationMs > 0 && (millis() - timeStart) > playDurationMs) break;
         if (playDurationMs == 0 && result == 0) break;
@@ -1605,7 +1607,7 @@ bool drawBmp(FS &fs, String filename, int x, int y, bool center) {
     return true;
 }
 
-bool drawImg(FS &fs, String filename, int x, int y, bool center, int playDurationMs) {
+bool drawImg(FS &fs, String filename, int x, int y, bool center, int playDurationMs, bool resetButtonStatus) {
     String ext = filename.substring(filename.lastIndexOf('.'));
     ext.toLowerCase();
     uint8_t fls = 2;         // 2 for Little FS
@@ -1617,7 +1619,8 @@ bool drawImg(FS &fs, String filename, int x, int y, bool center, int playDuratio
 
 #if !defined(LITE_VERSION)
 
-    else if (ext.endsWith("gif")) return showGif(&fs, filename.c_str(), x, y, center, playDurationMs);
+    else if (ext.endsWith("gif"))
+        return showGif(&fs, filename.c_str(), x, y, center, playDurationMs, resetButtonStatus);
 #endif
     else log_e("Image not supported");
 

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -91,12 +91,18 @@ private:
  * @param center: draw the image at the center of the screen
  * @param playDurationMs: time that the GIF will be played
  */
-bool drawImg(FS &fs, String filename, int x = 0, int y = 0, bool center = false, int playDurationMs = 0);
+bool drawImg(
+    FS &fs, String filename, int x = 0, int y = 0, bool center = false, int playDurationMs = 0,
+    bool resetButtonStatus = true
+);
 bool drawPNG(FS &fs, String filename, int x, int y, bool center);
 bool preparePngBin(FS &fs, String filename);
 bool drawBmp(FS &fs, String filename, int x = 0, int y = 0, bool center = false);
 #if !defined(LITE_VERSION)
-bool showGif(FS *fs, const char *filename, int x = 0, int y = 0, bool center = false, int playDurationMs = 0);
+bool showGif(
+    FS *fs, const char *filename, int x = 0, int y = 0, bool center = false, int playDurationMs = 0,
+    bool clearButtonStatus = true
+);
 #endif
 bool showJpeg(FS &fs, String filename, int x = 0, int y = 0, bool center = false);
 

--- a/src/core/theme.cpp
+++ b/src/core/theme.cpp
@@ -80,6 +80,7 @@ bool BruceTheme::openThemeFile(FS *fs, String filepath, bool overwriteConfigSett
 
     if (!_th["border"].isNull()) { theme.border = _th["border"].as<int>(); }
     if (!_th["label"].isNull()) { theme.label = _th["label"].as<int>(); }
+    if (!_th["gifDuration"].isNull()) { theme.gifDuration = _th["gifDuration"].as<int>(); }
 
     if (overwriteConfigSettings) {
         uint16_t _priColor = bruceConfig.priColor;

--- a/src/core/theme.h
+++ b/src/core/theme.h
@@ -51,6 +51,8 @@ struct themeInfo {
     bool boot_img = false;
     bool boot_sound = false;
     bool lora = false;
+    int gifDuration = 0;
+
     // Theme file paths, colors and border
     themeFiles paths;
 };


### PR DESCRIPTION
#### Proposed Changes ####

* The duration of the GIF playback can be set in the `theme.json` using `gifDuration`
   * Default is 0=one loop, can be set to -1=unlimited and an integer number of seconds as per the existing spec of `showGif`
* Update `check(volatile bool &btn)` to `check(volatile bool &btn, bool resetButtonStatus = true)` so checking for a button press does not reset the status of this button if required
   * This was added so the main menu GIF playback is interrupted AND go to the next menu item with one button press

Linked to web page PR #2105

#### Types of Changes ####

New Feature

#### Verification ####

Tested on T-Embed with looping GIFs.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Themes can specify a `gifDuration` to allow longer/unlimited looping of the GIF on the main menus.
```

#### Further Comments ####

