### PR TITLE
Add GIF Duration to theme builder

### DIFF
--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -579,6 +579,11 @@
                     <input type="checkbox" id="labels">
                     <label for="labels">Labels (reduces height by 40px)</label>
                 </div>
+                <div class="control-item" style="margin-top: 15px;">
+                    <label for="gifDurationInput">GIF Duration: (only applies to GIF themes)</label>
+                    <input type="number" id="gifDurationInput" class="form-text" min="-1" value="-1"/>
+                    <label style="font-family: monospace;">-1=Loops Forever<br>0=One Loop<br>1+=Number of milliseconds to loop</label>
+                </div>
             </div>
         </div>
 
@@ -805,6 +810,7 @@
             mapping.ledEffect = document.getElementById('ledEffectInput').value;
             mapping.ledEffectSpeed = document.getElementById('ledSyncToEncoder').checked ? 11 : document.getElementById('ledEffectSpeedInput').value;
             mapping.ledEffectDirection = document.getElementById('ledEffectDirection').checked ? -1 : 1;
+            mapping.gifDuration = parseInt(document.getElementById('gifDurationInput').value);
 
             return mapping;
         }
@@ -822,6 +828,7 @@
 
             const hasLabels = document.getElementById('labels').checked;
             const hasBorder = document.getElementById('border').checked;
+            const gifDuration = parseInt(document.getElementById('gifDurationInput').value);
             const totalToProcess = heights.length * Object.keys(selectedImages).length;
 
             if (totalToProcess === 0) {


### PR DESCRIPTION
#### Proposed Changes ####

* Add GIF Duration (`gifDuration`) to theme builder

Linked to firmware PR #2104

#### Types of Changes ####

New Feature

#### Verification ####

<img width="610" height="314" alt="image" src="https://github.com/user-attachments/assets/070de4e7-909c-4ef3-9eb1-5e21f3118430" />

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

