### PR TITLE
Web Page: Add 3.5inch CYD resistive and capacitive screens

### DIFF
--- a/src/lib/data/devices.json
+++ b/src/lib/data/devices.json
@@ -128,6 +128,22 @@
 		"PSRAM": "None"
 	},
 	{
+		"device": "CYD-3248S035",
+		"CC1101": "Module Required",
+		"NRF24": "Module Required",
+		"FMRadio": "Module Required",
+		"NFC": "Module Required",
+		"Mic": false,
+		"BadUSB": false,
+		"RGB_Led": false,
+		"Audio": false,
+		"Screen": "480x320",
+		"ESP": "ESP32-WROOM-32",
+		"Battery": "None",
+		"Flash": "4MB",
+		"PSRAM": "None"
+	},
+	{
 		"device": "Lilygo T-Embed CC1101",
 		"CC1101": true,
 		"NRF24": "Module Required",

--- a/src/lib/data/manifests.json
+++ b/src/lib/data/manifests.json
@@ -28,7 +28,9 @@
 		{ "id": "CYD-2432W328C", "name": "CYD-2432W328C", "family": "ESP32" },
 		{ "id": "CYD-2432W328C_2", "name": "CYD-2432W328C (inv colors) and CYD-2432S024C", "family": "ESP32" },
 		{ "id": "CYD-2432W328R-or-S024R", "name": "CYD-2432W328R or 2432S024R", "family": "ESP32" },
-		{ "id": "CYD-2USB", "name": "CYD-2432S028 (2USB or inverted Colors)", "family": "ESP32" }
+		{ "id": "CYD-2USB", "name": "CYD-2432S028 (2USB or inverted Colors)", "family": "ESP32" },
+		{ "id": "CYD-3248S035R", "name": "CYD-3248S035R", "family": "ESP32" },
+		{ "id": "CYD-3248S035C", "name": "CYD-3248S035C", "family": "ESP32" }
 	],
 	"ESP32": [
     { "id": "esp32-s3-devkitc-1", "name": "ESP32-S3", "family": "ESP32-S3" },
@@ -52,6 +54,8 @@
 		{ "id": "LAUNCHER_CYD-2432W328C", "name": "CYD-2432W328C", "family": "ESP32" },
 		{ "id": "LAUNCHER_CYD-2432W328R-or-S024R", "name": "CYD-2432W328R or 2432S024R", "family": "ESP32" },
 		{ "id": "LAUNCHER_CYD-2USB", "name": "CYD-2432S028 (2USB or Inverted Colors)", "family": "ESP32" },
+		{ "id": "LAUNCHER_CYD-3248S035R", "name": "LAUNCHER_CYD-3248S035R", "family": "ESP32" },
+		{ "id": "LAUNCHER_CYD-3248S035C", "name": "LAUNCHER_CYD-3248S035C", "family": "ESP32" },
 		{ "id": "LAUNCHER_Marauder-Mini", "name": "Marauder Mini (Launcher)", "family": "ESP32" },
 		{ "id": "LAUNCHER_Marauder-V4-V6", "name": "Marauder V4 or V6 (Launcher)", "family": "ESP32" },
 		{ "id": "LAUNCHER_Marauder-v61", "name": "Marauder V6.x (Launcher)", "family": "ESP32" },


### PR DESCRIPTION
#### Proposed Changes ####

* Web page updates for 3.5inch CYD resistive and capacitive screens

Linked to PR https://github.com/BruceDevices/firmware/pull/2113

#### Types of Changes ####

New feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

