### PR TITLE
Fix app store menu after merge + config menu confirmations

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -182,7 +182,20 @@ int8_t displayMessage(
     tft.setTextColor(color);
     tft.setTextSize(FM);
     tft.setTextDatum(TC_DATUM);
-    tft.drawString(message, tftWidth / 2, tftHeight / 2 - 20);
+
+    // Handle newline characters in message
+    String msg = String(message);
+    int y = tftHeight / 2 - 20;
+    int start = 0;
+    int end = msg.indexOf('\n');
+
+    while (end != -1) {
+        tft.drawString(msg.substring(start, end), tftWidth / 2, y);
+        y += FM * 8;
+        start = end + 1;
+        end = msg.indexOf('\n', start);
+    }
+    tft.drawString(msg.substring(start), tftWidth / 2, y);
 
     tft.setTextDatum(BC_DATUM);
     int16_t buttonHeight = 20;

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -30,10 +30,10 @@ void ConfigMenu::optionsMenu() {
             {"System Config", [this]() { systemMenu(); }   },
             {"Power Menu",    [this]() { powerMenu(); }    },
         };
-#if !defined(LITE_VERSION) // UNCOMMENT WHEN APP STORE IMPLEMENTED and DELETE PLACEHOLDER
-        // if (!appStoreInstalled()) {
-        //     localOptions.push_back({"Install App Store", []() { installAppStoreJS(); }});
-        localOptions.push_back({"Install App Store (X)", []() {}}); //  <--- PLACEHOLDER
+#if !defined(LITE_VERSION)
+        if (!appStoreInstalled()) {
+            localOptions.push_back({"Install App Store", []() { installAppStoreJS(); }});
+        }
 #endif
 
         if (bruceConfig.devMode) {

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -28,7 +28,7 @@ void ConfigMenu::optionsMenu() {
 #endif
             {"Audio Config",  [this]() { audioMenu(); }    },
             {"System Config", [this]() { systemMenu(); }   },
-            {"Power Menu",    [this]() { powerMenu(); }    },
+            {"Power",         [this]() { powerMenu(); }    },
         };
 #if !defined(LITE_VERSION)
         if (!appStoreInstalled()) {
@@ -188,10 +188,16 @@ void ConfigMenu::advancedMenu() {
             {"Network Creds",  [this]() { setNetworkCredsMenu(); }},
             {"BadUSB/BLE",     [this]() { setBadUSBBLEMenu(); }   },
             {"Factory Reset",
-                                      [this]() {
+                                      []() {
                  // Confirmation dialog for destructive action
-                 int8_t choice =
-                     displayMessage("All data will be lost!", "Cancel", nullptr, "Reset", TFT_RED);
+                 drawMainBorder(true);
+                 int8_t choice = displayMessage(
+                     "Are you sure you want\nto Factory Reset?\nAll data will be lost!",
+                     "No",
+                     nullptr,
+                     "Yes",
+                     TFT_RED
+                 );
 
                  if (choice == 1) {
                      // User confirmed - perform factory reset
@@ -220,10 +226,11 @@ void ConfigMenu::powerMenu() {
             {"Deep Sleep", goToDeepSleep          },
             {"Sleep",      setSleepMode           },
             {"Restart",    []() { ESP.restart(); }},
-            {"Turn-off",
+            {"Power Off",
              []() {
                  // Confirmation dialog for power off
-                 int8_t choice = displayMessage("Power Off Device?", "Cancel", nullptr, "Pwr Off", TFT_RED);
+                 drawMainBorder(true);
+                 int8_t choice = displayMessage("Power Off Device?", "No", nullptr, "Yes", TFT_RED);
 
                  if (choice == 1) { powerOff(); }
              }                                    },

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1688,7 +1688,9 @@ void installAppStoreJS() {
     }
 
     HTTPClient http;
-    http.begin("https://raw.githubusercontent.com/BruceDevices/App-Store/refs/heads/main/App%20Store.js");
+    http.begin(
+        "https://raw.githubusercontent.com/BruceDevices/App-Store/refs/heads/main/minified/App%20Store.js"
+    );
     int httpCode = http.GET();
     if (httpCode != 200) {
         http.end();


### PR DESCRIPTION
#### Proposed Changes ####

* Fix app store menu after merge
* Remove duplicate micMenu function from OthersMenu
* Handle newline characters in displayMessage function
* Power off and factory reset confimations updated
* Update `App Store.js` URL

#### Types of Changes ####

New feature

#### Verification ####

**Setting Menu Confirmations Now Clear Screen**

<img width="530" height="319" alt="image" src="https://github.com/user-attachments/assets/c5dee89c-23ea-421a-9537-8dc7b1e0ede4" />



#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

