### PR TITLE
Fix Beacon Spam SSID trailing spaces

### DIFF
--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -90,6 +90,7 @@ static inline void prepareBeaconPacket(
     // ensure SSID slot is cleared (32 bytes) then copy SSID
     memset(&outPacket[38], 0x20, 32); // keep template behavior
     if (ssidLen > 32) ssidLen = 32;
+    outPacket[37] = ssidLen; // SSID element length
     if (ssidLen > 0) { memcpy(&outPacket[38], ssid, ssidLen); }
 
     // set channel and WPA flags


### PR DESCRIPTION
Beacon SPAM was advertising the SSID IE length as 32 bytes, so shorter SSIDs appeared padded with trailing spaces on clients.

#### Proposed Changes ####

Bugfix to set the SSID information element length byte to the actual SSID length when building Beacon SPAM frames, instead of always advertising 32 bytes.

#### Types of Changes ####

Bugfix for WiFi Beacon SPAM

#### Verification ####

When WiFi -> WiFi Atks -> Beacon SPAM is run, SSIDs no longer have trailing spaces when viewed on certain devices.

#### Testing ####

SSIDs being spammed no longer have trailing spaces.

#### User-Facing Change ####

Beacon SPAM SSIDs no longer show trailing spaces in WiFi scan lists.

#### Further Comments ####

Just a one addition in src/modules/wifi/wifi_atks.cpp