### PR TITLE
Windows custom ble spam

### DIFF
--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -29,7 +29,9 @@ void BleMenu::optionsMenu() {
 #if !defined(LITE_VERSION)
     options.push_back({"Presenter", [=]() { PresenterMode(hid_ble, true); }});
     options.push_back({"BLE Scan", ble_scan});
-    options.push_back({"iBeacon", [=]() { ibeacon(); }});
+    options.push_back({"iBeacon", [=]() {
+                           ibeacon("Bruce", "e4c159a0-8c82-11e6-bdf4-0800200c9a66", 0x004C);
+                       }});
     options.push_back({"Bad BLE", [=]() { ducky_setup(hid_ble, true); }});
     options.push_back({"BLE Keyboard", [=]() { ducky_keyboard(hid_ble, true); }});
 #endif

--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -10,9 +10,11 @@
 #include "esp_gap_ble_api.h"
 #endif
 #include <globals.h>
-#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C2) || defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C2) ||                              \
+    defined(CONFIG_IDF_TARGET_ESP32S3)
 #define MAX_TX_POWER ESP_PWR_LVL_P21
-#elif defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5)
+#elif defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C6) ||                            \
+    defined(CONFIG_IDF_TARGET_ESP32C5)
 #define MAX_TX_POWER ESP_PWR_LVL_P20
 #else
 #define MAX_TX_POWER ESP_PWR_LVL_P9
@@ -77,20 +79,9 @@ const DeviceType android_models[] = {
     {0x005EF9}, {0xE2106F}, {0xB37A62}, {0x92ADC9}
 };
 
-const WatchModel watch_models[] = {
-    {0x1A}, {0x01}, {0x02}, {0x03}, {0x04},
-    {0x05}, {0x06}, {0x07}, {0x08}, {0x09},
-    {0x0A}, {0x0B}, {0x0C}, {0x11}, {0x12},
-    {0x13}, {0x14}, {0x15}, {0x16}, {0x17},
-    {0x18}, {0x1B}, {0x1C}, {0x1D}, {0x1E},
-    {0x20},
-    {0x43}, {0x44}, {0x45}, {0x46}, {0x47},
-    {0x48}, {0x49}, {0x4A}, {0x4B}, {0x4C},
-    {0x4D}, {0x4E}, {0x4F}, {0x50}, {0x51},
-    {0x52}, {0x53}, {0x54}, {0x55}, {0x56},
-    {0x57}, {0x58}, {0x59}, {0x5A}, {0x5B},
-    {0x5C}, {0x5D}
-};
+const WatchModel watch_models[26] = {{0x1A}, {0x01}, {0x02}, {0x03}, {0x04}, {0x05}, {0x06}, {0x07}, {0x08},
+                                     {0x09}, {0x0A}, {0x0B}, {0x0C}, {0x11}, {0x12}, {0x13}, {0x14}, {0x15},
+                                     {0x16}, {0x17}, {0x18}, {0x1B}, {0x1C}, {0x1D}, {0x1E}, {0x20}};
 
 char randomNameBuffer[32];
 
@@ -111,19 +102,27 @@ void generateRandomMac(uint8_t *mac) {
 }
 
 int android_models_count = (sizeof(android_models) / sizeof(android_models[0]));
-int watch_models_count = (sizeof(watch_models) / sizeof(watch_models[0]));
 
 BLEAdvertising *pAdvertising;
 
-BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
+BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type, String customName = "") {
     BLEAdvertisementData AdvData = BLEAdvertisementData();
     uint8_t *AdvData_Raw = nullptr;
     uint8_t i = 0;
 
     switch (Type) {
         case Microsoft: {
-            const char *Name = generateRandomName();
-            uint8_t name_len = strlen(Name);
+            const char *Name;
+            uint8_t name_len;
+
+            if (customName.length() > 0) {
+                Name = customName.c_str();
+                name_len = customName.length();
+            } else {
+                Name = generateRandomName();
+                name_len = strlen(Name);
+            }
+
             AdvData_Raw = new uint8_t[7 + name_len];
             AdvData_Raw[i++] = 6 + name_len;
             AdvData_Raw[i++] = 0xFF;
@@ -203,7 +202,7 @@ BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
             break;
         }
         case Samsung: {
-            uint8_t model = watch_models[random(watch_models_count)].value;
+            uint8_t model = watch_models[random(26)].value;
             uint8_t Samsung_Data[15] = {
                 0x0F, 0xFF, 0x75, 0x00, 0x01, 0x00, 0x02,
                 0x00, 0x01, 0x01, 0xFF, 0x00, 0x00, 0x43,
@@ -243,16 +242,16 @@ BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
     return AdvData;
 }
 
-void executeSpam(EBLEPayloadType type) {
+void executeSpam(EBLEPayloadType type, String customName = "") {
     uint8_t macAddr[6];
     generateRandomMac(macAddr);
     esp_iface_mac_addr_set(macAddr, ESP_MAC_BT);
 
     BLEDevice::init("");
-    vTaskDelay(50 / portTICK_PERIOD_MS);
+    vTaskDelay(5 / portTICK_PERIOD_MS);
     esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, MAX_TX_POWER);
     pAdvertising = BLEDevice::getAdvertising();
-    BLEAdvertisementData advertisementData = GetUniversalAdvertisementData(type);
+    BLEAdvertisementData advertisementData = GetUniversalAdvertisementData(type, customName);
     BLEAdvertisementData oScanResponseData = BLEAdvertisementData();
 
     advertisementData.setFlags(0x06);
@@ -262,10 +261,10 @@ void executeSpam(EBLEPayloadType type) {
     pAdvertising->setMinInterval(32);
     pAdvertising->setMaxInterval(48);
     pAdvertising->start();
-    vTaskDelay(250 / portTICK_PERIOD_MS);
+    vTaskDelay(20 / portTICK_PERIOD_MS);
 
     pAdvertising->stop();
-    vTaskDelay(50 / portTICK_PERIOD_MS);
+    vTaskDelay(5 / portTICK_PERIOD_MS);
 #if defined(CONFIG_IDF_TARGET_ESP32C5)
     esp_bt_controller_deinit();
 #else
@@ -292,7 +291,7 @@ void executeCustomSpam(String spamName) {
     pAdvertising->start();
     vTaskDelay(20 / portTICK_PERIOD_MS);
     pAdvertising->stop();
-    vTaskDelay(10 / portTICK_PERIOD_MS);
+    vTaskDelay(5 / portTICK_PERIOD_MS);
 #if defined(CONFIG_IDF_TARGET_ESP32C5)
     esp_bt_controller_deinit();
 #else
@@ -333,7 +332,7 @@ void ibeacon(const char *DeviceName, const char *BEACON_UUID, int ManufacturerId
         Serial.println("Advertizing started...");
         vTaskDelay(20 / portTICK_PERIOD_MS);
         pAdvertising->stop();
-        vTaskDelay(10 / portTICK_PERIOD_MS);
+        vTaskDelay(5 / portTICK_PERIOD_MS);
         Serial.println("Advertizing stop");
     }
 
@@ -347,7 +346,12 @@ void ibeacon(const char *DeviceName, const char *BEACON_UUID, int ManufacturerId
 void aj_adv(int ble_choice) {
     int count = 0;
     String spamName = "";
-    if (ble_choice == 6) { spamName = keyboard("", 10, "Name to spam"); }
+    if (ble_choice == 6) { spamName = keyboard("", 24, "Name to spam"); }
+
+    if (ble_choice == 2) {
+        spamName = keyboard("", 24, "Windows Name to spam");
+        if (spamName == "\x1B") return;
+    }
 
     if (ble_choice == 5) {
         displayTextLine("Spam All Sequential");
@@ -423,7 +427,7 @@ void aj_adv(int ble_choice) {
                 return;
             case 2:
                 displayTextLine("SwiftPair  (" + String(count) + ")");
-                executeSpam(Microsoft);
+                executeSpam(Microsoft, spamName);
                 break;
             case 3:
                 displayTextLine("Samsung  (" + String(count) + ")");


### PR DESCRIPTION
I added a function to create a custom spam filter for Windows spam. This means that when you go to Windows spam, the keyboard opens directly. If nothing is entered, it reverts to the random ID spam system.

I also reduced the delay between packet transmissions to 20ms, which is the minimum Windows accepts. I also changed the maximum number of characters allowed for the spam ID; it was 10 characters before, but I increased it to 24, which is the maximum Windows supports. I tested everything, and it works perfectly. I also made some modifications to the smartwatch packets.