### PR TITLE
CustomIR Bugs fixes for t-embed

### DIFF
--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -690,16 +690,8 @@ String loopSD(FS &fs, bool filePicker, String allowed_ext, String rootPath) {
                 } else if (fileList[index].folder == false && fileList[index].operation == false) {
                     goto Files;
                 } else {
-                    options = {
-                        {"New Folder", [=]() { createFolder(fs, Folder); }},
-                    };
-                    if (fileToCopy != "") options.push_back({"Paste", [=]() { pasteFile(fs, Folder); }});
-                    options.push_back({"Close Menu", [&]() { yield(); }});
-                    options.push_back({"Main Menu", [&]() { exit = true; }});
-                    loopOptions(options);
-                    tft.drawRoundRect(5, 5, tftWidth - 10, tftHeight - 10, 5, bruceConfig.priColor);
-                    reload = true;
-                    redraw = true;
+                    // "> Back" item selected (operation == true) → go up one folder level
+                    goto BACK_FOLDER;
                 }
             } else {
             Files:
@@ -743,7 +735,16 @@ String loopSD(FS &fs, bool filePicker, String allowed_ext, String rootPath) {
                     if (filepath.endsWith(".ir")) {
                         options.insert(options.begin(), {"IR Choose cmd", [&]() {
                                                              delay(200);
-                                                             chooseCmdIrFile(&fs, filepath);
+                                                             bool goToMain = chooseCmdIrFile(&fs, filepath);
+                                                             if (goToMain) exit = true;
+                                                             else {
+                                                                 // Short press: stay in current folder
+                                                                 // Flush any residual EscPress so file browser
+                                                                 // doesn't navigate up a folder unintentionally
+                                                                 delay(100);
+                                                                 while (check(EscPress)) delay(10);
+                                                                 reload = true;
+                                                             }
                                                          }});
                         options.insert(options.begin(), {"IR Tx SpamAll", [&]() {
                                                              delay(200);

--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -690,8 +690,16 @@ String loopSD(FS &fs, bool filePicker, String allowed_ext, String rootPath) {
                 } else if (fileList[index].folder == false && fileList[index].operation == false) {
                     goto Files;
                 } else {
-                    // "> Back" item selected (operation == true) → go up one folder level
-                    goto BACK_FOLDER;
+                    options = {
+                        {"New Folder", [=]() { createFolder(fs, Folder); }},
+                    };
+                    if (fileToCopy != "") options.push_back({"Paste", [=]() { pasteFile(fs, Folder); }});
+                    options.push_back({"Close Menu", [&]() { yield(); }});
+                    options.push_back({"Main Menu", [&]() { exit = true; }});
+                    loopOptions(options);
+                    tft.drawRoundRect(5, 5, tftWidth - 10, tftHeight - 10, 5, bruceConfig.priColor);
+                    reload = true;
+                    redraw = true;
                 }
             } else {
             Files:
@@ -735,16 +743,7 @@ String loopSD(FS &fs, bool filePicker, String allowed_ext, String rootPath) {
                     if (filepath.endsWith(".ir")) {
                         options.insert(options.begin(), {"IR Choose cmd", [&]() {
                                                              delay(200);
-                                                             bool goToMain = chooseCmdIrFile(&fs, filepath);
-                                                             if (goToMain) exit = true;
-                                                             else {
-                                                                 // Short press: stay in current folder
-                                                                 // Flush any residual EscPress so file browser
-                                                                 // doesn't navigate up a folder unintentionally
-                                                                 delay(100);
-                                                                 while (check(EscPress)) delay(10);
-                                                                 reload = true;
-                                                             }
+                                                             chooseCmdIrFile(&fs, filepath);
                                                          }});
                         options.insert(options.begin(), {"IR Tx SpamAll", [&]() {
                                                              delay(200);


### PR DESCRIPTION
I noticed a bug that appeared when selecting a custom IR and then trying to go back. The interface would visually "refresh," but it was simply a glitch in the CustomIR code that was looping back to the previous state. The only way to exit was to use the "main menu" at the bottom, but this meant going back the entire way to send other IR signals. The fix I found is that when you select the IR signals to send (after choosing the .ir file and pressing `choose cmd`) and then go back, it returns you to where you opened the file. This is very convenient if you want to quickly test IR signals without having to go back to the file again. Tested and working perfectly.