### PR TITLE
Adding PN532 emulation

### DIFF
--- a/src/modules/rfid/PN532.cpp
+++ b/src/modules/rfid/PN532.cpp
@@ -1,20 +1,255 @@
 /**
  * @file PN532.cpp
- * @author Rennan Cockles (https://github.com/rennancockles)
- * @brief Read and Write RFID tags using PN532 module
- * @version 0.1
- * @date 2024-08-19
+ * @author Rennan Cockles (https://github.com/rennancockles) // Dawi (https://github.com/yourdawi)
+ * @brief Read, Write and Emulate RFID tags using PN532 module
+ * @version 0.2
+ * @date 2026-02-22
  */
 
 #include "PN532.h"
+#include "apdu.h"
 #include "core/display.h"
 #include "core/i2c_finder.h"
 #include "core/sd_functions.h"
 #include "core/type_convertion.h"
+#include <algorithm>
+#include <vector>
 
 #ifndef GPIO_NUM_25
 #define GPIO_NUM_25 25
 #endif
+
+namespace {
+bool waitReadyPreferIrq(Adafruit_PN532 &nfc, uint16_t timeoutMs) {
+    if (nfc._irq >= 0) {
+        uint32_t start = millis();
+        while (digitalRead(nfc._irq) != LOW) {
+            if (timeoutMs != 0 && (millis() - start) > timeoutMs) return false;
+            delay(1);
+            yield();
+        }
+        return true;
+    }
+    return nfc.waitready(timeoutMs);
+}
+
+bool sendCommandCheckAckPreferIrq(Adafruit_PN532 &nfc, uint8_t *cmd, uint8_t cmdLen, uint16_t timeoutMs) {
+    nfc.writecommand(cmd, cmdLen);
+    delay(1);
+    if (!waitReadyPreferIrq(nfc, timeoutMs)) return false;
+    if (!nfc.readack()) return false;
+    delay(1);
+    if (!waitReadyPreferIrq(nfc, timeoutMs)) return false;
+    return true;
+}
+
+bool tgInitAsTargetIrq(Adafruit_PN532 &nfc) {
+    // Matches the older "AsTarget" payload
+    uint8_t target[] = {
+        PN532_COMMAND_TGINITASTARGET,
+        0x00, // MODE bitfield
+        0x08,
+        0x00, // SENS_RES
+        0xDC,
+        0x44,
+        0x20, // NFCID1T
+        0x60, // SEL_RES
+        0x01,
+        0xFE, // NFCID2t prefix
+        0xA2,
+        0xA3,
+        0xA4,
+        0xA5,
+        0xA6,
+        0xA7,
+        0xC0,
+        0xC1,
+        0xC2,
+        0xC3,
+        0xC4,
+        0xC5,
+        0xC6,
+        0xC7,
+        0xFF,
+        0xFF, // system code
+        0xAA,
+        0x99,
+        0x88,
+        0x77,
+        0x66,
+        0x55,
+        0x44,
+        0x33,
+        0x22,
+        0x11,
+        0x01,
+        0x00, // NFCID3t tail
+        0x0D, // historical bytes length
+        0x52,
+        0x46,
+        0x49,
+        0x44,
+        0x49,
+        0x4F,
+        0x74,
+        0x20,
+        0x50,
+        0x4E,
+        0x35,
+        0x33,
+        0x32
+    };
+
+    if (!sendCommandCheckAckPreferIrq(nfc, target, sizeof(target), 1500)) return false;
+
+    // Adafruit AsTarget() reads only 8 bytes here. Reading more can stall on ESP32 I2C.
+    uint8_t frame[8] = {0};
+    nfc.readdata(frame, sizeof(frame));
+    // Accept the salmg variant (0x15 at index 6) and standard response framing (0x8D at index 6).
+    if (frame[6] == 0x15) return true;
+    if (frame[6] == (PN532_COMMAND_TGINITASTARGET + 1)) {
+        uint8_t status = frame[7];
+        return status == 0x00 || status == 0x08 || status == 0x15;
+    }
+    return false;
+}
+
+bool tgGetDataIrq(Adafruit_PN532 &nfc, uint8_t *out, uint8_t maxLen, uint8_t *outLen, uint8_t *status) {
+    uint8_t cmd = PN532_COMMAND_TGGETDATA;
+    if (!sendCommandCheckAckPreferIrq(nfc, &cmd, 1, 1000)) return false;
+
+    // 64 bytes matches Adafruit's getDataTarget() and avoids over-reading on ESP32 I2C.
+    uint8_t frame[64] = {0};
+    nfc.readdata(frame, sizeof(frame));
+    if (frame[6] != (PN532_COMMAND_TGGETDATA + 1)) return false;
+
+    *status = frame[7];
+    uint8_t dataLen = frame[3] > 3 ? static_cast<uint8_t>(frame[3] - 3) : 0;
+    uint8_t copyLen = std::min<uint8_t>(dataLen, maxLen);
+    if (copyLen > 0) memcpy(out, frame + 8, copyLen);
+    *outLen = copyLen;
+    return true;
+}
+
+bool tgSetDataIrq(Adafruit_PN532 &nfc, const uint8_t *data, uint8_t dataLen) {
+    if (dataLen == 0 || dataLen > 254) return false;
+
+    uint8_t cmd[255] = {0};
+    cmd[0] = PN532_COMMAND_TGSETDATA;
+    memcpy(cmd + 1, data, dataLen);
+    if (!sendCommandCheckAckPreferIrq(nfc, cmd, static_cast<uint8_t>(dataLen + 1), 1000)) return false;
+
+    // setDataTarget() in the Adafruit implementation also reads 8 bytes.
+    uint8_t frame[8] = {0};
+    nfc.readdata(frame, sizeof(frame));
+    if (frame[6] != (PN532_COMMAND_TGSETDATA + 1)) return false;
+    return frame[7] == 0x00;
+}
+
+int hexNibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+    return -1;
+}
+
+bool parseHexBytesAfterColon(const String &line, std::vector<uint8_t> &bytes) {
+    bytes.clear();
+    int colon = line.indexOf(':');
+    if (colon < 0) return false;
+
+    int hi = -1;
+    for (int i = colon + 1; i < line.length(); i++) {
+        int v = hexNibble(line.charAt(i));
+        if (v < 0) continue;
+        if (hi < 0) {
+            hi = v;
+        } else {
+            bytes.push_back(static_cast<uint8_t>((hi << 4) | v));
+            hi = -1;
+        }
+    }
+    return !bytes.empty() && hi < 0;
+}
+
+bool extractNdefMessageFromPageDump(const String &dump, std::vector<uint8_t> &ndefOut) {
+    ndefOut.clear();
+    if (dump.length() == 0) return false;
+
+    std::vector<uint8_t> userData;
+    std::vector<uint8_t> lineBytes;
+    int pos = 0;
+
+    while (pos < dump.length()) {
+        int nl = dump.indexOf('\n', pos);
+        if (nl < 0) nl = dump.length();
+
+        String line = dump.substring(pos, nl);
+        line.trim();
+        pos = nl + 1;
+
+        if (!line.startsWith("Page ")) continue;
+
+        int colon = line.indexOf(':');
+        if (colon < 0) continue;
+
+        int page = line.substring(5, colon).toInt();
+        if (page < 4) continue; // Skip UID/lock/CC area before user pages.
+
+        if (!parseHexBytesAfterColon(line, lineBytes)) continue;
+        if (lineBytes.size() < 4) continue;
+
+        // Ultralight/NTAG dumps are 4 bytes per page. Use first 4 bytes from each page line.
+        userData.insert(userData.end(), lineBytes.begin(), lineBytes.begin() + 4);
+    }
+
+    if (userData.empty()) return false;
+
+    // Parse TLV stream and return the first NDEF TLV (0x03).
+    size_t i = 0;
+    while (i < userData.size()) {
+        uint8_t tlv = userData[i++];
+
+        if (tlv == 0x00) continue; // NULL TLV
+        if (tlv == 0xFE) break;    // Terminator TLV
+
+        if (i >= userData.size()) return false;
+
+        uint32_t len = userData[i++];
+        if (len == 0xFF) {
+            if (i + 1 >= userData.size()) return false;
+            len = (static_cast<uint32_t>(userData[i]) << 8) | userData[i + 1];
+            i += 2;
+        }
+
+        if (i + len > userData.size()) return false;
+
+        if (tlv == 0x03) {
+            ndefOut.assign(userData.begin() + i, userData.begin() + i + len);
+            return !ndefOut.empty();
+        }
+
+        i += len; // Skip unknown TLV payload
+    }
+
+    return false;
+}
+
+bool buildNdefMessageFromStruct(const RFIDInterface::NdefMessage &src, std::vector<uint8_t> &ndefOut) {
+    ndefOut.clear();
+    if (src.messageSize == 0) return false;
+    if (src.payloadSize == 0) return false;
+
+    ndefOut.reserve(4 + src.payloadSize);
+    ndefOut.push_back(src.header);
+    ndefOut.push_back(src.tnf);
+    ndefOut.push_back(src.payloadSize);
+    ndefOut.push_back(src.payloadType);
+    ndefOut.insert(ndefOut.end(), src.payload, src.payload + src.payloadSize);
+
+    return ndefOut.size() == src.messageSize;
+}
+} // namespace
 
 PN532::PN532(CONNECTION_TYPE connection_type) {
     _connection_type = connection_type;
@@ -145,6 +380,170 @@ int PN532::write_ndef() {
     if (!nfc.readDetectedPassiveTargetID()) return FAILURE;
 
     return write_ndef_blocks();
+}
+
+int PN532::emulate() {
+    static constexpr uint8_t kInsSelectFile = 0xA4;
+    static constexpr uint8_t kInsReadBinary = 0xB0;
+    static constexpr uint8_t kInsUpdateBinary = 0xD6;
+    static constexpr uint16_t kNdefMaxLen = 128;
+    static constexpr uint8_t kMaxResponseData = 252; // +2 SW bytes and 1 command byte for setDataTarget.
+    static const std::vector<uint8_t> kCcFile = {
+        0x00, 0x0F, 0x20, 0x00, 0x3B, 0x00, 0x34, 0x04, 0x06, 0xE1, 0x04, 0x00, 0x80, 0x00, 0xFF
+    };
+    static const std::vector<uint8_t> kNdefAidSelectByName = {
+        0x00, 0x07, 0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01
+    };
+    static const std::vector<uint8_t> kSwOk = {0x90, 0x00};
+    static const std::vector<uint8_t> kSwNotFound = {0x6A, 0x82};
+    static const std::vector<uint8_t> kSwNotSupported = {0x6A, 0x81};
+    static const std::vector<uint8_t> kSwEof = {0x62, 0x82};
+
+    std::vector<uint8_t> emulatedNdefMessage;
+    bool canParseUltralightDump = (uid.sak == PICC_TYPE_MIFARE_UL);
+    if ((!canParseUltralightDump || !extractNdefMessageFromPageDump(strAllPages, emulatedNdefMessage))) {
+        if (!buildNdefMessageFromStruct(this->ndefMessage, emulatedNdefMessage)) {
+            // Fallback test payload if no loaded/read NDEF is available.
+            std::vector<uint8_t> uriPayload = Ndef::urlNdefAbbrv("https://bruce.computer");
+            emulatedNdefMessage = Ndef::newMessage(uriPayload);
+        }
+    }
+    if (emulatedNdefMessage.empty()) return FAILURE;
+    if (emulatedNdefMessage.size() > (kNdefMaxLen - 2)) return FAILURE;
+
+    std::vector<uint8_t> ndefFile(kNdefMaxLen, 0x00);
+    ndefFile[0] = static_cast<uint8_t>((emulatedNdefMessage.size() >> 8) & 0xFF);
+    ndefFile[1] = static_cast<uint8_t>(emulatedNdefMessage.size() & 0xFF);
+    memcpy(ndefFile.data() + 2, emulatedNdefMessage.data(), emulatedNdefMessage.size());
+
+    TagFile currentFile = TagFile::NONE;
+    bool hadInteraction = false;
+    bool targetArmed = false;
+    uint32_t start = millis();
+    uint32_t nextArmTry = 0;
+    bool targetReady = false;
+
+    if (_use_i2c) {
+        // PN532 target mode is sensitive to ESP32 I2C timing/clock stretching.
+        Wire.setClock(100000);
+        Wire.setTimeOut(50);
+    }
+    // `begin()` already wakes and SAMConfig's the PN532. Avoid reusing Adafruit's I2C RDY polling path here.
+
+    while (millis() - start < 60000) {
+        if (check(EscPress) || returnToMenu) {
+            returnToMenu = true;
+            break;
+        }
+        yield();
+        if (!targetReady && millis() >= nextArmTry) {
+            targetReady = tgInitAsTargetIrq(nfc);
+            nextArmTry = millis() + 300;
+            currentFile = TagFile::NONE;
+            if (targetReady) targetArmed = true;
+            if (!targetReady) {
+                delay(20);
+                continue;
+            }
+        }
+
+        uint8_t request[255] = {0};
+        uint8_t request_len = 0;
+        uint8_t tgStatus = 0xFF;
+        if (!tgGetDataIrq(nfc, request, sizeof(request), &request_len, &tgStatus)) {
+            nfc.inRelease();
+            targetReady = false;
+            delay(20);
+            continue;
+        }
+        if (tgStatus == 0x29 || tgStatus == 0x25) {
+            nfc.inRelease();
+            targetReady = false;
+            delay(20);
+            continue;
+        }
+        if (tgStatus != 0x00 || request_len < 5) {
+            delay(10);
+            continue;
+        }
+
+        std::vector<uint8_t> apdu(request, request + request_len);
+        if (apdu.size() < 5) {
+            delay(10);
+            continue;
+        }
+        uint8_t ins = apdu[ApduCommand::C_APDU_INS];
+        uint8_t p1 = apdu[ApduCommand::C_APDU_P1];
+        uint8_t p2 = apdu[ApduCommand::C_APDU_P2];
+        uint8_t lc = apdu[ApduCommand::C_APDU_LC];
+        uint16_t p1p2 = (static_cast<uint16_t>(p1) << 8) | p2;
+        std::vector<uint8_t> response;
+
+        if (ins == kInsSelectFile) {
+            if (p1 == ApduCommand::C_APDU_P1_SELECT_BY_ID) {
+                if (p2 != 0x0C) {
+                    response = kSwOk;
+                } else if (lc == 2 && apdu.size() >= 7 && apdu[ApduCommand::C_APDU_DATA] == 0xE1 &&
+                           (apdu[ApduCommand::C_APDU_DATA + 1] == 0x03 ||
+                            apdu[ApduCommand::C_APDU_DATA + 1] == 0x04)) {
+                    currentFile = (apdu[ApduCommand::C_APDU_DATA + 1] == 0x03) ? TagFile::CC : TagFile::NDEF;
+                    response = kSwOk;
+                } else {
+                    response = kSwNotFound;
+                }
+            } else if (p1 == ApduCommand::C_APDU_P1_SELECT_BY_NAME) {
+                if (apdu.size() >= 12 &&
+                    memcmp(kNdefAidSelectByName.data(), apdu.data() + ApduCommand::C_APDU_P2, 9) == 0) {
+                    response = kSwOk;
+                } else {
+                    response = kSwNotSupported;
+                }
+            } else {
+                response = kSwNotSupported;
+            }
+        } else if (ins == kInsReadBinary) {
+            if (currentFile == TagFile::NONE) {
+                response = kSwNotFound;
+            } else if (p1p2 > kNdefMaxLen) {
+                response = kSwEof;
+            } else {
+                size_t dataLen = (lc == 0) ? kMaxResponseData : std::min<size_t>(lc, kMaxResponseData);
+                if (currentFile == TagFile::CC) {
+                    for (size_t i = 0; i < dataLen; i++) {
+                        size_t idx = static_cast<size_t>(p1p2) + i;
+                        response.push_back(idx < kCcFile.size() ? kCcFile[idx] : 0x00);
+                    }
+                } else {
+                    for (size_t i = 0; i < dataLen; i++) {
+                        size_t idx = static_cast<size_t>(p1p2) + i;
+                        response.push_back(idx < ndefFile.size() ? ndefFile[idx] : 0x00);
+                    }
+                }
+                response.insert(response.end(), kSwOk.begin(), kSwOk.end());
+            }
+        } else if (ins == kInsUpdateBinary) {
+            response = kSwNotSupported;
+        } else {
+            response = kSwNotSupported;
+        }
+
+        hadInteraction = true;
+        if (response.empty() || response.size() > 254) {
+            nfc.inRelease();
+            targetReady = false;
+            delay(20);
+            continue;
+        }
+        if (!tgSetDataIrq(nfc, response.data(), static_cast<uint8_t>(response.size()))) {
+            nfc.inRelease();
+            targetReady = false;
+            delay(20);
+        }
+    }
+
+    nfc.inRelease();
+    if (hadInteraction) return SUCCESS;
+    return targetArmed ? TAG_NOT_PRESENT : FAILURE;
 }
 
 int PN532::load() {

--- a/src/modules/rfid/PN532.h
+++ b/src/modules/rfid/PN532.h
@@ -7,7 +7,9 @@
  */
 
 #include "RFIDInterface.h"
+#define private public
 #include <Adafruit_PN532.h>
+#undef private
 
 class PN532 : public RFIDInterface {
 public:
@@ -46,6 +48,7 @@ public:
     int erase();
     int write(int cardBaudRate = PN532_MIFARE_ISO14443A);
     int write_ndef();
+    int emulate() override;
     int load();
     int save(String filename);
 

--- a/src/modules/rfid/RFIDInterface.h
+++ b/src/modules/rfid/RFIDInterface.h
@@ -92,6 +92,7 @@ public:
     virtual int erase() = 0;
     virtual int write(int cardBaudRate = 0) = 0;
     virtual int write_ndef() = 0;
+    virtual int emulate() { return NOT_IMPLEMENTED; }
     virtual int load() = 0;
     virtual int save(String filename) = 0;
 

--- a/src/modules/rfid/tag_o_matic.h
+++ b/src/modules/rfid/tag_o_matic.h
@@ -22,6 +22,7 @@ public:
         CUSTOM_UID_MODE,
         WRITE_MODE,
         WRITE_NDEF_MODE,
+        EMULATE_MODE,
         ERASE_MODE,
         LOAD_MODE,
         SAVE_MODE
@@ -90,6 +91,7 @@ private:
     void check_card();
     void write_custom_uid();
     void clone_card();
+    void emulate_card();
     void erase_card();
     void write_data();
     void write_ndef_data();


### PR DESCRIPTION
#### Proposed Changes ####

This PR adds **PN532 NFC tag emulation support** to Bruce (tested on **LilyGO T-Embed CC1101 Plus with onboard PN532 over I2C**) and integrates it into the `Tag-O-Matic` workflow.

The implementation can now emulate an NFC Type 4 tag  and supports emulating NDEF content from loaded/read tag data (with some limitations).

#### Types of Changes ####

New Feature

#### Testing ####

Tested on LilyGo T-Embed-CC1101-Plus and iPhone

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
### PN532 emulation backend
- Added `emulate()` to the RFID interface and PN532 implementation.
- Implemented PN532 target-mode (card emulation) APDU handling
- Added NDEF/CC file responses for NFC Forum Type 4 Tag style interactions.
- Added proper exit handling (`Back/Esc`) while emulation is running.

### ESP32 + PN532 (I2C) reliability fixes
- Added a PN532 target-mode path that uses **IRQ-based ready waiting** instead of relying only on the Adafruit I2C RDY polling path.
- Reduced PN532 response reads to avoid I2C over-read timeouts on ESP32 (`Error en ack` / `i2c.master timeout` issues observed during testing).
- Added I2C timing adjustments for emulation mode (100 kHz, shorter timeout) to improve stability.

### Tag-O-Matic UI / workflow integration
- Added `Emulate tag` mode to `Tag-O-Matic` into the **contextual actions** area (shown when tag data is available), alongside actions such as:
  - Clone UID
  - Check tag
  - Write data

### NDEF source selection for emulation
Emulation use this priority:
1. NDEF extracted from loaded/read page dump (`strAllPages`) for supported NTAG/Ultralight dumps
2. Existing in-memory `ndefMessage` (e.g. from `Write NDEF` flow)
3. Fallback test URL (`https://bruce.computer`) if no emulatable NDEF content is available
```

#### Further Comments ####

