### PR TITLE
add js app shortcuts

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -68,6 +68,9 @@ JsonDocument BruceConfig::toJson() const {
     setting["badUSBBLEKeyDelay"] = badUSBBLEKeyDelay;
     setting["badUSBBLEShowOutput"] = badUSBBLEShowOutput;
 
+    JsonArray pinned = setting["pinnedScripts"].to<JsonArray>();
+    for (int i = 0; i < pinnedScripts.size(); i++) { pinned.add(pinnedScripts[i]); }
+
     JsonArray dm = setting["disabledMenus"].to<JsonArray>();
     for (int i = 0; i < disabledMenus.size(); i++) { dm.add(disabledMenus[i]); }
 
@@ -340,7 +343,14 @@ void BruceConfig::fromFile(bool checkFS) {
         count++;
         log_e("Fail");
     }
-
+    if (!setting["pinnedScripts"].isNull()) {
+        pinnedScripts.clear();
+        JsonArray pinned = setting["pinnedScripts"].as<JsonArray>();
+        for (JsonVariant e : pinned) { pinnedScripts.push_back(e.as<String>()); }
+    } else {
+        count++;
+        log_e("Fail");
+    }
     if (!setting["wigleBasicToken"].isNull()) {
         wigleBasicToken = setting["wigleBasicToken"].as<String>();
     } else {
@@ -710,6 +720,25 @@ void BruceConfig::setStartupApp(String value) {
 void BruceConfig::setStartupAppJSInterpreterFile(String value) {
     startupAppJSInterpreterFile = value;
     saveFile();
+}
+
+void BruceConfig::addPinnedScript(String path) {
+    if (!isScriptPinned(path)) {
+        pinnedScripts.push_back(path);
+        saveFile();
+    }
+}
+
+void BruceConfig::removePinnedScript(String path) {
+    auto it = std::find(pinnedScripts.begin(), pinnedScripts.end(), path);
+    if (it != pinnedScripts.end()) {
+        pinnedScripts.erase(it);
+        saveFile();
+    }
+}
+
+bool BruceConfig::isScriptPinned(String path) {
+    return std::find(pinnedScripts.begin(), pinnedScripts.end(), path) != pinnedScripts.end();
 }
 
 void BruceConfig::setWigleBasicToken(String value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -81,6 +81,12 @@ public:
     String startupApp = "";
     String startupAppJSInterpreterFile = "";
     String wigleBasicToken = "";
+    std::vector<String> pinnedScripts;
+
+    void addPinnedScript(String path);
+    void removePinnedScript(String path);
+    bool isScriptPinned(String path);
+
     int devMode = 0;
     int colorInverted = 1;
     int badUSBBLEKeyboardLayout = 0;

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -1,8 +1,64 @@
 #include "main_menu.h"
+#include "../modules/bjs_interpreter/interpreter.h"
 #include "display.h"
+#include "main_menu.h"
 #include "utils.h"
+#include <LittleFS.h>
 #include <globals.h>
+#include <vector>
+class DynamicJSApp : public MenuItemInterface {
+public:
+    String filePath;
 
+    DynamicJSApp(String name, String path) : MenuItemInterface(name) { filePath = path; }
+
+    void optionsMenu() override { run_bjs_script_headless(LittleFS, filePath); }
+
+    void drawIcon(float scale = 1) override {
+        tft.setTextSize(2 * scale);
+        tft.setTextColor(TFT_CYAN);
+        tft.drawCentreString(getName(), tftWidth / 2, tftHeight / 2 - 10, 1);
+
+        tft.setTextSize(1 * scale);
+        tft.setTextColor(TFT_WHITE);
+        tft.drawCentreString("(JS App)", tftWidth / 2, tftHeight / 2 + 15, 1);
+    }
+
+    bool hasTheme() override { return false; }
+
+    String themePath() override { return ""; }
+};
+
+static std::vector<DynamicJSApp *> dynamicHomeApps;
+
+void loadDynamicApps() {
+    for (auto app : dynamicHomeApps) { delete app; }
+    dynamicHomeApps.clear();
+
+    if (!LittleFS.exists("/apps")) {
+        LittleFS.mkdir("/apps");
+        return;
+    }
+
+    File root = LittleFS.open("/apps");
+    if (!root || !root.isDirectory()) return;
+
+    while (true) {
+        bool isDir;
+        String fullPath = root.getNextFileName(&isDir);
+        if (fullPath == "") break;
+
+        if (!isDir && (fullPath.endsWith(".js") || fullPath.endsWith(".JS"))) {
+            String nameOnly = fullPath.substring(fullPath.lastIndexOf("/") + 1);
+            nameOnly = nameOnly.substring(0, nameOnly.lastIndexOf("."));
+
+            DynamicJSApp *newApp = new DynamicJSApp(nameOnly, fullPath);
+            dynamicHomeApps.push_back(newApp);
+        }
+    }
+    root.close();
+}
+// --------------------------------
 MainMenu::MainMenu() {
     _menuItems = {
         &wifiMenu,
@@ -43,6 +99,8 @@ void MainMenu::begin(void) {
     options = {};
 
     std::vector<String> l = bruceConfig.disabledMenus;
+
+    // 1. Load all standard firmware apps
     for (int i = 0; i < _totalItems; i++) {
         String itemName = _menuItems[i]->getName();
         if (find(l.begin(), l.end(), itemName) == l.end()) { // If menu item is not disabled
@@ -69,6 +127,35 @@ void MainMenu::begin(void) {
             );
         }
     }
+
+    loadDynamicApps();
+
+    for (auto app : dynamicHomeApps) {
+        String itemName = app->getName();
+        if (find(l.begin(), l.end(), itemName) == l.end()) {
+            options.push_back(
+                {app->getName(),
+                 [app]() { app->optionsMenu(); },
+                 false,
+                 [](void *menuItem, bool shouldRender) {
+                     if (!shouldRender) return false;
+                     drawMainBorder(false);
+
+                     MenuItemInterface *obj = static_cast<MenuItemInterface *>(menuItem);
+                     float scale = float((float)tftWidth / (float)240);
+                     if (bruceConfigPins.rotation & 0b01) scale = float((float)tftHeight / (float)135);
+                     obj->draw(scale);
+#if defined(HAS_TOUCH)
+                     TouchFooter();
+#endif
+                     return true;
+                 },
+                 app}
+            );
+        }
+    }
+    // ----------------------------------------
+
     _currentIndex = loopOptions(options, MENU_TYPE_MAIN, "Main Menu", _currentIndex);
 };
 

--- a/src/core/main_menu.h
+++ b/src/core/main_menu.h
@@ -35,6 +35,7 @@ public:
     RFMenu rfMenu;
     ScriptsMenu scriptsMenu;
     WifiMenu wifiMenu;
+
 #if !defined(LITE_VERSION)
     LoRaMenu loraMenu;
     EthernetMenu ethernetMenu;

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -2,6 +2,7 @@
 #include "core/display.h"
 #include "core/i2c_finder.h"
 #include "core/main_menu.h"
+#include "core/sd_functions.h"
 #include "core/settings.h"
 #include "core/utils.h"
 #include "core/wifi/wifi_common.h"
@@ -168,6 +169,7 @@ void ConfigMenu::systemMenu() {
              }                                                                                                           },
             {"Startup App",                                                         [this]() { setStartupApp(); }        },
             {"Hide/Show Apps",                                                      [this]() { mainMenu.hideAppsMenu(); }},
+            {"Pinned Apps",                                                         [this]() { pinnedAppsMenu(); }       },
             {"Clock",                                                               [this]() { setClock(); }             },
             {"Advanced",                                                            [this]() { advancedMenu(); }         },
             {"Back",                                                                []() {}                              },

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -86,6 +86,8 @@ void setWifiStartupConfig();
 
 void setStartupApp();
 
+void pinnedAppsMenu();
+
 void setGpsBaudrateMenu();
 
 void setNetworkCredsMenu();

--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -225,73 +225,8 @@ std::vector<Option> getScriptsOptionsList(String currentPath, bool saveStartupSc
                                    bruceConfig.startupAppJSInterpreterFile = fullPath;
                                    bruceConfig.saveFile();
                                } else {
-
-                                   String pinnedPath = "/apps/" + nameOnly;
-                                   bool isPinned = LittleFS.exists(pinnedPath);
-
-                                   std::vector<Option> scriptActionMenu;
-
-                                   scriptActionMenu.push_back(
-                                       {"Run App", [=]() {
-                                            Serial.printf("Running script: %s\n", fullPath.c_str());
-                                            run_bjs_script_headless(*fs, fullPath);
-                                        }}
-                                   );
-
-                                   if (isPinned) {
-                                       scriptActionMenu.push_back(
-                                           {"Unpin from Home", [=]() {
-                                                LittleFS.remove(pinnedPath);
-
-                                                tft.fillScreen(TFT_BLACK);
-                                                tft.setTextSize(FM);
-                                                tft.setTextColor(TFT_ORANGE);
-                                                tft.drawCentreString(
-                                                    "App Unpinned!", tftWidth / 2, tftHeight / 2 - 10, 1
-                                                );
-                                                tft.setTextColor(TFT_WHITE);
-                                                tft.drawCentreString(
-                                                    "Reboot to apply", tftWidth / 2, tftHeight / 2 + 15, 1
-                                                );
-
-                                                vTaskDelay(pdMS_TO_TICKS(1500));
-                                                returnToMenu = true;
-                                            }}
-                                       );
-                                   } else {
-                                       scriptActionMenu.push_back(
-                                           {"Pin to Home", [=]() {
-                                                if (!LittleFS.exists("/apps")) { LittleFS.mkdir("/apps"); }
-
-                                                File src = fs->open(fullPath, FILE_READ);
-                                                File dst = LittleFS.open(pinnedPath, FILE_WRITE);
-
-                                                if (src && dst) {
-                                                    size_t n;
-                                                    uint8_t buf[128];
-                                                    while ((n = src.read(buf, sizeof(buf))) > 0) {
-                                                        dst.write(buf, n);
-                                                    }
-                                                }
-                                                if (src) src.close();
-                                                if (dst) dst.close();
-
-                                                tft.fillScreen(TFT_BLACK);
-                                                tft.setTextSize(FM);
-                                                tft.setTextColor(TFT_GREEN);
-                                                tft.drawCentreString(
-                                                    "App Pinned!", tftWidth / 2, tftHeight / 2 - 10, 1
-                                                );
-                                                tft.setTextColor(TFT_WHITE);
-                                                vTaskDelay(pdMS_TO_TICKS(1500));
-                                                returnToMenu = true;
-                                            }}
-                                       );
-                                   }
-
-                                   // Trigger the UI for the submenu
-                                   loopOptions(scriptActionMenu, MENU_TYPE_SUBMENU, entry_title.c_str());
-                                   // -------------------------------------------------
+                                   Serial.printf("Running script: %s\n", fullPath.c_str());
+                                   run_bjs_script_headless(*fs, fullPath);
                                }
                            }});
         }

--- a/src/modules/dynamicjs/dynamicjs.cpp
+++ b/src/modules/dynamicjs/dynamicjs.cpp
@@ -1,0 +1,24 @@
+#include "./dynamicjs.h"
+#include "./modules/bjs_interpreter/interpreter.h"
+#include "core/utils.h"
+#include <LittleFS.h>
+
+DynamicJSApp::DynamicJSApp(String name, String path, FS *fileSystem) : MenuItemInterface(name) {
+    filePath = path;
+    fs = fileSystem;
+}
+
+void DynamicJSApp::optionsMenu() { run_bjs_script_headless(*fs, filePath); }
+
+void DynamicJSApp::drawIcon(float scale) {
+    tft.setTextSize(2 * scale);
+    tft.setTextColor(TFT_CYAN);
+    tft.drawCentreString(getName(), tftWidth / 2, tftHeight / 2 - 10, 1);
+
+    tft.setTextSize(1 * scale);
+    tft.setTextColor(TFT_WHITE);
+    tft.drawCentreString("(JS App)", tftWidth / 2, tftHeight / 2 + 15, 1);
+}
+
+bool DynamicJSApp::hasTheme() { return false; }
+String DynamicJSApp::themePath() { return ""; }

--- a/src/modules/dynamicjs/dynamicjs.h
+++ b/src/modules/dynamicjs/dynamicjs.h
@@ -1,0 +1,16 @@
+#include "MenuItemInterface.h"
+#include <FS.h>
+
+class DynamicJSApp : public MenuItemInterface {
+public:
+    String filePath;
+    FS *fs; // <--- Store the filesystem pointer here
+
+    // Require the filesystem in the constructor
+    DynamicJSApp(String name, String path, FS *fileSystem);
+
+    void optionsMenu() override;
+    void drawIcon(float scale = 1) override;
+    bool hasTheme() override;
+    String themePath() override;
+};

--- a/src/modules/dynamicjs/dynamicjs.h
+++ b/src/modules/dynamicjs/dynamicjs.h
@@ -4,9 +4,8 @@
 class DynamicJSApp : public MenuItemInterface {
 public:
     String filePath;
-    FS *fs; // <--- Store the filesystem pointer here
+    FS *fs; 
 
-    // Require the filesystem in the constructor
     DynamicJSApp(String name, String path, FS *fileSystem);
 
     void optionsMenu() override;


### PR DESCRIPTION
- Proposed Changes
Added a way to pin custom JS scripts directly to the main home screen. Instead of digging through the Scripts app every time you want to use a favorite tool, you can now just pin it to the main carousel.

When you select a script, instead of just running it immediately, it now opens a small submenu with:

    Run App: Runs it normally.

    Pin to Home: Copies the file to a new /apps folder on LittleFS.

    Unpin from Home: (Shows up if it's already pinned) Removes it from the /apps folder.

Under the hood, I added a DynamicJSApp class in main_menu.cpp. It scans the /apps folder and dynamically generates menu items for whatever it finds there, injecting them straight into the main menu.
Types of Changes

    [x] New Feature (non-breaking change which adds functionality)

    [x] UI/UX Improvement

    [ ] Bugfix (non-breaking change which fixes an issue)

    [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

- Verification

    Upload a .js file to /scripts via the WebUI.

    Open JS Interpreter on the device.

    Click your script and select Pin to Home.

    Back out to the main menu—you'll see your script right there in the carousel.

    Go back to JS Interpreter,click the same script, and hit Unpin from Home. Back out to the main menu and it's gone.

- Testing

Tested manually on my board using LittleFS.

    Verified that copying the files to and from /apps/ works cleanly.
