### PR TITLE
JS Interpreter Add RSSI and Channel to WiFi Object

### DIFF
--- a/src/modules/bjs_interpreter/wifi_js.cpp
+++ b/src/modules/bjs_interpreter/wifi_js.cpp
@@ -85,6 +85,8 @@ JSValue native_wifiScan(JSContext *ctx, JSValue *this_val, int argc, JSValue *ar
         JS_SetPropertyStr(ctx, obj, "encryptionType", JS_NewString(ctx, enctype));
         JS_SetPropertyStr(ctx, obj, "SSID", JS_NewString(ctx, WiFi.SSID(i).c_str()));
         JS_SetPropertyStr(ctx, obj, "MAC", JS_NewString(ctx, WiFi.BSSIDstr(i).c_str()));
+        JS_SetPropertyStr(ctx, obj, "RSSI", JS_NewInt32(ctx, WiFi.RSSI(i)));
+        JS_SetPropertyStr(ctx, obj, "channel", JS_NewInt32(ctx, WiFi.channel(i)));
         JS_SetPropertyUint32(ctx, arr, idx++, obj);
     }
     return arr;


### PR DESCRIPTION
#### Proposed Changes ####

* JS Interpreter Add RSSI and Channel to WiFi Object


Due to line ending differences in the last commit which have been fixed in this commit the lines changed are 88-89 in wifi_js.cpp

#### Types of Changes ####

New Feature

#### Verification ####

<img width="687" height="198" alt="image" src="https://github.com/user-attachments/assets/09ee9583-5854-4e68-9009-20cbf6bafa55" />


<img width="885" height="366" alt="image" src="https://github.com/user-attachments/assets/d0f2dae6-f08d-4193-b18a-1757ad494a78" />

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

