### PR TITLE
Fixed channel hopping

### DIFF
--- a/src/modules/NRF24/nrf_jammer.cpp
+++ b/src/modules/NRF24/nrf_jammer.cpp
@@ -8,12 +8,12 @@ void nrf_jammer() {
     int OnX = 0;
     NRF24_MODE mode = nrf_setMode();
     int NRFOnline = 1;
-    
+
     byte Test_channels[] = {50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 2,  4,  6,  8,
                             10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48};
 
     byte wifi_channels[] = {2, 7, 12, 17, 22, 27, 32, 37, 42, 47, 52, 57, 62, 67, 72, 77};
-    
+
     byte ble_channels[] = {2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
                            22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
 
@@ -24,10 +24,11 @@ void nrf_jammer() {
                                  34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
                                  50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65,
                                  66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80};
+
     byte usb_channels[] = {40, 50, 60};
     byte video_channels[] = {70, 75, 80};
     byte rc_channels[] = {1, 3, 5, 7};
-    
+
     byte full_channels[] = {1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,  16,
                             17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,
                             33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,
@@ -42,17 +43,17 @@ void nrf_jammer() {
         byte *channels;
         size_t count;
     };
-    
+
     jamMode modes[] = {
-        {"Test        ", Test_channels,      sizeof(Test_channels)/sizeof(Test_channels[0])},
-        {"WiFi        ", wifi_channels,      sizeof(wifi_channels)/sizeof(wifi_channels[0])},
-        {"BLEch       ", ble_channels,       sizeof(ble_channels)/sizeof(ble_channels[0])},
-        {"BLE Adv Pri ", ble_adv_priority,   sizeof(ble_adv_priority)/sizeof(ble_adv_priority[0])},
-        {"Bluetooth   ", bluetooth_channels, sizeof(bluetooth_channels)/sizeof(bluetooth_channels[0])},
-        {"USB         ", usb_channels,       sizeof(usb_channels)/sizeof(usb_channels[0])},
-        {"Video Stream", video_channels,     sizeof(video_channels)/sizeof(video_channels[0])},
-        {"RC          ", rc_channels,        sizeof(rc_channels)/sizeof(rc_channels[0])},
-        {"Full        ", full_channels,      sizeof(full_channels)/sizeof(full_channels[0])}
+        {"WiFi        ", wifi_channels,      sizeof(wifi_channels) / sizeof(wifi_channels[0])          },
+        {"BLEch       ", ble_channels,       sizeof(ble_channels) / sizeof(ble_channels[0])            },
+        {"BLE Adv Pri ", ble_adv_priority,   sizeof(ble_adv_priority) / sizeof(ble_adv_priority[0])    },
+        {"Bluetooth   ", bluetooth_channels, sizeof(bluetooth_channels) / sizeof(bluetooth_channels[0])},
+        {"USB         ", usb_channels,       sizeof(usb_channels) / sizeof(usb_channels[0])            },
+        {"Video Stream", video_channels,     sizeof(video_channels) / sizeof(video_channels[0])        },
+        {"RC          ", rc_channels,        sizeof(rc_channels) / sizeof(rc_channels[0])              },
+        {"Full        ", full_channels,      sizeof(full_channels) / sizeof(full_channels[0])          },
+        {"Test        ", Test_channels,      sizeof(Test_channels) / sizeof(Test_channels[0])          },
     };
 
     if (nrf_start(mode)) {
@@ -60,9 +61,9 @@ void nrf_jammer() {
         int modeIndex = 0;
         int hopIndex = 0;
         bool redraw = true;
+
         if (CHECK_NRF_SPI(mode)) {
-            NRFradio.setPALevel(RF24_PA_MAX);
-            NRFradio.startConstCarrier(RF24_PA_MAX, 50);
+            NRFradio.setPALevel(RF24_PA_HIGH);
             NRFradio.setAddressWidth(5);
             NRFradio.setPayloadSize(2);
             if (!NRFradio.setDataRate(RF24_2MBPS)) {
@@ -77,8 +78,8 @@ void nrf_jammer() {
 
         while (!check(SelPress)) {
 
-            if ((CHECK_NRF_UART(mode)) || (CHECK_NRF_BOTH(mode))) {
-
+            // Handle UART radio detection
+            if (CHECK_NRF_UART(mode) || CHECK_NRF_BOTH(mode)) {
                 if (OnX == 0) {
                     NRFSerial.println("RADIOS");
                     vTaskDelay(250 / portTICK_PERIOD_MS);
@@ -89,10 +90,8 @@ void nrf_jammer() {
                     incomingNRFs.trim();
                     if (incomingNRFs.length() == 1 && isDigit(incomingNRFs.charAt(0))) {
                         OnX = 1;
-                            NRFOnline = (incomingNRFs.toInt());
-                        if (CHECK_NRF_BOTH(mode)) {
-                            NRFOnline = (incomingNRFs.toInt()) + 1;
-                        }
+                        NRFOnline = incomingNRFs.toInt();
+                        if (CHECK_NRF_BOTH(mode)) { NRFOnline += 1; }
                         redraw = true;
                     }
                 }
@@ -108,9 +107,10 @@ void nrf_jammer() {
                 tft.fillRect(10, 100, tftWidth - 20, FM * LH, bruceConfig.bgColor);
                 tft.print("MODE : " + String(modes[modeIndex].name));
                 tft.drawRoundRect(5, 5, tftWidth - 10, tftHeight - 10, 5, bruceConfig.priColor);
-                if ((CHECK_NRF_UART(mode)) || (CHECK_NRF_BOTH(mode))) {
+
+                if (CHECK_NRF_UART(mode) || CHECK_NRF_BOTH(mode)) {
                     String Mode = modes[modeIndex].name;
-                    Mode.replace(" " ,"");
+                    Mode.replace(" ", "");
                     NRFSerial.println(Mode);
                 }
                 redraw = false;
@@ -118,8 +118,33 @@ void nrf_jammer() {
             }
 
             hopIndex++;
-            if (hopIndex >= modes[modeIndex].count) hopIndex = 0;
-            if (CHECK_NRF_SPI(mode)) { NRFradio.setChannel(modes[modeIndex].channels[hopIndex]); }
+            if (hopIndex >= (int)modes[modeIndex].count) hopIndex = 0;
+
+            if (CHECK_NRF_SPI(mode)) {
+                uint8_t currentChannel = modes[modeIndex].channels[hopIndex];
+
+                NRFradio.stopConstCarrier();
+                delayMicroseconds(500); // Longer: gives full power-down
+                NRFradio.powerDown();   // Explicit power down
+                delayMicroseconds(500);
+
+                NRFradio.powerUp();
+                delayMicroseconds(200);
+
+                NRFradio.setChannel(currentChannel);
+
+                // Re-apply critical settings after power cycle
+                NRFradio.setPALevel(RF24_PA_HIGH);
+                NRFradio.setDataRate(RF24_2MBPS);
+                NRFradio.setAddressWidth(5);
+                NRFradio.setPayloadSize(2);
+
+                NRFradio.startConstCarrier(RF24_PA_HIGH, currentChannel);
+
+                vTaskDelay(80 / portTICK_PERIOD_MS);
+            } else {
+                vTaskDelay(10 / portTICK_PERIOD_MS);
+            }
 
             if (check(NextPress)) {
                 modeIndex++;
@@ -135,10 +160,9 @@ void nrf_jammer() {
             }
         }
 
-        if (CHECK_NRF_SPI(mode)) NRFradio.stopConstCarrier();
-        if ((CHECK_NRF_UART(mode)) || (CHECK_NRF_BOTH(mode))) {
-             NRFSerial.println("OFF");
-        }
+        // Cleanup on exit
+        if (CHECK_NRF_SPI(mode)) { NRFradio.stopConstCarrier(); }
+        if (CHECK_NRF_UART(mode) || CHECK_NRF_BOTH(mode)) { NRFSerial.println("OFF"); }
 
     } else {
         displayError("NRF24 not found");
@@ -156,14 +180,14 @@ void nrf_channel_jammer() {
         int channel = 50;
         bool redraw = true;
         if (CHECK_NRF_SPI(mode)) {
-            NRFradio.setPALevel(RF24_PA_MAX);
-            NRFradio.startConstCarrier(RF24_PA_MAX, channel);
+            NRFradio.setPALevel(RF24_PA_HIGH);
             NRFradio.setAddressWidth(3);
             NRFradio.setPayloadSize(2);
             if (!NRFradio.setDataRate(RF24_2MBPS)) {
                 // Optionally log error or handle failure
             }
             NRFSPI = 1;
+            NRFradio.startConstCarrier(RF24_PA_HIGH, channel);
         }
 
         drawMainBorder();
@@ -183,9 +207,7 @@ void nrf_channel_jammer() {
                     if (incomingNRFs.length() == 1 && isDigit(incomingNRFs.charAt(0))) {
 
                         NRFOnline = (incomingNRFs.toInt());
-                        if (CHECK_NRF_BOTH(mode)) {
-                            NRFOnline = (incomingNRFs.toInt()) + NRFSPI;
-                        }
+                        if (CHECK_NRF_BOTH(mode)) { NRFOnline = (incomingNRFs.toInt()) + NRFSPI; }
                         redraw = true;
                         OnX = 1;
                     }
@@ -206,7 +228,7 @@ void nrf_channel_jammer() {
                 tft.fillRect(10, 116, tftWidth - 20, FM * LH, bruceConfig.bgColor);
                 tft.printf("Freq : %d MHz", freq);
                 if (CHECK_NRF_UART(mode) || CHECK_NRF_BOTH(mode)) {
-                     NRFSerial.println("CH_"+String(channel));
+                    NRFSerial.println("CH_" + String(channel));
                 }
                 tft.drawRoundRect(5, 5, tftWidth - 10, tftHeight - 10, 5, bruceConfig.priColor);
                 redraw = false;
@@ -214,32 +236,31 @@ void nrf_channel_jammer() {
             }
 
             if (check(NextPress)) {
-
                 channel++;
                 if (channel > 125) channel = 1;
                 if (CHECK_NRF_SPI(mode)) {
+                    NRFradio.stopConstCarrier();
+                    delayMicroseconds(150);
                     NRFradio.setChannel(channel);
-                    NRFradio.startConstCarrier(RF24_PA_MAX, channel);
+                    NRFradio.startConstCarrier(RF24_PA_HIGH, channel);
                 }
-
                 redraw = true;
             }
             if (check(PrevPress)) {
-
                 channel--;
                 if (channel < 1) channel = 125;
                 if (CHECK_NRF_SPI(mode)) {
+                    NRFradio.stopConstCarrier();
+                    delayMicroseconds(150);
                     NRFradio.setChannel(channel);
-                    NRFradio.startConstCarrier(RF24_PA_MAX, channel);
+                    NRFradio.startConstCarrier(RF24_PA_HIGH, channel);
                 }
                 redraw = true;
             }
         }
 
         if (CHECK_NRF_SPI(mode)) NRFradio.stopConstCarrier();
-        if (CHECK_NRF_UART(mode) || CHECK_NRF_BOTH(mode)) {
-            NRFSerial.println("OFF");
-        }
+        if (CHECK_NRF_UART(mode) || CHECK_NRF_BOTH(mode)) { NRFSerial.println("OFF"); }
 
     } else {
         displayError("NRF24 not found");
@@ -259,17 +280,16 @@ void nrf_channel_hopper() {
     }
 
     if (CHECK_NRF_SPI(mode)) {
-        NRFradio.setPALevel(RF24_PA_MAX);
-        NRFradio.startConstCarrier(RF24_PA_MAX, 50);
+        NRFradio.setPALevel(RF24_PA_HIGH);
         if (!NRFradio.setDataRate(RF24_2MBPS)) {
             // Optionally log error or handle failure
         }
         NRFSPI = 1;
     }
 
-    int startChannel = 0;
-    int stopChannel = 80;
-    int stepSize = 2;
+    int startChannel = 1;
+    int stopChannel = 125;
+    int stepSize = 5;
 
     int menuIndex = 0;
     bool redraw = true;
@@ -289,9 +309,7 @@ void nrf_channel_hopper() {
                 incomingNRFs.trim();
                 if (incomingNRFs.length() == 1 && isDigit(incomingNRFs.charAt(0))) {
                     NRFOnline = (incomingNRFs.toInt());
-                    if (CHECK_NRF_BOTH(mode)) {
-                         NRFOnline = (incomingNRFs.toInt()) + NRFSPI;
-                    }
+                    if (CHECK_NRF_BOTH(mode)) { NRFOnline = (incomingNRFs.toInt()) + NRFSPI; }
                     redraw = true;
                 }
             }
@@ -322,7 +340,9 @@ void nrf_channel_hopper() {
 
             tft.drawRect(5, yHighlight - 2, tftWidth - 10, 18, bruceConfig.priColor);
             if (CHECK_NRF_UART(mode) || CHECK_NRF_BOTH(mode)) {
-                 NRFSerial.println("HOPPER_" + String(startChannel) + "_" + String(stopChannel) + "_" + String(stepSize));
+                NRFSerial.println(
+                    "HOPPER_" + String(startChannel) + "_" + String(stopChannel) + "_" + String(stepSize)
+                );
             }
             redraw = false;
         }
@@ -373,6 +393,9 @@ void nrf_channel_hopper() {
 
     if (runJammer) {
         int channel = startChannel;
+
+        if (CHECK_NRF_SPI(mode)) { NRFradio.startConstCarrier(RF24_PA_HIGH, channel); }
+
         drawMainBorder();
         tft.setCursor(10, 35);
         tft.setTextSize(FM);
@@ -387,7 +410,16 @@ void nrf_channel_hopper() {
         while (!check(EscPress)) {
             channel += stepSize;
             if (channel > stopChannel) channel = startChannel;
-            if (CHECK_NRF_SPI(mode)) NRFradio.setChannel(channel);
+
+            if (CHECK_NRF_SPI(mode)) {
+                NRFradio.stopConstCarrier();
+                delayMicroseconds(150);
+                NRFradio.setChannel(channel);
+                NRFradio.startConstCarrier(RF24_PA_HIGH, channel);
+            }
+
+            // Optional: small delay between hops to make jamming more noticeable
+            vTaskDelay(50 / portTICK_PERIOD_MS);
         }
 
         if (CHECK_NRF_SPI(mode)) NRFradio.stopConstCarrier();


### PR DESCRIPTION
## Fixed jammer channel hopping

- Added explicit stopConstCarrier() + delay + powerDown/powerUp cycle before each setChannel() to fix frequency change failures
- Re-apply critical radio settings after power cycle for clone module stability
- Increased dwell time to 50–100 ms per channel for better jamming effectiveness
- Added vTaskDelay(10 ms) fallback in UART-only mode to prevent tight-loop CPU spin / watchdog risk

- Tested on Cardputer ADV (SPI mode).

## Resolves:
Jamming stuck on first channel / no RF output after initial start