### PR TITLE
Add new board nm-cyd-c5, new Cheap Yellow Display with ESP32-C5 which support dual band wifi ( 2.4G/5.8G)

### DIFF
--- a/boards/nm-cyd-c5/connections.md
+++ b/boards/nm-cyd-c5/connections.md
@@ -1,0 +1,39 @@
+# Pinouts diagram to use Bruce
+
+## USING NM-CYD-C5, with SPI / CC1101 and NRF24 work with NM-RF-HAT
+
+| Device  | SCK   | MISO  | MOSI  | CS    | GDO0/CE | TFT_DC | TFT_RST | TFT_BL |
+| ---     | :---: | :---: | :---: | :---: | :---:   | :---:  | :---:   | :---:  |
+| Display | 6     | 2     | 7     | 23    | ---     | 24     | C5 RST  | 25     |
+| SD Card | 6     | 2     | 7     | 10    | ---     | ---    |  ---    | ---    |
+| CC1101  | 6     | 2     | 7     | 9*    | 8*      | ---    |  ---    | ---    |
+| NRF24   | 6     | 2     | 7     | 9*    | 8*      | ---    |  ---    | ---    |
+
+(*) CC1101, NRF24, W5500 use the same pinouts, need to add a switch on CS and CE/GDO0 to choose which to use.
+
+
+If using ST7789 with XPT2046 fo touchscreen, in this case you have 2 GPIO available (0 and 28) to use on CC1101/NRF24
+| Device  | SCK   | MISO  | MOSI  | CS    | IRQ   |
+| ---     | :---: | :---: | :---: | :---: | :---: |
+| Display | 6     | 2     | 7     | 23    | ---   |
+| Touch   | 6     | 2     | 7     | 1     | ---   |
+
+
+| Device  | RX    | TX    | GPIO  |
+| ---     | :---: | :---: | :---: |
+| GPS     | 4     | 5     | ---   |
+| IR RX   |  ---  | ---   | 9     |
+| IR TX   |  ---  | ---   | 8     |
+| LED     |  ---  | ---   | 27    |
+| 433 RX  |  ---  | ---   | 9     |
+| 433 TX  |  ---  | ---   | 8     |
+
+ESP32-C5 doesn't support USB-OTG, for BadUSB you need to use a CH9329 module
+
+FM Radio, PN532 on I2C, other I2C devices, CH9329, Temperature and humidity sensor: BME280.
+I2C SDA: 9
+I2C SCL: 8
+
+Serial interface to other devices (Flipper) - USB TypeC interface on NM-CYD-C5
+Serial Tx: 11
+Serial Rx: 12

--- a/boards/nm-cyd-c5/interface.cpp
+++ b/boards/nm-cyd-c5/interface.cpp
@@ -1,0 +1,174 @@
+#include "core/powerSave.h"
+#include "core/utils.h"
+#include <interface.h>
+
+/***************************************************************************************
+** Function name: _setup_gpio()
+** Location: main.cpp
+** Description:   initial setup for the device
+***************************************************************************************/
+void _setup_gpio() {
+
+    pinMode(TFT_CS, OUTPUT);
+    digitalWrite(TFT_CS, HIGH);
+    pinMode(TFT_MOSI, OUTPUT);
+    digitalWrite(TFT_MOSI, HIGH);
+    pinMode(TFT_SCLK, OUTPUT);
+
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, HIGH);
+    pinMode(TFT_RST, OUTPUT);
+    pinMode(TFT_DC, OUTPUT);
+    digitalWrite(TFT_DC, HIGH);
+
+#ifdef HAS_3_BUTTONS
+    pinMode(UP_BTN, INPUT_PULLUP); // Sets the power btn as an INPUT
+    pinMode(SEL_BTN, INPUT_PULLUP);
+    pinMode(DW_BTN, INPUT_PULLUP);
+#endif
+    pinMode(NRF24_SS_PIN, OUTPUT);
+    pinMode(CC1101_SS_PIN, OUTPUT);
+    pinMode(SDCARD_CS, OUTPUT);
+    pinMode(W5500_SS_PIN, OUTPUT);
+    pinMode(TFT_CS, OUTPUT);
+
+    digitalWrite(NRF24_SS_PIN, HIGH);
+    digitalWrite(CC1101_SS_PIN, HIGH);
+    digitalWrite(SDCARD_CS, HIGH);
+    digitalWrite(W5500_SS_PIN, HIGH);
+    digitalWrite(TFT_CS, HIGH);
+#ifdef ST7789_DRIVER
+    bruceConfig.colorInverted = 0;
+#endif
+#ifdef ILI9341_DRIVER
+    bruceConfig.colorInverted = 0;
+#endif
+}
+/***************************************************************************************
+** Function name: _post_setup_gpio()
+** Location: main.cpp
+** Description:   second stage gpio setup to make a few functions work
+***************************************************************************************/
+void _post_setup_gpio() {
+#ifdef HAS_TOUCH
+    pinMode(TOUCH_CS, OUTPUT);
+    uint16_t calData[5] = {225, 3413, 403, 3334, 1};
+    tft.setTouch(calData);
+#endif
+    bruceConfigPins.gps_bus.rx = (gpio_num_t)GPS_SERIAL_RX;
+    bruceConfigPins.gps_bus.tx = (gpio_num_t)GPS_SERIAL_TX;
+    bruceConfigPins.gpsBaudrate = 9600;
+    bruceConfigPins.rfTx = 8;
+    bruceConfigPins.rfRx = 9;
+}
+
+/***************************************************************************************
+** Function name: getBattery()
+** location: display.cpp
+** Description:   Delivers the battery value from 1-100
+***************************************************************************************/
+int getBattery() { return 0; }
+
+/***************************************************************************************
+** Function name: isCharging()
+** Description:   Default implementation that returns false
+***************************************************************************************/
+bool isCharging() { return false; }
+
+/*********************************************************************
+** Function: setBrightness
+** location: settings.cpp
+** set brightness value
+**********************************************************************/
+void _setBrightness(uint8_t brightval) {
+    if (brightval == 0) {
+        analogWrite(TFT_BL, brightval);
+    } else {
+        int bl = MINBRIGHT + round(((255 - MINBRIGHT) * brightval / 100));
+        analogWrite(TFT_BL, bl);
+    }
+}
+
+/*********************************************************************
+** Function: InputHandler
+** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
+**********************************************************************/
+void InputHandler(void) {
+    static unsigned long tm = 0;
+    if (millis() - tm < 200 && !LongPress) return;
+#ifdef HAS_TOUCH
+    TouchPoint t;
+    checkPowerSaveTime();
+    bool _IH_touched = tft.getTouch(&t.x, &t.y);
+    if (_IH_touched) {
+        NextPress = false;
+        PrevPress = false;
+        UpPress = false;
+        DownPress = false;
+        SelPress = false;
+        EscPress = false;
+        AnyKeyPress = false;
+        NextPagePress = false;
+        PrevPagePress = false;
+        touchPoint.pressed = false;
+        _IH_touched = false;
+        Serial.printf("\nRAW: Touch Pressed on x=%d, y=%d", t.x, t.y);
+        if (bruceConfigPins.rotation == 3) {
+            t.y = (tftHeight + 20) - t.y;
+            t.x = tftWidth - t.x;
+        }
+        if (bruceConfigPins.rotation == 0) {
+            uint16_t tmp = t.x;
+            t.x = map((tftHeight + 20) - t.y, 0, 320, 0, 240);
+            t.y = map(tmp, 0, 240, 0, 320);
+        }
+        if (bruceConfigPins.rotation == 2) {
+            uint16_t tmp = t.x;
+            t.x = map(t.y, 0, 320, 0, 240);
+            t.y = map(tftWidth - tmp, 0, 240, 0, 320);
+        }
+
+        Serial.printf("\nROT: Touch Pressed on x=%d, y=%d, rot=%d\n", t.x, t.y, bruceConfigPins.rotation);
+
+        if (!wakeUpScreen()) AnyKeyPress = true;
+        else return;
+
+        // Touch point global variable
+        touchPoint.x = t.x;
+        touchPoint.y = t.y;
+        touchPoint.pressed = true;
+        touchHeatMap(touchPoint);
+        tm = millis();
+    }
+
+#endif
+#ifdef HAS_3_BUTTONS
+    bool upPressed = (digitalRead(UP_BTN) == LOW);
+    bool selPressed = (digitalRead(SEL_BTN) == LOW);
+    bool dwPressed = (digitalRead(DW_BTN) == LOW);
+
+    bool anyPressed = upPressed || selPressed || dwPressed;
+    if (anyPressed) tm = millis();
+    if (anyPressed && wakeUpScreen()) return;
+
+    AnyKeyPress = anyPressed;
+    PrevPress = upPressed;
+    EscPress = upPressed && dwPressed;
+    NextPress = dwPressed;
+    SelPress = selPressed;
+#endif
+}
+
+/*********************************************************************
+** Function: powerOff
+** location: mykeyboard.cpp
+** Turns off the device (or try to)
+**********************************************************************/
+void powerOff() {}
+
+/*********************************************************************
+** Function: checkReboot
+** location: mykeyboard.cpp
+** Btn logic to turnoff the device (name is odd btw)
+**********************************************************************/
+void checkReboot() {}

--- a/boards/nm-cyd-c5/nm-cyd-c5.ini
+++ b/boards/nm-cyd-c5/nm-cyd-c5.ini
@@ -1,0 +1,58 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:nm-cyd-c5]
+board = esp32-c5-devkitc-1
+board_build.partitions = custom_8Mb.csv
+build_src_filter =${env.build_src_filter} +<../boards/nm-cyd-c5>
+build_flags =
+	${env.build_flags}
+	-Iboards/nm-cyd-c5
+	-DDEVICE_NAME='"ESP32-C5"'
+	-DNM_CYD_ESP32C5=1
+	-DBOARD_HAS_PSRAM=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DARDUINO_USB_MODE=1
+	-DCORE_DEBUG_LEVEL=1
+	-DHAS_TOUCH=1
+	-DROTATION=3
+
+	-DGPS_SERIAL_TX=5
+	-DGPS_SERIAL_RX=4
+	; grove pins
+	; defaults from https://github.com/espressif/arduino-esp32/blob/master/variants/esp32s3/pins_arduino.h
+	-DGROVE_SDA=8  ; default RF TX pin
+	-DGROVE_SCL=9  ; default IR/RF RX pin
+	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	; ir led pin
+	-DIR_TX_PINS='{{"Pin 9", 9}, {"Pin 8", 8}}'
+	-DIR_RX_PINS='{{"Pin 9", 9}, {"Pin 8", 8}}'
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	;Radio Frequency (one pin modules) pin setting
+	-DRF_TX_PINS='{{"Pin 9", 9}, {"Pin 8", 8}}'
+	-DRF_RX_PINS='{{"Pin 9", 9}, {"Pin 8", 8}}'
+
+	; text sizes
+	-DFP=1
+	-DFM=2
+	-DFG=3
+	; ui control buttons
+	;-DSEL_BTN=1
+	;-DUP_BTN=2  ; also work as ESC
+	;-DDW_BTN=3  ; also work as NEXT
+	-DBTN_ALIAS='"OK"'
+
+	;FM Radio
+	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+
+

--- a/boards/nm-cyd-c5/pins_arduino.h
+++ b/boards/nm-cyd-c5/pins_arduino.h
@@ -1,0 +1,146 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+#define PIN_RGB_LED 27
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
+#define BUILTIN_LED LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
+static const uint8_t TX = 11;
+static const uint8_t RX = 12;
+
+static const uint8_t USB_DM = 13;
+static const uint8_t USB_DP = 14;
+
+static const uint8_t SDA = 4;
+static const uint8_t SCL = 5;
+
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 7;
+static const uint8_t MISO = 2;
+static const uint8_t SCK = 6;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+
+// LP I2C Pins are fixed on ESP32-C5
+static const uint8_t LP_SDA = 4;
+static const uint8_t LP_SCL = 5;
+#define WIRE1_PIN_DEFINED
+#define SDA1 LP_SDA
+#define SCL1 LP_SCL
+
+// LP UART Pins are fixed on ESP32-C5
+static const uint8_t LP_RX = 12;
+static const uint8_t LP_TX = 11;
+
+#define HAS_RGB_LED 1
+#define LED_ORDER GRB
+#define LED_TYPE_IS_RGBW 1
+#define LED_COUNT 1
+#define LED_TYPE WS2812
+#define LED_COLOR_STEP 15
+#define RGB_LED 27
+
+/* Communication Buses*/
+// UART
+#define SERIAL_TX 11
+#define SERIAL_RX 12
+// I2C
+#define GROVE_SDA 8
+#define GROVE_SCL 9
+// SPI
+#define SPI_SCK_PIN 6
+#define SPI_MOSI_PIN 7
+#define SPI_MISO_PIN 2
+#define SPI_SS_PIN 9
+
+/* TFT definitions */
+#define HAS_SCREEN 1
+#define MINBRIGHT (uint8_t)1
+#define USER_SETUP_LOADED 1
+
+/* ---------------------   */
+// Setup for ST7789 240x320
+
+#define ST7789_DRIVER 1
+#define TFT_WIDTH 240
+#define TFT_HEIGHT 320
+
+/* ---------------------   */
+// Setup for ILI9341 320x240 (no touch)
+
+// #define ILI9341_DRIVER 1
+// #define TFT_HEIGHT 320
+// #define TFT_WIDTH 240
+
+/* ---------------------   */
+// Common TFT definitions
+#define TFT_BACKLIGHT_ON 1
+#define TFT_BL 25
+#define TFT_RST -1
+#define TFT_DC 24
+#define TFT_MISO 2 // set to share SPI with other devices
+#define TFT_MOSI 7
+#define TFT_SCLK 6
+#define TFT_CS 23
+#define TOUCH_CS 1
+#define SMOOTH_FONT 1
+#define SPI_FREQUENCY 20000000
+#define SPI_READ_FREQUENCY 20000000
+#define SPI_TOUCH_FREQUENCY 2500000
+
+/*  Peripheral settings  */
+// Bad USB with CH9329
+#define BAD_RX 4
+#define BAD_TX 5
+// GPS Bus
+#define GPS_SERIAL_RX 4
+#define GPS_SERIAL_TX 5
+
+#define USE_TFT_eSPI_TOUCH 1
+#define HAS_TOUCH 1
+#define TOUCH_CS 1
+#define BTN_ACT LOW
+#define DEEPSLEEP_WAKEUP_PIN 0
+
+// InfraRed
+#define RXLED 9
+#define TXLED 8
+#define LED_ON HIGH
+#define LED_OFF LOW
+// SDCard
+#define SDCARD_CS 10
+#define SDCARD_SCK SPI_SCK_PIN
+#define SDCARD_MISO SPI_MISO_PIN
+#define SDCARD_MOSI SPI_MOSI_PIN
+// CC1101
+#define CC1101_GDO0_PIN 8
+#define CC1101_SS_PIN 9
+#define CC1101_MOSI_PIN SPI_MOSI_PIN
+#define CC1101_SCK_PIN SPI_SCK_PIN
+#define CC1101_MISO_PIN SPI_MISO_PIN
+// NRF24
+#define NRF24_CE_PIN 8
+#define NRF24_SS_PIN 9
+#define NRF24_MOSI_PIN SPI_MOSI_PIN
+#define NRF24_SCK_PIN SPI_SCK_PIN
+#define NRF24_MISO_PIN SPI_MISO_PIN
+// Ethernet
+#define W5500_INT_PIN 8
+#define W5500_SS_PIN 9
+#define W5500_MOSI_PIN SPI_MOSI_PIN
+#define W5500_SCK_PIN SPI_SCK_PIN
+#define W5500_MISO_PIN SPI_MISO_PIN
+#endif /* Pins_Arduino_h */

--- a/boards/pinouts/pins_arduino.h
+++ b/boards/pinouts/pins_arduino.h
@@ -46,4 +46,6 @@
 #include "../ESP32-C5-tft/pins_arduino.h"
 #elif ESP32C5_DEVKITC_1
 #include "../ESP32-C5/pins_arduino.h"
+#elif NM_CYD_ESP32C5
+#include "../nm-cyd-c5/pins_arduino.h"
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs =
 	;m5stack-cardputer
 	;m5stack-sticks3
-	m5stack-cplus2
+	;m5stack-cplus2
 	;m5stack-cplus1_1
 	;LAUNCHER_m5stack-cplus1_1
 	;m5stack-core2
@@ -66,6 +66,7 @@ default_envs =
 	;esp32-c5-tft
   	;esp32-c5
   	;ES3C28P
+	nm-cyd-c5
 
 ;uncomment to not use global dirs to avoid possible conflicts
 ;platforms_dir = .pio/platforms
@@ -82,8 +83,8 @@ extra_configs =
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.36/platform-espressif32.zip ; Arduino 3.3.6
            ;https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip ; Arduino 3.3.4
 		   ;https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip ; Last Version
-platform_packages =
-    framework-arduinoespressif32-libs @ https://github.com/bmorcelli/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/bruce_esp32-arduino-libs-20260123-153546.zip ; Arduino 3.3.6
+;platform_packages =
+    ;framework-arduinoespressif32-libs @ https://github.com/bmorcelli/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/bruce_esp32-arduino-libs-20260123-153546.zip ; Arduino 3.3.6
 	;framework-arduinoespressif32-libs @ https://github.com/bmorcelli/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/bruce_esp32-arduino-libs-20251205-131242.zip ; Arduino 3.3.4
 	;framework-arduinoespressif32-libs @ https://github.com/bmorcelli/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-20250919-170356.zip ; Arduino 3.3.1
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -36,7 +36,7 @@ public:
     const char *filepath = "/bruce.conf";
 
     //  Settings
-    int dimmerSet = 10;
+    int dimmerSet = 60;
     int bright = 100;
     bool automaticTimeUpdateViaNTP = true;
     float tmz = 0;

--- a/src/modules/gps/gps_tracker.cpp
+++ b/src/modules/gps/gps_tracker.cpp
@@ -40,6 +40,7 @@ void GPSTracker::setup() {
 
 bool GPSTracker::begin_gps() {
     releasePins();
+    pinMode(bruceConfigPins.gps_bus.rx, INPUT);
     GPSserial.begin(
         bruceConfigPins.gpsBaudrate, SERIAL_8N1, bruceConfigPins.gps_bus.rx, bruceConfigPins.gps_bus.tx
     );

--- a/src/modules/gps/wardriving.cpp
+++ b/src/modules/gps/wardriving.cpp
@@ -80,6 +80,7 @@ void Wardriving::begin_wifi() {
 
 bool Wardriving::begin_gps() {
     releasePins();
+    pinMode(bruceConfigPins.gps_bus.rx, INPUT);
     GPSserial.begin(
         bruceConfigPins.gpsBaudrate, SERIAL_8N1, bruceConfigPins.gps_bus.rx, bruceConfigPins.gps_bus.tx
     );


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add a new board nm-cyd-c5, a new Cheap Yellow Display with ESP32-C5.

- The TFT share the SPI with SD Card.
- The TFT driver changed to ST7789.
- Change the GPS Serial Pin to RX (4) TX(5), use the LP-UART, not share the I2C with other devices.

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

New Feature.

Add a new ESP32-C5 board.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Can flash the firmware.bin from [Web Flasher](https://flash.nmiot.net), project: Bruce, device: nm-cyd-c5, version: 1.14.0.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

The functions: LED, IR TX/RX, 433 ASK RF TX/RX, PN532-I2C, CC1101, nRF24 already tested with NM-RF-HAT. And GPS test with NM-ATGM336 module.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

The NM-CYD-C5 use the ESP32-C5 WROOM N16R8, with 16MB flash, but the nm-cyd-c5 still use the custom_8Mb.csv. Because with the custom_16Mb.csv, the merged bin file can't boot normal, always restart.