### PR TITLE
fix(ui): auto-scale title font and fix wifi recover layout on small screens

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -851,11 +851,17 @@ void drawMainBorderWithTitle(String title, bool clear) {
 }
 
 void printTitle(String title) {
-    tft.setCursor((tftWidth - (title.length() * FM * LW)) / 2, BORDER_PAD_Y);
-    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
-    tft.setTextSize(FM);
-
     title.toUpperCase();
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+
+    // Scale down title font if it doesn't fit the screen width
+    int titleSize = FM;
+    while (titleSize > FP && (int)(title.length() * titleSize * LW) > tftWidth - 2 * BORDER_PAD_X) {
+        titleSize--;
+    }
+
+    tft.setTextSize(titleSize);
+    tft.setCursor((tftWidth - (title.length() * titleSize * LW)) / 2, BORDER_PAD_Y);
     tft.println(title);
 
     tft.setTextSize(FP);

--- a/src/modules/wifi/wifi_recover.cpp
+++ b/src/modules/wifi/wifi_recover.cpp
@@ -962,7 +962,6 @@ void wifi_crack_handshake(const String &wordlist_path, const String &pcap_path) 
         hs.ap_mac[4],
         hs.ap_mac[5]
     );
-    padprintln("");
 
     if (hs.ssid[0] == '\0') {
         padprintln("SSID not found in PCAP");
@@ -977,7 +976,6 @@ void wifi_crack_handshake(const String &wordlist_path, const String &pcap_path) 
         drawMainBorderWithTitle("WiFi Password Recover", true);
         padprintln("");
         padprintf("SSID: %s\n", hs.ssid);
-        padprintln("");
     }
 
     File wf = fs->open(wordlist_path, FILE_READ);
@@ -1082,15 +1080,6 @@ void wifi_crack_handshake(const String &wordlist_path, const String &pcap_path) 
     vSemaphoreDelete(shared.done_sem);
     reader.deinit();
     wf.close();
-
-    uint64_t total_time = now_us() - start_time;
-    double seconds = total_time / 1000000.0;
-
-    padprintln("");
-    padprintln("");
-    // padprintf("Tested: %u passwords\n", (uint32_t)shared.attempts);
-    // padprintf("Time: %.1f sec (%.1f/sec)\n", seconds, shared.attempts / (seconds > 0 ? seconds : 1.0));
-    padprintln("");
 
     if (shared.found) {
         resetTftDisplay();


### PR DESCRIPTION
## Summary

- `printTitle` now auto-scales from `FM` to `FP` when the title text overflows the screen width — benefits all screens globally
- Remove redundant empty lines in wifi password recover that pushed progress info and results off-screen on small displays
- Clean up unused variables and commented-out code

Closes #2172

## Test plan

- [ ] Verify WiFi Password Recover screen fits on M5StickC Plus 2 (240x135)
- [ ] Verify title auto-scaling works on small screens with long titles
- [ ] Verify no visual regression on larger screens (Cardputer, T-Embed, CoreS3)