### PR TITLE
fix(keyboard): force redraw after shortcut opens submenu

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -533,7 +533,11 @@ int loopOptions(
 
         // handleSerialCommands(); // always use serial task for it
 #ifdef HAS_KEYBOARD
-        checkShortcutPress(); // shortctus to quickly start apps without navigating the menus
+        if (checkShortcutPress()) {
+            // Shortcut opened a submenu that drew over the screen; force full redraw
+            redraw = true;
+            drawMainBorder();
+        }
 #endif
 
         if (menuType == MENU_TYPE_REGULAR) {

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -486,7 +486,7 @@ int loopOptions(
         );
     if (index >= options.size()) index = 0;
     bool firstRender = true;
-    static unsigned long menuOpenTs = 0; // timestamp when menu was first rendered
+    unsigned long menuOpenTs = 0; // timestamp when this menu was first rendered (per-invocation, not shared across nested menus)
     drawMainBorder();
     while (1) {
         // Check for shutdown before drawing menu to avoid drawing a black bar on the screen

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -533,17 +533,10 @@ int loopOptions(
 
         // handleSerialCommands(); // always use serial task for it
 #ifdef HAS_KEYBOARD
-        // Keyboard shortcuts are only processed on the main menu (their purpose is to start
-        // apps without navigating the menus). The menuType check MUST come first so that
-        // checkShortcutPress() is not called inside the submenu a shortcut just opened —
-        // otherwise, while the key is still held, the shortcut re-fires and opens a second
-        // nested copy of the menu (requiring an extra ESC to back out of each level).
-        //
-        // A shortcut runs an app via optionsMenu(), which refills the shared global `options`
-        // vector (held here by reference) and draws over the screen. Break so the caller
-        // (MainMenu::begin, re-invoked each loop()) rebuilds the menu from scratch — exactly
-        // what selecting an option does. Repainting in place would instead render the now-stale
-        // `options` (the app's items, which lack the main-menu hover lambda) as an overlay list.
+        // Only process shortcuts on the main menu; the menuType check must short-circuit
+        // checkShortcutPress() so a held key can't re-fire inside the submenu it just opened.
+        // Break so the caller rebuilds the menu, since the shortcut refilled the shared global
+        // `options` (like selecting an option does) rather than repainting stale options.
         if (menuType == MENU_TYPE_MAIN && checkShortcutPress()) break;
 #endif
 

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -533,11 +533,18 @@ int loopOptions(
 
         // handleSerialCommands(); // always use serial task for it
 #ifdef HAS_KEYBOARD
-        if (checkShortcutPress()) {
-            // Shortcut opened a submenu that drew over the screen; force full redraw
-            redraw = true;
-            drawMainBorder();
-        }
+        // Keyboard shortcuts are only processed on the main menu (their purpose is to start
+        // apps without navigating the menus). The menuType check MUST come first so that
+        // checkShortcutPress() is not called inside the submenu a shortcut just opened —
+        // otherwise, while the key is still held, the shortcut re-fires and opens a second
+        // nested copy of the menu (requiring an extra ESC to back out of each level).
+        //
+        // A shortcut runs an app via optionsMenu(), which refills the shared global `options`
+        // vector (held here by reference) and draws over the screen. Break so the caller
+        // (MainMenu::begin, re-invoked each loop()) rebuilds the menu from scratch — exactly
+        // what selecting an option does. Repainting in place would instead render the now-stale
+        // `options` (the app's items, which lack the main-menu hover lambda) as an overlay list.
+        if (menuType == MENU_TYPE_MAIN && checkShortcutPress()) break;
 #endif
 
         if (menuType == MENU_TYPE_REGULAR) {

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -253,13 +253,14 @@ keyStroke _getKeyPress() {
 ** location: mykeyboard.cpp
 ** runs a function called by the shortcut action
 **********************************************************************/
-void checkShortcutPress() {
+bool checkShortcutPress() {
     static JsonDocument shortcutsJson; // parsed only once
+    bool executed = false;
 
     // lazy init
     if (shortcutsJson.size() == 0) {
         FS *fs;
-        if (!getFsStorage(fs)) return;
+        if (!getFsStorage(fs)) return false;
         File file = fs->open("/shortcuts.json", FILE_READ);
         if (!file) {
             log_e("Shortcuts Config file not found. Using default values");
@@ -270,13 +271,13 @@ void checkShortcutPress() {
             shortcuts["b"] = "loader open badusb";
             shortcuts["w"] = "loader open webui";
             shortcuts["f"] = "loader open files";
-            return;
+            return false;
         }
         // else
         if (deserializeJson(shortcutsJson, file)) {
             log_e("Failed to parse shortcuts.json");
             file.close();
-            return;
+            return false;
         }
         file.close();
     }
@@ -293,9 +294,11 @@ void checkShortcutPress() {
             if (i == *shortcut_key) { // compare the 1st char of the key string
                 // execute the associated action
                 serialCli.parse(String(shortcut_value));
+                executed = true;
             }
         }
     }
+    return executed;
 }
 
 /*********************************************************************

--- a/src/core/mykeyboard.h
+++ b/src/core/mykeyboard.h
@@ -23,6 +23,6 @@ keyStroke _getKeyPress(); // This function must be implemented in the interface.
                           // by using the flag HAS_KEYBOARD
 
 // Core functions, depends on the implementation of the funtions above in the interface.h
-void checkShortcutPress();
+bool checkShortcutPress();
 int checkNumberShortcutPress();
 char checkLetterShortcutPress();


### PR DESCRIPTION
## Summary

- When a keyboard shortcut (e.g. `f` for Files) opens a submenu from the main menu, the submenu draws over the screen. On exit, the main menu loop didn't know it needed to redraw, causing ESC to appear broken and navigation to produce font-size overlay glitches.
- Change `checkShortcutPress()` to return `bool`, and force a full redraw when it executed a shortcut command.

Closes #2156

## Test plan

- [ ] On Cardputer, press `f` in main menu to open Files via shortcut
- [ ] Press ESC — should return to main menu with clean rendering
- [ ] Navigate with arrow keys — no font overlap or rendering artifacts
- [ ] Repeat with other shortcuts (`i`, `r`, `b`, `w`)