### PR TITLE
🫡 fix overloaded bulk upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ docker-logs
 lib/mquickjs_headers/mqjs_stdlib_generator
 lib/mquickjs_headers/mqjs_stdlib_generator.exe
 .github/agents/Bruce-AI.agent.md
+.idea
+.ai

--- a/embedded_resources/web_interface/index.css
+++ b/embedded_resources/web_interface/index.css
@@ -410,8 +410,17 @@ svg > path {
   overflow-wrap: normal;
   overflow: auto;
 }
+.dialog.upload {
+  width: 100%;
+  max-width: 420px;
+  max-height: calc(100vh - 20px);
+  display: flex;
+  flex-direction: column;
+}
 .dialog.upload .dialog-body {
   padding: 10px;
+  overflow-y: auto;
+  max-height: calc(100vh - 60px);
 }
 .dialog.upload .upload-loading {
   width: 350px;


### PR DESCRIPTION
This pull request updates the styling of the upload dialog to improve its layout and usability, especially on smaller screens.

**Upload dialog layout improvements:**

* Added a `.dialog.upload` CSS class to make the upload dialog responsive, setting its width to 100%, max-width to 420px, and max-height to fit within the viewport. The dialog now uses a flex column layout for better content organization.
* Updated `.dialog.upload .dialog-body` to allow vertical scrolling and limit its maximum height, ensuring content remains accessible without overflowing the viewport.