### PR TITLE
feat: Add WDGoWars (wdgwars.pl) upload support for wardriving

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -62,6 +62,7 @@ JsonDocument BruceConfig::toJson() const {
     setting["startupApp"] = startupApp;
     setting["startupAppJSInterpreterFile"] = startupAppJSInterpreterFile;
     setting["wigleBasicToken"] = wigleBasicToken;
+    setting["wdgwarsApiKey"] = wdgwarsApiKey;
     setting["devMode"] = devMode;
     setting["colorInverted"] = colorInverted;
 
@@ -349,6 +350,12 @@ void BruceConfig::fromFile(bool checkFS) {
 
     if (!setting["wigleBasicToken"].isNull()) {
         wigleBasicToken = setting["wigleBasicToken"].as<String>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
+    if (!setting["wdgwarsApiKey"].isNull()) {
+        wdgwarsApiKey = setting["wdgwarsApiKey"].as<String>();
     } else {
         count++;
         log_e("Fail");
@@ -720,6 +727,11 @@ void BruceConfig::setStartupAppJSInterpreterFile(String value) {
 
 void BruceConfig::setWigleBasicToken(String value) {
     wigleBasicToken = value;
+    saveFile();
+}
+
+void BruceConfig::setWdgwarsApiKey(String value) {
+    wdgwarsApiKey = value;
     saveFile();
 }
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -82,6 +82,7 @@ public:
     String startupApp = "";
     String startupAppJSInterpreterFile = "";
     String wigleBasicToken = "";
+    String wdgwarsApiKey = "";
     int devMode = 0;
     int colorInverted = 1;
     int badUSBBLEKeyboardLayout = 0;
@@ -175,6 +176,7 @@ public:
     void setStartupApp(String value);
     void setStartupAppJSInterpreterFile(String value);
     void setWigleBasicToken(String value);
+    void setWdgwarsApiKey(String value);
     void setDevMode(int value);
     void validateDevModeValue();
     void setColorInverted(int value);

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -82,7 +82,7 @@ public:
     String startupApp = "";
     String startupAppJSInterpreterFile = "";
     String wigleBasicToken = "";
-    String wdgwarsApiKey = "";
+    String wdgwarsApiKey = "your 64-char hex key from wdgwars.pl/profile";
     int devMode = 0;
     int colorInverted = 1;
     int badUSBBLEKeyboardLayout = 0;

--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -3,6 +3,7 @@
 #include "modules/badusb_ble/ducky_typer.h"
 #include "modules/bjs_interpreter/interpreter.h"
 #include "modules/gps/wigle.h"
+#include "modules/gps/wdgwars.h"
 #include "modules/ir/TV-B-Gone.h"
 #include "modules/ir/custom_ir.h"
 #include "modules/others/audio.h"
@@ -771,6 +772,16 @@ String loopSD(FS &fs, bool filePicker, String allowed_ext, String rootPath) {
                                                              delay(200);
                                                              Wigle wigle;
                                                              wigle.upload_all(&fs, Folder);
+                                                         }});
+                        options.insert(options.begin(), {"WDG Upload", [&]() {
+                                                             delay(200);
+                                                             WDGoWars wdg;
+                                                             wdg.upload(&fs, filepath);
+                                                         }});
+                        options.insert(options.begin(), {"WDG Up All", [&]() {
+                                                             delay(200);
+                                                             WDGoWars wdg;
+                                                             wdg.upload_all(&fs, Folder);
                                                          }});
                     }
 #if !defined(LITE_VERSION) && !defined(DISABLE_INTERPRETER)

--- a/src/core/serial_commands/settings_commands.cpp
+++ b/src/core/serial_commands/settings_commands.cpp
@@ -74,6 +74,7 @@ uint32_t settingsCallback(cmd *c) {
     if (setting_name == "rfidModule")
         bruceConfigPins.setRfidModule(static_cast<RFIDModules>(setting_value.toInt()));
     if (setting_name == "wigleBasicToken") bruceConfig.setWigleBasicToken(setting_value);
+    if (setting_name == "wdgwarsApiKey") bruceConfig.setWdgwarsApiKey(setting_value);
     if (setting_name == "devMode") bruceConfig.setDevMode(setting_value.toInt());
     if (setting_name == "disabledMenus") bruceConfig.addDisabledMenu(setting_value);
 

--- a/src/modules/gps/wdgwars.cpp
+++ b/src/modules/gps/wdgwars.cpp
@@ -17,8 +17,8 @@ WDGoWars::WDGoWars() {}
 WDGoWars::~WDGoWars() {}
 
 bool WDGoWars::_check_api_key() {
-    if (bruceConfig.wdgwarsApiKey == "") {
-        displayError("WDGoWars API key not found", true);
+    if (bruceConfig.wdgwarsApiKey.length() != 64) {
+        displayError("Set API key in bruce.conf\nGet it at wdgwars.pl", true);
         return false;
     }
 

--- a/src/modules/gps/wdgwars.cpp
+++ b/src/modules/gps/wdgwars.cpp
@@ -1,0 +1,180 @@
+/**
+ * @file wdgwars.cpp
+ * @brief WDGoWars connector — uploads wardriving CSV to wdgwars.pl
+ * @version 0.1
+ */
+
+#include "wdgwars.h"
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/sd_functions.h"
+#include "core/wifi/wifi_common.h"
+
+#define CBUFLEN 1024
+
+WDGoWars::WDGoWars() {}
+
+WDGoWars::~WDGoWars() {}
+
+bool WDGoWars::_check_api_key() {
+    if (bruceConfig.wdgwarsApiKey == "") {
+        displayError("WDGoWars API key not found", true);
+        return false;
+    }
+
+    if (!wifiConnected) wifiConnectMenu();
+
+    return wifiConnected;
+}
+
+void WDGoWars::_display_banner() {
+    drawMainBorderWithTitle("WDG Upload");
+    padprintln("\n");
+}
+
+void WDGoWars::_send_upload_headers(WiFiClientSecure &client, String filename, int filesize, String boundary) {
+    int cd_header_len = 147 - 45 - 8 + filename.length() + 2 * (boundary.length() + 2);
+
+    client.print("POST ");
+    client.print(upload_path);
+    client.println(" HTTP/1.0");
+    client.print("Host: ");
+    client.println(host);
+    client.println("Connection: close");
+    client.println("User-Agent: bruce.wardriving");
+    client.print("X-API-Key: ");
+    client.println(bruceConfig.wdgwarsApiKey);
+    client.print("Content-Type: multipart/form-data; boundary=");
+    client.println(boundary);
+    client.print("Content-Length: ");
+    client.println(filesize + cd_header_len);
+    client.println();
+
+    client.println("--" + boundary);
+    client.print("Content-Disposition: form-data; name=\"file\"; filename=\"");
+    client.print(filename);
+    client.println("\"");
+    client.println("Content-Type: text/csv");
+    client.println();
+}
+
+bool WDGoWars::upload(FS *fs, String filepath, bool auto_delete) {
+    _display_banner();
+
+    if (!fs || !_check_api_key()) return false;
+
+    padprintln("Uploading to WDGoWars...");
+
+    File file = fs->open(filepath);
+    if (!file) {
+        displayError("Failed to open file", true);
+        return false;
+    }
+
+    if (!_upload_file(file, "Uploading...")) {
+        file.close();
+        displayError("File upload error", true);
+        return false;
+    }
+
+    file.close();
+    if (auto_delete) fs->remove(filepath);
+
+    displaySuccess("File upload success", true);
+    return true;
+}
+
+bool WDGoWars::upload_all(FS *fs, String folder, bool auto_delete) {
+    _display_banner();
+
+    if (!fs || !_check_api_key()) return false;
+
+    File root = fs->open(folder);
+    if (!root || !root.isDirectory()) return false;
+
+    padprintln("Uploading all to WDGoWars...");
+    int i = 1;
+    bool success;
+
+    while (true) {
+        bool isDir;
+        success = false;
+
+        String fullPath = root.getNextFileName(&isDir);
+        String nameOnly = fullPath.substring(fullPath.lastIndexOf("/") + 1);
+        if (fullPath == "") break;
+
+        if (!isDir) {
+            int dotIndex = nameOnly.lastIndexOf(".");
+            String ext = dotIndex >= 0 ? nameOnly.substring(dotIndex + 1) : "";
+            ext.toUpperCase();
+            if (ext.equals("CSV")) {
+                File file = fs->open(fullPath);
+                if (file) {
+                    if (!_upload_file(file, "Uploading " + String(i) + "...")) {
+                        file.close();
+                        displayError("File upload error", true);
+                        return false;
+                    }
+                    i++;
+                    success = true;
+                    file.close();
+                    if (success && auto_delete) fs->remove(fullPath);
+                }
+            }
+        }
+    }
+    root.close();
+
+    String plural = i > 2 ? "s" : "";
+    displaySuccess(String(i - 1) + " file" + plural + " uploaded", true);
+    return true;
+}
+
+bool WDGoWars::_upload_file(File file, String upload_message) {
+    WiFiClientSecure client;
+    client.setInsecure();
+    if (!client.connect(host, 443)) {
+        displayError("WDGoWars connection failed", true);
+        return false;
+    }
+
+    String filename = file.name();
+    int filesize = file.size();
+    String boundary = "BRUCE";
+    boundary.concat(esp_random());
+
+    _send_upload_headers(client, filename, filesize, boundary);
+
+    byte cbuf[CBUFLEN];
+    float percent = 0;
+    while (file.available()) {
+        long bytes_available = file.available();
+        int toread = CBUFLEN;
+        if (bytes_available < CBUFLEN) toread = bytes_available;
+        file.read(cbuf, toread);
+        client.write(cbuf, toread);
+        percent = ((float)file.position() / (float)file.size()) * 100;
+        progressHandler(percent, 100, upload_message);
+    }
+
+    client.println();
+    client.print("--");
+    client.print(boundary);
+    client.println("--");
+    client.println();
+    client.flush();
+
+    String serverres = "";
+    while (client.connected()) {
+        if (client.available()) {
+            char c = client.read();
+            serverres.concat(c);
+        }
+        if (serverres.length() > 1024) break;
+    }
+
+    client.stop();
+
+    return (serverres.indexOf("\"ok\":true") > -1);
+}

--- a/src/modules/gps/wdgwars.h
+++ b/src/modules/gps/wdgwars.h
@@ -1,0 +1,31 @@
+/**
+ * @file wdgwars.h
+ * @brief WDGoWars connector — uploads wardriving CSV to wdgwars.pl
+ * @version 0.1
+ */
+
+#ifndef __WDGWARS_H__
+#define __WDGWARS_H__
+
+#include <WiFiClientSecure.h>
+#include <globals.h>
+
+class WDGoWars {
+public:
+    WDGoWars();
+    ~WDGoWars();
+
+    bool upload(FS *fs, String filepath, bool auto_delete = true);
+    bool upload_all(FS *fs, String folder, bool auto_delete = true);
+
+private:
+    const char *host = "wdgwars.pl";
+    const char *upload_path = "/api/upload-csv";
+
+    bool _check_api_key(void);
+    bool _upload_file(File file, String upload_message);
+    void _send_upload_headers(WiFiClientSecure &client, String filename, int filesize, String boundary);
+    void _display_banner(void);
+};
+
+#endif


### PR DESCRIPTION
## Summary

- Adds [WDGoWars](https://wdgwars.pl) as an alternative upload target for wardriving CSV files, alongside the existing Wigle integration
- New menu options **"WDG Upload"** and **"WDG Up All"** appear in the file browser when selecting CSV files in the BruceWardriving folder
- Zero changes to existing wardriving scanning, CSV format, or Wigle upload — purely additive

## What is WDGoWars?

[WDGoWars](https://wdgwars.pl/press) is an open wardriving platform that combines real-world wireless network scanning with cyberpunk-themed territorial gang warfare. Players explore cities with portable scanning devices, map WiFi/BLE networks, and compete for territorial control on a global map.

Key features:
- **Territory warfare** — scanned access points belong to gangs; capturing requires physical re-scanning of enemy territory
- **Live events** — real cybersecurity news and simulated cyberattacks appear on the map at actual locations
- **Leaderboards & badges** — competitive ranking system with achievements
- **Open REST API** — community-driven, supports custom hardware integrations
- **Legal** — only collects publicly broadcast data (passive scanning)

WDGoWars already supports ESP32 devices, Flipper Zero, and community firmware. This PR adds native Bruce integration.

More info: https://wdgwars.pl/press

## Implementation

The implementation closely mirrors the existing Wigle upload pattern (`wigle.cpp/h`):

| | Wigle | WDGoWars |
|---|---|---|
| Host | `api.wigle.net` | `wdgwars.pl` |
| Path | `/api/v2/file/upload` | `/api/upload-csv` |
| Auth | `Authorization: Basic <token>` | `X-API-Key: <64-char hex key>` |
| Format | Multipart CSV | Multipart CSV (same!) |
| Response | `"success":true` | `"ok":true` |

### Files changed (6 files, +237 lines, 0 deletions from existing code)

| File | Change |
|---|---|
| `src/modules/gps/wdgwars.h` | **New** — WDGoWars class header |
| `src/modules/gps/wdgwars.cpp` | **New** — Upload logic (multipart CSV to wdgwars.pl) |
| `src/core/config.h` | +1 field: `wdgwarsApiKey` with setup hint |
| `src/core/config.cpp` | Save/load/setter for `wdgwarsApiKey` |
| `src/core/serial_commands/settings_commands.cpp` | +1 serial command: `set wdgwarsApiKey=...` |
| `src/core/sd_functions.cpp` | +include + "WDG Upload" / "WDG Up All" menu options |

### How users set up their API key

1. Register at [wdgwars.pl](https://wdgwars.pl) and copy API key from profile
2. Edit `bruce.conf` on SD card: set `wdgwarsApiKey` to the 64-char hex key
   — or via serial: `set wdgwarsApiKey=<key>`
3. Go to Files → SD Card → BruceWardriving → select CSV → "WDG Upload"

Default config includes a hint: `"your 64-char hex key from wdgwars.pl/profile"`

## Test plan

- [x] Builds successfully for `lilygo-t-lora-pager` via GitHub Actions
- [x] Verify "WDG Upload" and "WDG Up All" appear in file browser for CSV files
- [x] Verify upload works with valid API key
- [x] Verify graceful error when API key is missing/invalid
- [x] Verify existing Wigle upload is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)