### PR TITLE
Added multiple wardriving startup options. Default enables Wifi and BLE.

### DIFF
--- a/src/core/startup_app.cpp
+++ b/src/core/startup_app.cpp
@@ -37,7 +37,10 @@ StartupApp::StartupApp() {
 #if defined(SOC_USB_OTG_SUPPORTED)
     _startupApps["Mass Storage"] = []() { MassStorage(); };
 #endif
-    _startupApps["Wardriving"] = []() { Wardriving(); };
+    _startupApps["Wardriving"] = []() { Wardriving(true, true); };
+    _startupApps["WardrivingNoRadio"] = []() { Wardriving(); };
+    _startupApps["WardrivingBTEOnly"] = []() { Wardriving(false, true); };
+    _startupApps["WardrivingWifiOnly"] = []() { Wardriving(true, false); };
     _startupApps["WebUI"] = []() { startWebUi(!wifiConnecttoKnownNet()); };
 #if !defined(LITE_VERSION) && !defined(DISABLE_INTERPRETER)
     _startupApps["JS Interpreter"] = []() {


### PR DESCRIPTION
#### Proposed Changes ####
Wardriving is initialized with [Wardriving()](https://github.com/BruceDevices/firmware/blob/main/src/core/startup_app.cpp#L40) which calls Wardriving(bool scanWiFi = false, bool scanBLE = false) , essentially making the startup application useless.

#### Types of Changes ####
Bugfix

#### Verification ####
1. Set the following value in ``bruce.conf``
"startupApp": "Wardriving"
2. Power device and observe wardriving starts and can capture BLE and Wifi

#### Testing ####

Tested on Cardputer ADV

#### Linked Issues ####
https://github.com/BruceDevices/firmware/issues/2436

#### User-Facing Change ####
```release-note
The startupApp value in ``bruce.conf now has 4 different options for Wardriving:
- Wardriving
- WardrivingNoRadio (Original Behavior)
- WardrivingBTEOnly
- WebUI
```

#### Further Comments ####

