### PR TITLE
feat: add pomodoro timer presets

### DIFF
--- a/src/core/menu_items/ClockMenu.cpp
+++ b/src/core/menu_items/ClockMenu.cpp
@@ -20,9 +20,11 @@ void ClockMenu::optionsMenu() {
 
 void ClockMenu::showSubMenu() {
     options = {
-        {"Timer",         [=]() { Timer(); }            },
-        {"Back to Clock", [=]() {}                      },
-        {"Exit",          [=]() { returnToMenu = true; }}
+        {"Timer",         [=]() { Timer(); }                                                     },
+        {"Pomodoro 25m",  [=]() { Timer(TIMER_POMODORO_DURATION_MS, "Pomodoro", "Focus complete!"); }},
+        {"Break 5m",      [=]() { Timer(TIMER_SHORT_BREAK_DURATION_MS, "Short break", "Break complete!"); }},
+        {"Back to Clock", [=]() {}                                                               },
+        {"Exit",          [=]() { returnToMenu = true; }                                         }
         // Add more options here
     };
 

--- a/src/modules/others/timer.cpp
+++ b/src/modules/others/timer.cpp
@@ -30,6 +30,13 @@ enum SettingMode {
 
 Timer::Timer() { setup(); }
 
+Timer::Timer(unsigned long presetDurationMs, const char *title, const char *doneTitle) {
+    duration = presetDurationMs;
+    countdownTitle = title;
+    finishedTitle = doneTitle ? doneTitle : "Timer finished!";
+    loop();
+}
+
 Timer::~Timer() {
     tft.fillScreen(bruceConfig.bgColor);
     backToMenu();
@@ -113,7 +120,7 @@ void Timer::setup() {
             // If completed all fields and timer is valid, start countdown
             if (settingMode >= SETTING_COMPLETE) {
                 if (hours > 0 || minutes > 0 || seconds > 0) {
-                    duration = (hours * 3600 + minutes * 60 + seconds) * 1000;
+                    duration = (hours * 3600UL + minutes * 60UL + seconds) * 1000UL;
                     break; // Exit setup, proceed to loop()
                 }
                 // If timer is 0:0:0, reset to first field
@@ -186,7 +193,11 @@ void Timer::loop() {
                     }
                 }
 
-                drawMainBorder(false);
+                if (countdownTitle) {
+                    drawMainBorderWithTitle(countdownTitle, false);
+                } else {
+                    drawMainBorder(false);
+                }
                 tft.setTextSize(f_size);
                 tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
                 tft.drawCentreString(timeString, timerX, timerY, 1);
@@ -204,7 +215,7 @@ void Timer::loop() {
 void Timer::playAlarmPattern() {
     // Display "TIME'S UP!" message
     tft.fillScreen(bruceConfig.bgColor);
-    drawMainBorderWithTitle("Timer finished!", false);
+    drawMainBorderWithTitle(finishedTitle, false);
 
     tft.setTextSize(2);
     tft.setTextColor(TFT_RED, bruceConfig.bgColor);

--- a/src/modules/others/timer.h
+++ b/src/modules/others/timer.h
@@ -11,14 +11,19 @@
 
 #include <globals.h>
 
+constexpr unsigned long TIMER_POMODORO_DURATION_MS = 25UL * 60UL * 1000UL;
+constexpr unsigned long TIMER_SHORT_BREAK_DURATION_MS = 5UL * 60UL * 1000UL;
+
 class Timer {
 private:
     int fontSize = 4;
-    int duration = 0;
+    unsigned long duration = 0;
     int timerX = tftWidth / 2;
     int timerY = tftHeight / 2;
     int underlineY = timerY + (fontSize + 1) * LH;
     bool playSoundOnFinish = true; // Sound option
+    const char *countdownTitle = nullptr;
+    const char *finishedTitle = "Timer finished!";
 
     void clearUnderline();
     void underlineHours();
@@ -30,6 +35,7 @@ private:
 
 public:
     Timer();
+    Timer(unsigned long presetDurationMs, const char *countdownTitle, const char *finishedTitle);
     ~Timer();
 
     void setup();


### PR DESCRIPTION
## Summary
- Add Clock menu presets for `Pomodoro 25m` and `Break 5m`.
- Reuse the existing Timer implementation with a preset-duration constructor instead of adding a separate timer module.
- Keep the custom timer setup path unchanged while using unsigned millisecond duration math.

## Test Plan
- `git diff --check`
- `pio run -e m5stack-cplus2`
- `pio run -e esp32-c5-tft`

## Notes
The existing Timer remains available for custom durations. The new presets are quick-start options for common focus/break intervals.
