### PR TITLE
fix(ble): NimBLE v2 scan broken, pRxCharacteristic null, destructor UB, size_t underflow, Cardputer display offset

### DIFF
--- a/src/modules/ble/BLE_Suite.cpp
+++ b/src/modules/ble/BLE_Suite.cpp
@@ -3644,7 +3644,7 @@ String selectTargetFromScan(const char *title) {
 
     const int ACTIVE_SCAN_TIME = 15, PASSIVE_SCAN_TIME = 15;
 
-    tft.setCursor(20, 120);
+    tft.setCursor(20, tftHeight - 30);
     tft.print("Active scan (15s)...");
 
 #ifdef NIMBLE_V2_PLUS
@@ -3653,7 +3653,7 @@ String selectTargetFromScan(const char *title) {
     NimBLEScanResults results = pBLEScan->start(ACTIVE_SCAN_TIME, false);
 #endif
 
-    tft.setCursor(20, 140);
+    tft.setCursor(20, tftHeight - 15);
     tft.print("Passive scan (15s)...");
     pBLEScan->setActiveScan(false);
 
@@ -3720,7 +3720,7 @@ String selectTargetFromScan(const char *title) {
     size_t deviceCount = scannerData.size();
 
     if (xSemaphoreTake(scannerData.mutex, portMAX_DELAY)) {
-        for (size_t i = 0; i < scannerData.deviceAddresses.size() - 1; i++) {
+        for (size_t i = 0; scannerData.deviceAddresses.size() > 1 && i < scannerData.deviceAddresses.size() - 1; i++) {
             for (size_t j = i + 1; j < scannerData.deviceAddresses.size(); j++) {
                 bool swapNeeded = false;
                 if (scannerData.deviceFastPair[j] && !scannerData.deviceFastPair[i]) swapNeeded = true;

--- a/src/modules/ble/ble_common.cpp
+++ b/src/modules/ble/ble_common.cpp
@@ -87,7 +87,7 @@ void ble_scan_setup() {
     BLEDevice::init("");
     pBLEScan = BLEDevice::getScan();
 #ifdef NIMBLE_V2_PLUS
-    pBLEScan->setScanCallbacks(new NimBLEScanCallbacks());
+    pBLEScan->setScanCallbacks(new AdvertisedDeviceCallbacks());
 #else
     pBLEScan->setAdvertisedDeviceCallbacks(new AdvertisedDeviceCallbacks());
 #endif
@@ -173,7 +173,7 @@ bool initBLEServer() {
     pTxCharacteristic = pService->createCharacteristic(CHARACTERISTIC_RX_UUID, NIMBLE_PROPERTY::NOTIFY);
 
     pTxCharacteristic->addDescriptor(new NimBLE2904());
-    BLECharacteristic *pRxCharacteristic = pService->createCharacteristic(
+    pRxCharacteristic = pService->createCharacteristic(
         CHARACTERISTIC_TX_UUID, NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR
     );
     pRxCharacteristic->setCallbacks(new MyCallbacks());
@@ -250,7 +250,6 @@ void disPlayBLESend() {
     }
 
     tft.setTextColor(TFT_WHITE);
-    pService->~NimBLEService();
     pServer->getAdvertising()->stop();
 #if defined(CONFIG_IDF_TARGET_ESP32C5)
     esp_bt_controller_deinit();


### PR DESCRIPTION
Five bugs in the BLE module, all found by reading the source. PRs against `dev` as per contributing guidelines.

## 1. NimBLE v2+ scan always finds nothing

`ble_scan_setup()` registered the base `NimBLEScanCallbacks` class on the v2+ path instead of the `AdvertisedDeviceCallbacks` subclass. The base class has an empty `onResult()`, so no devices are ever added to `options`. The BLE scanner menu shows only "Back" on any NimBLE v2+ build.

## 2. `pRxCharacteristic` local variable shadows module global

`initBLEServer()` declared `BLECharacteristic *pRxCharacteristic = ...` as a local, shadowing the module-level global on line 21. The global stays `nullptr` for the lifetime of the program. Any code that uses the global after `initBLEServer()` returns dereferences null.

## 3. Explicit `~NimBLEService()` destructor call is undefined behaviour

`disPlayBLESend()` called `pService->~NimBLEService()` directly. The service is owned by the NimBLE stack; manual destructor invocation corrupts the stack's internal service table without freeing memory. `BLEDevice::deinit()` on the next line already performs a full teardown — the explicit call is both wrong and redundant.

## 4. `size_t` underflow crashes sort when device list is empty

The bubble-sort in `selectTargetFromScan()` computed `scannerData.deviceAddresses.size() - 1` as `size_t`. When the vector is empty, `size_t(0) - 1` wraps to `SIZE_MAX`, making the loop condition always true and immediately causing an out-of-bounds vector access.

## 5. Scan progress text rendered off-screen on Cardputer (135 px tall display)

`setCursor(20, 140)` for "Passive scan (15s)..." places text 5 px below the bottom of the Cardputer's 135 px landscape display. Changed to `tftHeight`-relative offsets, which are already used throughout the rest of the file.

## Files changed
- `src/modules/ble/ble_common.cpp` — bugs 1, 2, 3
- `src/modules/ble/BLE_Suite.cpp` — bugs 4, 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)