### PR TITLE
fix(bjs): strndup crash on scripts without directory path — likely root cause of issue #2450

### DIFF
--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -167,8 +167,13 @@ bool run_bjs_script_headless(FS fs, String filename) {
     if (script == NULL) { return false; }
 
     int slash = filename.lastIndexOf('/');
-    scriptName = strdup(filename.c_str() + slash + 1);
-    scriptDirpath = strndup(filename.c_str(), slash);
+    if (slash < 0) {
+        scriptDirpath = strdup("/");
+        scriptName = strdup(filename.c_str());
+    } else {
+        scriptName = strdup(filename.c_str() + slash + 1);
+        scriptDirpath = strndup(filename.c_str(), slash == 0 ? 1 : slash);
+    }
     returnToMenu = true;
     interpreter_state = 1;
     startInterpreterTask();


### PR DESCRIPTION
Fixes a crash in `run_bjs_script_headless()` that is the likely root cause of [#2450](https://github.com/BruceDevices/firmware/issues/2450) (crash launching app store on Cardputer ADV).

## Bug

```cpp
int slash = filename.lastIndexOf('/');
scriptName = strdup(filename.c_str() + slash + 1);
scriptDirpath = strndup(filename.c_str(), slash);  // ← slash can be -1
```

`String::lastIndexOf()` returns `-1` when no `/` is present. `strndup` takes `size_t`, so `-1` coerces to `SIZE_MAX` (~4 GB). The allocator either triggers a heap assertion panic, or returns `NULL`. The subsequent `JS_NewString(ctx, scriptDirpath)` then dereferences `NULL`, crashing before the script runs.

Secondary case: when `slash == 0` (file at filesystem root, e.g. `/main.js`), `strndup(p, 0)` produces an empty string `""` instead of `"/"`, breaking any relative path resolution inside the script via `__dirpath`.

## Fix

Handle the no-slash and root-slash cases before the normal `strndup` path:

```cpp
int slash = filename.lastIndexOf('/');
if (slash < 0) {
    scriptDirpath = strdup("/");
    scriptName = strdup(filename.c_str());
} else {
    scriptName = strdup(filename.c_str() + slash + 1);
    scriptDirpath = strndup(filename.c_str(), slash == 0 ? 1 : slash);
}
```

## Connection to #2450

The app store fetches and invokes scripts. Depending on how the invocation path is constructed, the filename passed to `run_bjs_script_headless()` may lack a leading `/`. On a memory-constrained Cardputer ADV, the near-infinite `strndup` allocation attempt hits the heap guard and panics, which matches the reported crash-on-launch behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)