### PR TITLE
add support for Tenstar ESP32-S3 TFT board

### DIFF
--- a/boards/tenstar-esp32-s3-tft/interface.cpp
+++ b/boards/tenstar-esp32-s3-tft/interface.cpp
@@ -1,0 +1,112 @@
+// ============================================================
+// interface.cpp — TENSTAR TS-ESP32-S3 (1.14" TFT)
+// ============================================================
+#include "core/powerSave.h"
+#include "core/utils.h"
+#include "interface.h"
+
+#ifndef TFT_I2C_POWER
+#define TFT_I2C_POWER 21
+#endif
+
+static const uint32_t BL_FREQ     = 5000;
+static const uint8_t  BL_RES_BITS = 8;
+
+void _setup_gpio() {
+    // Power up the TFT + I2C rail
+    pinMode(TFT_I2C_POWER, OUTPUT);
+    digitalWrite(TFT_I2C_POWER, HIGH);
+    delay(100);  // give the LDO/rail time to stabilize
+
+    // Backlight via LEDC
+    ledcAttach(TFT_BL, BL_FREQ, BL_RES_BITS);
+    ledcWrite(TFT_BL, 255);
+
+    // Navigation buttons (active LOW, internal pull-up)
+    pinMode(SEL_BTN, INPUT_PULLUP);
+    pinMode(DW_BTN,  INPUT_PULLUP);
+#ifdef UP_BTN
+    pinMode(UP_BTN,  INPUT_PULLUP);
+#endif
+}
+
+void _post_setup_gpio() { }
+
+/*********************************************************************
+** Function: InputHandler
+** Handles PrevPress, NextPress, SelPress, AnyKeyPress, EscPress
+** Pattern: follow Bruce's template — set flags directly here,
+**          no separate check*Press() logic needed by the framework.
+**********************************************************************/
+void InputHandler(void) {
+    checkPowerSaveTime();
+
+    // Reset all flags
+    PrevPress    = false;
+    NextPress    = false;
+    SelPress     = false;
+    AnyKeyPress  = false;
+    EscPress     = false;
+
+    bool selPressed = (digitalRead(SEL_BTN) == BTN_ACT);
+    bool dwPressed  = (digitalRead(DW_BTN)  == BTN_ACT);
+#ifdef UP_BTN
+    bool upPressed  = (digitalRead(UP_BTN)  == BTN_ACT);
+#else
+    bool upPressed  = false;
+#endif
+
+    bool anyPressed = selPressed || dwPressed || upPressed;
+
+    // Wake screen first if sleeping; don't process nav on wake event
+    if (anyPressed) {
+        if (!wakeUpScreen()) AnyKeyPress = true;
+        else goto END;
+    }
+
+    PrevPress = upPressed;
+    NextPress = dwPressed && !selPressed;   // DW alone = next
+    EscPress  = dwPressed && selPressed;    // DW + SEL = escape/back
+    SelPress  = selPressed && !dwPressed;   // SEL alone = select
+
+END:
+    // Debounce: hold until buttons released or 200 ms passed
+    if (AnyKeyPress) {
+        long tmp = millis();
+        while ((millis() - tmp) < 200 &&
+               ((digitalRead(SEL_BTN) == BTN_ACT) ||
+                (digitalRead(DW_BTN)  == BTN_ACT)
+#ifdef UP_BTN
+                || (digitalRead(UP_BTN) == BTN_ACT)
+#endif
+               ));
+    }
+}
+
+/*********************************************************************
+** Function: _setBrightness
+** Sets backlight brightness (0–100)
+**********************************************************************/
+void _setBrightness(uint8_t brightval) {
+    if (brightval == 0) {
+        ledcWrite(TFT_BL, 0);
+    } else {
+        uint32_t duty = MINBRIGHT + round((255 - MINBRIGHT) * brightval / 100.0);
+        ledcWrite(TFT_BL, duty);
+    }
+}
+
+int  getBattery()   { return 0; }
+bool isCharging()   { return false; }
+void powerOff()     { }
+
+void checkReboot() {
+    if ((digitalRead(SEL_BTN) == BTN_ACT) &&
+        (digitalRead(DW_BTN)  == BTN_ACT)) {
+        delay(2000);
+        if ((digitalRead(SEL_BTN) == BTN_ACT) &&
+            (digitalRead(DW_BTN)  == BTN_ACT)) {
+            ESP.restart();
+        }
+    }
+}

--- a/boards/tenstar-esp32-s3-tft/pinout.md
+++ b/boards/tenstar-esp32-s3-tft/pinout.md
@@ -1,0 +1,52 @@
+# Pinouts diagram to use Bruce
+
+## TENSTAR TS-ESP32-S3 Board Pinouts
+
+### SPI Devices & Display Mapping
+The display uses a dedicated SPI bus (FSPI), while the SD Card and external hardware modules (CC1101/NRF24) share a separate SPI expansion bus.
+
+| Device  | SCK   | MISO  | MOSI  | CS    | GDO0/CE | TFT_DC | TFT_RST | TFT_BL |
+| ---     | :---: | :---: | :---: | :---: | :---:   | :---:  | :---:   | :---:  |
+| Display | 36    | 37    | 35    | 7     | ---     | 39     | 40      | 45     |
+| SD Card | 13    | 12    | 11    | 10    | ---     | ---    | ---     | ---    |
+| CC1101  | 13    | 12    | 11    | 10* | Slot* | ---    | ---     | ---    |
+| NRF24   | 13    | 12    | 11    | 10* | Slot* | ---    | ---     | ---    |
+
+> **Note on Display Power:** GPIO 21 (`TFT_I2C_POWER`) acts as the main power enable rail for both the TFT display and the onboard I2C sensors. It must be driven **HIGH** for them to function (`interface.cpp` handles this automatically).
+>
+> **(*) Shared SPI Bus:** The SD Card, CC1101, and NRF24 modules share the same SPI lines (11, 12, 13). If you hook up multiple external SPI devices simultaneously alongside the SD card slot, you must use physical toggle switches or isolate separate GPIOs for individual Chip Select (`CS`) signals to prevent data collision.
+
+### Navigation Buttons
+The board utilizes 3 navigation buttons configured as **Active LOW** with internal pull-ups enabled.
+
+| Buttons | GPIO  | Default Label / Action |
+| ---     | :---: | :---:                  |
+| Prev    | 8     | UP                     |
+| Sel     | 14    | SELECT                 |
+| Next    | 15    | DOWN                   |
+
+### Auxiliary Modules & Onboard Peripherals
+
+| Device   | RX    | TX    | GPIO  | Notes                                      |
+| ---      | :---: | :---: | :---: | :---                                       |
+| IR RX    | ---   | ---   | 16/17 | Configurable pin pairs for external modules |
+| IR TX    | ---   | ---   | 16/17 | Configurable pin pairs for external modules |
+| RF RX    | ---   | ---   | 6     | For external sub-GHz receivers             |
+| RF TX    | ---   | ---   | 5     | For external sub-GHz transmitters            |
+| Status LED | --- | ---   | 13    | Onboard standard LED (Active HIGH)         |
+| RGB LED  | ---   | ---   | 33    | Onboard WS2812 NeoPixel (GRB order)        |
+
+### Shared I2C Interface
+The main I2C interface hosts the onboard sensors and is exposed for external expansions (like Grooves or physical modules).
+
+* **I2C SDA:** 42
+* **I2C SCL:** 41
+
+**Onboard Built-In Sensors:**
+* **BMP280** (Barometric Pressure/Temperature) @ I2C address `0x76`
+* **QMI8658C** (6-Axis IMU/Accelerometer) @ I2C address `0x77`
+
+### USB Features & BadUSB
+Unlike older architectures or lower-tier chips, the **ESP32-S3 natively supports USB-OTG**.
+* **BadUSB / USB HID** functions directly over the internal USB-Serial peripheral configuration via firmware.
+* **No external hardware (like a CH9329 module) is required** to execute BadUSB keystrokes or scripts; just plug a USB cable straight from the ESP32-S3 native port into your target machine.

--- a/boards/tenstar-esp32-s3-tft/pins_arduino.h
+++ b/boards/tenstar-esp32-s3-tft/pins_arduino.h
@@ -1,0 +1,270 @@
+// ============================================================
+// pins_arduino.h — TENSTAR TS-ESP32-S3 (1.14" TFT)
+// Bruce Firmware port
+//
+// Board: ESP32-S3FH4R2
+// Display: ST7789, 240x135, SPI
+// Sensors: BMP280 @ I2C 0x76, QMI8658C @ I2C 0x77
+// NeoPixel: GPIO33
+// Nav Buttons: SEL=GPIO14, DW=GPIO15  (wire to GND via momentary switch)
+// SD Card: external module, SPI on GPIO10/11/12/13
+// ============================================================
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t SDA  = 42;
+static const uint8_t SCL  = 41;
+static const uint8_t SS   = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 12;
+static const uint8_t SCK  = 13;
+
+// ── TFT Display (ST7789, SPI FSPI bus) ──────────────────────
+// IMPORTANT: TFT_I2C_POWER (GPIO21) must be pulled HIGH before
+// the display or I2C sensors will work. interface.cpp handles this.
+#ifndef TFT_I2C_POWER
+#define TFT_I2C_POWER   21  // Power enable for TFT + I2C rail
+#endif
+#ifndef TFT_MISO
+#define TFT_MISO        37  // FSPIID  (not needed for write-only, kept for SPI bus)
+#endif
+#ifndef TFT_MOSI
+#define TFT_MOSI        35  // FSPID   (data out)
+#endif
+#ifndef TFT_SCLK
+#define TFT_SCLK        36  // FSPICLK (clock)
+#endif
+#ifndef TFT_CS
+#define TFT_CS           7  // Chip select
+#endif
+#ifndef TFT_DC
+#define TFT_DC          39  // Data/Command
+#endif
+#ifndef TFT_RST
+#define TFT_RST         40  // Reset
+#endif
+#ifndef TFT_BL
+#define TFT_BL          45  // Backlight (active HIGH)
+#endif
+
+// ── ST7789 driver flags ──────────────────────────────────────
+#ifndef ST7789_DRIVER
+#define ST7789_DRIVER       1
+#endif
+#ifndef TFT_RGB_ORDER
+#define TFT_RGB_ORDER       TFT_RGB   // correct color order for this panel
+#endif
+#ifndef TFT_WIDTH
+#define TFT_WIDTH         135
+#endif
+#ifndef TFT_HEIGHT
+#define TFT_HEIGHT        240
+#endif
+#ifndef TFT_BACKLIGHT_ON
+#define TFT_BACKLIGHT_ON    1         // backlight is active HIGH
+#endif
+#ifndef SMOOTH_FONT
+#define SMOOTH_FONT         1
+#endif
+#ifndef SPI_FREQUENCY
+#define SPI_FREQUENCY       40000000
+#endif
+#ifndef SPI_READ_FREQUENCY
+#define SPI_READ_FREQUENCY  20000000
+#endif
+#ifndef SPI_TOUCH_FREQUENCY
+#define SPI_TOUCH_FREQUENCY  2500000
+#endif
+#ifndef TOUCH_CS
+#define TOUCH_CS           -1         // no touch
+#endif
+
+// ── I2C (BMP280 + QMI8658C + QWIIC/SH1.0-4P) ───────────────
+#ifndef SDA_PIN
+#define SDA_PIN             42
+#endif
+#ifndef SCL_PIN
+#define SCL_PIN             41
+#endif
+// Sensor addresses (informational, used in code):
+//   BMP280   → 0x76
+//   QMI8658C → 0x77
+
+// ── NeoPixel RGB LED ─────────────────────────────────────────
+#ifndef PIN_NEOPIXEL
+#define PIN_NEOPIXEL        33
+#endif
+#ifndef NEOPIXEL_NUM
+#define NEOPIXEL_NUM         1
+#endif
+#ifndef NEOPIXEL_POWER
+#define NEOPIXEL_POWER      -1   // always powered, no enable pin
+#endif
+
+// ── Built-in LED (red, GPIO13) ───────────────────────────────
+#ifndef LED_BUILTIN
+#define LED_BUILTIN         13
+#endif
+#ifndef LED
+#define LED                 13
+#endif
+#ifndef LED_ON
+#define LED_ON            HIGH
+#endif
+#ifndef LED_OFF
+#define LED_OFF            LOW
+#endif
+
+// ── Navigation Buttons ───────────────────────────────────────
+// Wire each button between the GPIO and GND (internal pull-up used).
+// SEL (select/OK) = GPIO14
+// DW  (back/down) = GPIO15
+// BOOT button on GPIO0 can be used as an additional input if needed.
+#ifndef HAS_3_BUTTONS
+#define HAS_3_BUTTONS   1
+#endif
+#ifndef UP_BTN
+#define UP_BTN          8   // BOOT button
+#endif
+#ifndef SEL_BTN
+#define SEL_BTN        14
+#endif
+#ifndef DW_BTN
+#define DW_BTN         15
+#endif
+#ifndef BTN_ACT
+#define BTN_ACT           LOW   // buttons pull to GND
+#endif
+#ifndef BTN_ALIAS
+#define BTN_ALIAS         "SEL"
+#endif
+
+// ── SD Card (external SPI module) ────────────────────────────
+// Default wiring suggestion using free GPIOs:
+//   CS   → GPIO10
+//   MOSI → GPIO11
+//   MISO → GPIO12
+//   SCK  → GPIO13  (shares with LED_BUILTIN — LED unusable when SD active)
+// Override in bruce.conf or .ini if you use different pins.
+#ifndef SDCARD_CS
+#define SDCARD_CS          10
+#endif
+#ifndef SDCARD_MOSI
+#define SDCARD_MOSI        11
+#endif
+#ifndef SDCARD_MISO
+#define SDCARD_MISO        12
+#endif
+#ifndef SDCARD_SCK
+#define SDCARD_SCK         13
+#endif
+
+// ── IR TX/RX (external module, optional) ─────────────────────
+// Suggested free pins; change to whatever you wire up.
+// Defined here so they appear in Bruce's pin picker.
+#ifndef IR_TX_PINS
+#define IR_TX_PINS  { {"GPIO16", 16}, {"GPIO17", 17} }
+#endif
+#ifndef IR_RX_PINS
+#define IR_RX_PINS  { {"GPIO16", 16}, {"GPIO17", 17} }
+#endif
+
+// ── RF TX/RX (one-pin external module, optional) ─────────────
+#ifndef RF_TX_PINS
+#define RF_TX_PINS  { {"GPIO16", 16}, {"GPIO17", 17} }
+#endif
+#ifndef RF_RX_PINS
+#define RF_RX_PINS  { {"GPIO18", 18}, {"GPIO8",   8} }
+#endif
+
+// ── UART (exposed header) ────────────────────────────────────
+#ifndef TX
+#define TX                   1
+#endif
+#ifndef RX
+#define RX                   2
+#endif
+
+// ── Battery ADC ──────────────────────────────────────────────
+// The board has no dedicated BAT ADC pin exposed.
+// If you tap VBAT through a voltage divider to a free ADC pin, set here.
+// Leave -1 to disable battery percentage in Bruce UI.
+#ifndef BAT_PIN
+#define BAT_PIN            -1
+#endif
+
+// ── Screen geometry & font sizes ─────────────────────────────
+// Bruce uses these for layout calculations.
+// ROTATION=1  →  landscape with USB-C on the right (135 wide, 240 tall → 240w x 135h)
+#ifndef HAS_SCREEN
+#define HAS_SCREEN          1
+#endif
+#ifndef ROTATION
+#define ROTATION            1
+#endif
+#ifndef WIDTH
+#define WIDTH             240
+#endif
+#ifndef HEIGHT
+#define HEIGHT            135
+#endif
+#ifndef MINBRIGHT
+#define MINBRIGHT          10   // minimum backlight duty cycle (0-255)
+#endif
+
+
+// ── RGB LED (FastLED) ────────────────────────────────────────
+#ifndef HAS_RGB_LED
+#define HAS_RGB_LED         1
+#endif
+#ifndef RGB_LED
+#define RGB_LED             33
+#endif
+#ifndef LED_TYPE
+#define LED_TYPE            WS2812
+#endif
+#ifndef LED_ORDER
+#define LED_ORDER           GRB
+#endif
+#ifndef LED_COUNT
+#define LED_COUNT           1
+#endif
+#ifndef LED_COLOR_STEP
+#define LED_COLOR_STEP      15
+#endif
+
+// ── Font scale presets ───────────────────────────────────────
+#ifndef FP
+#define FP                  1   // small
+#endif
+#ifndef FM
+#define FM                  2   // medium
+#endif
+#ifndef FG
+#define FG                  3   // large
+#endif
+
+// ── SPI bus aliases (shared with SD card) ────────────────────
+// These may be defined by the framework or .ini before this header.
+#ifndef SPI_SCK_PIN
+#define SPI_SCK_PIN        13
+#endif
+#ifndef SPI_MOSI_PIN
+#define SPI_MOSI_PIN       11
+#endif
+#ifndef SPI_MISO_PIN
+#define SPI_MISO_PIN       12
+#endif
+#ifndef SPI_SS_PIN
+#define SPI_SS_PIN         10
+#endif
+
+// ── Device identity ──────────────────────────────────────────
+#ifndef DEVICE_NAME
+#define DEVICE_NAME        "TENSTAR ESP32-S3 TFT"
+#endif
+
+#endif // Pins_Arduino_h

--- a/boards/tenstar-esp32-s3-tft/tenstar-esp32-s3-tft.ini
+++ b/boards/tenstar-esp32-s3-tft/tenstar-esp32-s3-tft.ini
@@ -1,0 +1,102 @@
+[env:tenstar-esp32-s3-tft]
+extends = env
+board = esp32-s3-devkitc-1
+board_build.partitions = custom_4Mb_full.csv
+board_upload.flash_size = 4MB
+board_upload.maximum_size = 4194304
+board_build.arduino.memory_type = qio_qspi
+board_build.flash_mode = qio
+board_build.f_flash = 80000000
+build_src_filter = ${env.build_src_filter} +<../boards/tenstar-esp32-s3-tft>
+build_flags =
+    ${env.build_flags}
+    -Iboards/tenstar-esp32-s3-tft
+
+    -DDEVICE_NAME='"TENSTAR ESP32-S3 TFT"'
+    -DNEW_DEVICE=1
+    -Isrc
+
+    ; ── Screen ───────────────────────────────────────────
+    -DHAS_SCREEN=1
+    -DROTATION=1
+    -DWIDTH=240
+    -DHEIGHT=135
+    -DMINBRIGHT=10
+    -DFP=1
+    -DFM=2
+    -DFG=3
+
+    ; ── TFT (ST7789, SPI) ────────────────────────────────
+    -DUSER_SETUP_LOADED=1
+    -DST7789_DRIVER=1
+    -DTFT_RGB_ORDER=TFT_RGB
+    -DTFT_WIDTH=135
+    -DTFT_HEIGHT=240
+    -DUSE_HSPI_PORT
+    -DTFT_BACKLIGHT_ON=1
+    -DTFT_MISO=37
+    -DTFT_MOSI=35
+    -DTFT_SCLK=36
+    -DTFT_CS=7
+    -DTFT_DC=39
+    -DTFT_RST=40
+    -DTFT_BL=45
+    -DTOUCH_CS=-1
+    -DSMOOTH_FONT=1
+    -DSPI_FREQUENCY=40000000
+    -DSPI_READ_FREQUENCY=20000000
+    -DSPI_TOUCH_FREQUENCY=2500000
+    -DBOARD_HAS_PSRAM
+
+    ; ── Buttons ──────────────────────────────────────────
+    -DHAS_3_BUTTONS=1
+    -DUP_BTN=8
+    -DSEL_BTN=14
+    -DDW_BTN=15
+    -DBTN_ACT=LOW
+    -DBTN_ALIAS='"SEL"'
+
+    ; ── RGB LED (FastLED, WS2812, GPIO33) ────────────────────
+    -DHAS_RGB_LED=1
+    -DRGB_LED=33
+    -DLED_TYPE=WS2812
+    -DLED_ORDER=GRB
+    -DLED_COUNT=1
+    -DLED_COLOR_STEP=15
+
+    ; ── LED ──────────────────────────────────────────────
+    -DLED=13
+    -DLED_ON=HIGH
+    -DLED_OFF=LOW
+
+    ; ── I2C ──────────────────────────────────────────────
+    -DGROVE_SDA=42
+    -DGROVE_SCL=41
+
+    ; ── SD Card (external SPI module) ────────────────────
+    -DSDCARD_CS=10
+    -DSDCARD_MOSI=11
+    -DSDCARD_MISO=12
+    -DSDCARD_SCK=13
+
+    ; ── SPI bus (for CC1101/NRF24 if attached later) ─────
+    -DSPI_SCK_PIN=13
+    -DSPI_MOSI_PIN=11
+    -DSPI_MISO_PIN=12
+    -DSPI_SS_PIN=10
+
+    ; ── IR (external module, free GPIOs) ─────────────────
+    -DIR_TX_PINS='{{"GPIO16", 16}, {"GPIO17", 17}}'
+    -DIR_RX_PINS='{{"GPIO16", 16}, {"GPIO17", 17}}'
+
+    ; ── RF (external module, free GPIOs) ─────────────────
+    -DRF_TX_PINS='{{"GPIO5", 5}, {"GPIO5", 5}}'
+    -DRF_RX_PINS='{{"GPIO6", 6}, {"GPIO6", 6}}'
+
+    ; ── Battery ──────────────────────────────────────────
+    -DBAT_PIN=-1
+
+    ; ── USB HID (ESP32-S3 native USB) ────────────────────
+    -DUSB_as_HID=1
+
+lib_deps = ${env.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,7 +73,7 @@ default_envs =
 	;elecrow-28B
 	;elecrow-35B
 	;elecrow-35Bv2_2
-
+	;tenstar-esp32-s3-tft
 
 ;uncomment to not use global dirs to avoid possible conflicts
 ;platforms_dir = .pio/platforms


### PR DESCRIPTION
#### Proposed Changes ####

This pull request introduces native board support for the **TENSTAR TS-ESP32-S3 (1.14" TFT)** development board.

The changes include:
-  PlatformIO environment configuration (`tenstar-esp32-s3-tft.ini`).
- Full enablement of the embedded **2MB QSPI PSRAM** (`-DBOARD_HAS_PSRAM`).
- Custom `pins_arduino.h` and `interface.cpp` implementations to handle the ST7789 display layout, 3 active-low navigation buttons, internal I2C rail power management, and the onboard WS2812 NeoPixel.
- Port documentation charting the physical pinout configurations.

#### Types of Changes ####

- New Feature (New Hardware Board Support)

#### Verification ####

The changes can be verified by building the project via PlatformIO using the newly introduced environment profile:
```bash
pio run -e tenstar-esp32-s3-tft
```
The firmware compiles cleanly without dependency errors. When flashed, the boot logs successfully register the 2MB PSRAM footprint, the screen initializes smoothly on its power-gated rail, and navigation buttons cleanly cycle through the UI.

#### Testing ####

This change has been physically tested and verified on the target hardware:
- **Display:** Verified ST7789 240x135 rendering alignment and active backlight frequency controls.
- **Memory:** Inspected heap stats via `ESP.getFreePsram()` to confirm all 2MB of external memory are addressable.
- **Inputs:** Verified active-low execution on navigation pins (GPIO 8, 14, 15).

<img width="2256" height="4000" alt="tenstar" src="https://github.com/user-attachments/assets/812dc308-74e6-4723-8d5f-f179cda3f7ec" />
1427.html

#### Linked Issues ####

Closes #2488

#### User-Facing Change ####
```release-note
Adds native compilation support and pin mapping for the TENSTAR TS-ESP32-S3 (1.14" TFT) development board target.
```

#### Further Comments ####

Hardware reference for the specific dev board utilized:
https://www.aliexpress.com/item/1005006455931427.html
