### PR TITLE
Add Elecrow CrowPanel Advance 3.5 inch (ESP32-S3) board support

### DIFF
--- a/boards/elecrow_advance_s3/elecrow_advance_s3.ini
+++ b/boards/elecrow_advance_s3/elecrow_advance_s3.ini
@@ -1,0 +1,133 @@
+#################################### CrowPanel Advance 3.5" ESP32-S3 ##############################
+; Elecrow CrowPanel Advance 3.5" HMI (https://www.elecrow.com/crowpanel-advance-3-5-hmi-esp32-ai-display)
+; Hardware: ESP32-S3-WROOM-1-N16R8 (16MB Flash, 8MB OPI PSRAM)
+;           ILI9488 480x320 IPS over SPI, GT911 capacitive touch over I2C
+; TFT SPI:        MOSI=39, MISO=-1, SCLK=42, CS=40, DC=41, BL=38 (PWM)
+; Touch GT911:    I2C SDA=15, SCL=16, INT=47, addr 0x5D
+; SD Card SPI:    MOSI=6, MISO=4, SCK=5, CS=7
+; Speaker  I2S:   BCLK=13, WCLK=11, DOUT=12
+; Microphone I2S: CLK=9, WS=3, DATA=10
+; Note: Serial routed to UART0 (CH341 bridge) via ARDUINO_USB_CDC_ON_BOOT=0.
+
+[env:elecrow-advance-35-s3]
+board = esp32-s3-devkitc1-n16r8
+board_build.arduino.memory_type = qio_opi
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.partitions = custom_16Mb.csv
+build_src_filter = ${env.build_src_filter} +<../boards/elecrow_advance_s3>
+build_unflags =
+	-DARDUINO_USB_CDC_ON_BOOT=1
+build_flags =
+	${env.build_flags}
+	-Iboards/elecrow_advance_s3
+	-Os
+	-DARDUINO_USB_CDC_ON_BOOT=0
+	-DBOARD_HAS_PSRAM
+	-DDISABLE_ALL_LIBRARY_WARNINGS
+
+	-DELECROW
+
+	; Speaker I2S
+	-DBCLK=13
+	-DWCLK=11
+	-DDOUT=12
+
+	; Microphone I2S
+	-DPIN_CLK=9
+	-DI2S_SCLK_PIN=9
+	-DPIN_DATA=10
+	-DI2S_DATA_PIN=10
+
+	; No RGB LED
+	-DRGB_LED=-1
+
+	; BadUSB on UART pins
+	-DBAD_TX=17
+	-DBAD_RX=18
+
+	; Serial/GPS
+	-DSERIAL_TX=43
+	-DSERIAL_RX=44
+	-DGPS_SERIAL_TX=SERIAL_TX
+	-DGPS_SERIAL_RX=SERIAL_RX
+
+	; Buttons - touch only
+	-DHAS_BTN=0
+	-DBTN_ALIAS='"Ok"'
+	-DBTN_PIN=0
+
+	; IR/RF free pins
+	-DIR_TX_PINS='{{"Pin 17", 17}, {"Pin 18", 18}}'
+	-DIR_RX_PINS='{{"Pin 17", 17}, {"Pin 18", 18}}'
+	-DTXLED=-1
+	-DLED_ON=HIGH
+	-DLED_OFF=LOW
+
+	-DRF_TX_PINS='{{"Pin 17", 17}, {"Pin 18", 18}}'
+	-DRF_RX_PINS='{{"Pin 17", 17}, {"Pin 18", 18}}'
+
+	; Font sizes
+	-DFP=1
+	-DFM=2
+	-DFG=3
+
+	; Screen
+	-DHAS_SCREEN=1
+	-DROTATION=1
+	-DBACKLIGHT=38
+	-DMINBRIGHT=10
+
+	; TFT_eSPI - SPI display (ILI9488, 480x320)
+	; USE_HSPI_PORT is required on ESP32-S3 or the SPI register pointers stay
+	; null and the first write in begin_tft_write() panics (StoreProhibited).
+	-DUSER_SETUP_LOADED=1
+	-DUSE_HSPI_PORT=1
+	-DILI9488_DRIVER=1
+	-DTFT_WIDTH=320
+	-DTFT_HEIGHT=480
+	-DTFT_MOSI=39
+	-DTFT_MISO=-1
+	-DTFT_SCLK=42
+	-DTFT_CS=40
+	-DTFT_DC=41
+	-DTFT_RST=-1
+	-DTFT_BL=38
+	-DTFT_BACKLIGHT_ON=HIGH
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=40000000
+	-DSPI_READ_FREQUENCY=16000000
+
+	; Touch GT911 capacitive I2C
+	-DHAS_TOUCH=1
+	-DHAS_CAPACITIVE_TOUCH=1
+	-DTOUCH_GT911_I2C=1
+	-DGT911_SLAVE_ADDRESS_L=0x5D
+	-DGT911_I2C_CONFIG_SDA_IO_NUM=15
+	-DGT911_I2C_CONFIG_SCL_IO_NUM=16
+	-DGT911_TOUCH_CONFIG_INT_GPIO_NUM=47
+	-DBOARD_TOUCH_INT=47
+
+	; SD Card SPI
+	-DSDCARD_CS=7
+	-DSDCARD_SCK=5
+	-DSDCARD_MISO=4
+	-DSDCARD_MOSI=6
+
+	; SPI bus pin aliases (required by utils.cpp)
+	-DSPI_SCK_PIN=5
+	-DSPI_MOSI_PIN=6
+	-DSPI_MISO_PIN=4
+	-DSPI_SS_PIN=7
+
+	; Backlight PWM
+	-DTFT_BRIGHT_CHANNEL=0
+	-DTFT_BRIGHT_Bits=8
+	-DTFT_BRIGHT_FREQ=5000
+
+	-DDEVICE_NAME='"Elecrow Advance 3.5 S3"'
+
+lib_deps =
+	${env.lib_deps}
+	lewisxhe/SensorLib @ 0.3.4
+################################## END CrowPanel Advance 3.5" #####################################

--- a/boards/elecrow_advance_s3/interface.cpp
+++ b/boards/elecrow_advance_s3/interface.cpp
@@ -1,0 +1,162 @@
+#include "core/powerSave.h"
+#include "core/utils.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <interface.h>
+
+// =============================================================================
+//  CrowPanel Advance 3.5" (ESP32-S3) interface
+//  - Display: ILI9488 over SPI (handled by TFT_eSPI)
+//  - Touch:   GT911 capacitive, directly on I2C (SDA=15, SCL=16, INT=47),
+//             no IO expander, no dedicated RST line.
+//  - Backlight: direct PWM on GPIO38.
+// =============================================================================
+
+#if defined(HAS_CAPACITIVE_TOUCH) && defined(TOUCH_GT911_I2C)
+#include "TouchDrvGT911.hpp"
+TouchDrvGT911 touch;
+struct TouchPointPro {
+    int16_t x = 0;
+    int16_t y = 0;
+};
+#endif
+
+/***************************************************************************************
+** Function name: _setup_gpio()
+***************************************************************************************/
+void _setup_gpio() {
+    bruceConfig.colorInverted = 0;
+
+#if defined(HAS_CAPACITIVE_TOUCH) && defined(TOUCH_GT911_I2C)
+    // Bring up the I2C bus the GT911 lives on
+    Wire.begin(GT911_I2C_CONFIG_SDA_IO_NUM, GT911_I2C_CONFIG_SCL_IO_NUM);
+
+    // GT911 power-on reset sequence. No RST line on this board, so hold INT low
+    // briefly to keep address 0x5D, then release it as an input.
+    pinMode(BOARD_TOUCH_INT, OUTPUT);
+    digitalWrite(BOARD_TOUCH_INT, LOW);
+    delay(10);
+    pinMode(BOARD_TOUCH_INT, INPUT);
+    delay(50);
+
+    // No reset line available -> pass -1 for RST.
+    touch.setPins(-1, BOARD_TOUCH_INT);
+    if (!touch.begin(
+            Wire, GT911_SLAVE_ADDRESS_L, GT911_I2C_CONFIG_SDA_IO_NUM, GT911_I2C_CONFIG_SCL_IO_NUM
+        )) {
+        Serial.println("Failed to find GT911 touch - check wiring!");
+    } else {
+        Serial.println("GT911 touch started");
+    }
+#endif
+}
+
+/***************************************************************************************
+** Function name: _post_setup_gpio()
+***************************************************************************************/
+void _post_setup_gpio() {
+    pinMode(TFT_BL, OUTPUT);
+    ledcAttach(TFT_BL, TFT_BRIGHT_FREQ, TFT_BRIGHT_Bits);
+    ledcWrite(TFT_BL, 255);
+}
+
+/***************************************************************************************
+** Function name: getBattery()
+***************************************************************************************/
+int getBattery() { return 100; }
+
+/*********************************************************************
+** Function: _setBrightness
+**********************************************************************/
+void _setBrightness(uint8_t brightval) {
+    int dutyCycle;
+    if (brightval == 100) dutyCycle = 255;
+    else if (brightval == 75) dutyCycle = 130;
+    else if (brightval == 50) dutyCycle = 70;
+    else if (brightval == 25) dutyCycle = 20;
+    else if (brightval == 0) dutyCycle = 0;
+    else dutyCycle = ((brightval * 255) / 100);
+    ledcWrite(TFT_BL, dutyCycle);
+}
+
+/*********************************************************************
+** Function: InputHandler (GT911 capacitive)
+**********************************************************************/
+void InputHandler(void) {
+#if defined(HAS_CAPACITIVE_TOUCH) && defined(TOUCH_GT911_I2C)
+    static long d_tmp = 0;
+    if (millis() - d_tmp > 200 || LongPress) {
+        static unsigned long tm = millis();
+        TouchPointPro t;
+        uint8_t touched = 0;
+        static uint8_t rot = 5;
+
+        if (rot != bruceConfigPins.rotation) {
+            if (bruceConfigPins.rotation == 1) {
+                touch.setMaxCoordinates(TFT_HEIGHT, TFT_WIDTH);
+                touch.setSwapXY(true);
+                touch.setMirrorXY(false, true);
+            }
+            if (bruceConfigPins.rotation == 3) {
+                touch.setMaxCoordinates(TFT_HEIGHT, TFT_WIDTH);
+                touch.setSwapXY(true);
+                touch.setMirrorXY(true, false);
+            }
+            if (bruceConfigPins.rotation == 0) {
+                touch.setMaxCoordinates(TFT_WIDTH, TFT_HEIGHT);
+                touch.setSwapXY(false);
+                touch.setMirrorXY(false, false);
+            }
+            if (bruceConfigPins.rotation == 2) {
+                touch.setMaxCoordinates(TFT_WIDTH, TFT_HEIGHT);
+                touch.setSwapXY(false);
+                touch.setMirrorXY(true, true);
+            }
+            rot = bruceConfigPins.rotation;
+        }
+
+        static bool lastTouchState = false;
+        static unsigned long lastTouchTime = 0;
+
+        touched = touch.getPoint(&t.x, &t.y);
+        bool currentTouchState = touched > 0;
+
+        if (currentTouchState && !lastTouchState && (millis() - lastTouchTime) > 100) {
+            lastTouchTime = millis();
+        } else if (!currentTouchState || lastTouchState) {
+            touched = 0;
+        }
+        lastTouchState = currentTouchState;
+
+        if (((millis() - tm) > 190 || LongPress) && touched) {
+            tm = millis();
+            if (!wakeUpScreen()) AnyKeyPress = true;
+            else goto END;
+
+            touchPoint.x = t.x;
+            touchPoint.y = t.y;
+            touchPoint.pressed = true;
+            touchHeatMap(touchPoint);
+        END:
+            d_tmp = millis();
+        }
+    }
+#else
+    checkPowerSaveTime();
+    PrevPress = false;
+    NextPress = false;
+    SelPress = false;
+    AnyKeyPress = false;
+    EscPress = false;
+#endif
+}
+
+/*********************************************************************
+** Function: powerOff
+**********************************************************************/
+void powerOff() {}
+
+/*********************************************************************
+** Function: checkReboot
+**********************************************************************/
+void checkReboot() {}

--- a/boards/elecrow_advance_s3/pins_arduino.h
+++ b/boards/elecrow_advance_s3/pins_arduino.h
@@ -1,0 +1,32 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+#ifndef DEVICE_NAME
+#define DEVICE_NAME "Elecrow Advance 3.5 S3"
+#endif
+
+// =============================================================================
+//  Elecrow CrowPanel Advance 3.5" HMI
+//  ESP32-S3-WROOM-1-N16R8, ILI9488 480x320 IPS over SPI (TFT_eSPI backend),
+//  GT911 capacitive touch over I2C. Concrete pin assignments live in the build
+//  flags (boards/elecrow_advance_s3/elecrow_advance_s3.ini); this header only
+//  provides the standard Arduino aliases the core/libraries expect.
+// =============================================================================
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// GT911 capacitive touch I2C bus
+static const uint8_t SDA = 15;
+static const uint8_t SCL = 16;
+
+// Display / SD share SPI signals; chip-selects differ (see board .ini)
+static const uint8_t SS = 40;   // TFT_CS
+static const uint8_t MOSI = 39; // TFT_MOSI
+static const uint8_t MISO = 4;  // SD_MISO (TFT MISO is unused, -1)
+static const uint8_t SCK = 42;  // TFT_SCLK
+
+#endif /* Pins_Arduino_h */

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,6 +73,7 @@ default_envs =
 	;elecrow-28B
 	;elecrow-35B
 	;elecrow-35Bv2_2
+	;elecrow-advance-35-s3
 
 
 ;uncomment to not use global dirs to avoid possible conflicts


### PR DESCRIPTION
#### Proposed Changes ####

Adds support for the **Elecrow CrowPanel Advance 3.5" HMI** display board.

It is an **ESP32-S3-WROOM-1-N16R8** (16 MB flash, 8 MB OPI PSRAM) board with a
**480×320 ILI9488** IPS panel over SPI and a **GT911** capacitive touch
controller on I²C. This is a different product from the CrowPanel HMI boards
already in `boards/elecrow/` (those are ESP32 + resistive XPT2046), so the new
board is added as its own self-contained folder rather than folded into the
existing one.

<!-- Drag the photo of the board running Bruce here -->

**Files added** (all under `boards/elecrow_advance_s3/`):
| File | Purpose |
|------|---------|
| `elecrow_advance_s3.ini` | Build environment `env:elecrow-advance-35-s3` |
| `interface.cpp` | GT911 capacitive-touch + PWM-backlight HAL |
| `pins_arduino.h` | Standard Arduino pin aliases |

`platformio.ini` is touched only to list the new env in the commented
`default_envs` reference block (1 line).

**Pin map** (from the [manufacturer reference driver](https://github.com/Elecrow-RD/CrowPanel-Advance-3.5-HMI-ESP32-S3-AI-Powered-IPS-Touch-Screen-480x320)):

| Function | Pins |
|----------|------|
| TFT SPI (ILI9488) | MOSI 39, MISO −1, SCLK 42, CS 40, DC 41, BL 38 (PWM) |
| Touch GT911 (I²C) | SDA 15, SCL 16, INT 47, addr `0x5D` |
| SD card (SPI) | MOSI 6, MISO 4, SCK 5, CS 7 |

Two board-specific notes for reviewers:
- **`USE_HSPI_PORT=1` is required on the ESP32-S3** — without it TFT_eSPI leaves
  the SPI register pointers unset and panics (`StoreProhibited`) on the first
  display write.
- **`ARDUINO_USB_CDC_ON_BOOT=0`** routes the serial console to UART0, which is
  the on-board CH341 USB-UART bridge this board exposes.

#### Types of Changes ####

New Feature — new board support. No changes to shared code; nothing else is affected.

#### Verification ####

Built with `pio run -e elecrow-advance-35-s3` and flashed to physical hardware:

- ✅ Boots to the Bruce main menu
- ✅ ILI9488 display renders correctly
- ✅ GT911 capacitive touch navigates the UI
- ✅ 8 MB OPI PSRAM detected
- ✅ 16 MB QIO flash detected

#### Testing ####

Manual hardware testing on the physical board (consistent with existing board additions; no automated tests).

#### Linked Issues ####

N/A

#### User-Facing Change ####
```release-note
Add support for the Elecrow CrowPanel Advance 3.5" HMI (ESP32-S3, ILI9488, GT911) board.
```

#### Further Comments ####

The board is fully usable. The boot animation / splash are Bruce's standard
shared behaviour and are unchanged here.
