### PR TITLE
fix(nrf24): don't error "NRF24 pins undefined" when SPI & UART pins are both valid

### DIFF
--- a/src/modules/NRF24/nrf_common.cpp
+++ b/src/modules/NRF24/nrf_common.cpp
@@ -126,8 +126,12 @@ NRF24_MODE nrf_setMode() {
         nrfUART = false;
     }
     if (nrfSPI && nrfUART) {
-        displayError("NRF24 pins undefined", true);
-        mode = NRF_MODE_BOTH;
+        // FIX: having both valid SPI pins AND valid UART pins is not an error.
+        // A UART-NRF can't be reliably auto-detected from pin config, so when the
+        // SPI pins are configured, default to SPI (the common case — e.g. the
+        // M5Stick RF Pack S3 with an SPI nRF24). Previously this branch wrongly
+        // raised "NRF24 pins undefined", blocking every SPI-only NRF24 device.
+        mode = NRF_MODE_SPI;
     } else if (nrfSPI) {
         mode = NRF_MODE_SPI;
     } else if (nrfUART) {


### PR DESCRIPTION
### Problem
On the `dev` branch, opening any NRF24 feature on an SPI-only nRF24 setup (e.g. M5Stack StickS3 + pingequa RF Pack S3) fails with a blocking **"NRF24 pins undefined"** error, even though the pins are correctly configured.

### Cause
`nrf_setMode()` in `src/modules/NRF24/nrf_common.cpp` initializes `nrfSPI = true` and `nrfUART = true`, then treats the *both valid* case as an error:

```cpp
if (nrfSPI && nrfUART) {
    displayError("NRF24 pins undefined", true);   // fires on a VALID state
    mode = NRF_MODE_BOTH;
}
```

Any device with valid NRF24 SPI pins **and** ordinary (non-conflicting) UART pins lands here, so SPI nRF24 modules are unusable on `dev`. (`main` is unaffected — it uses a user-selected mode menu instead.)

### Fix
A UART-NRF can't be auto-detected from pin config, so when the SPI pins are configured, default to `NRF_MODE_SPI` instead of raising a false error.

### Testing
Built `dev` + this fix for `m5stack-sticks3` and flashed to an M5Stack StickS3 with the pingequa RF Pack S3 (CC1101 + nRF24L01+). NRF24 jammer/spectrum now initialize and run; the "NRF24 pins undefined" error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)