### PR TITLE
feat(wifi): Channel Analyzer + Jam Detect modules

### DIFF
--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -19,6 +19,8 @@
 
 #ifndef LITE_VERSION
 #include "modules/pwnagotchi/pwnagotchi.h"
+#include "modules/wifi/channel_analyzer.h"
+#include "modules/wifi/jam_detect.h"
 #include "modules/wifi/wifi_recover.h"
 #endif
 
@@ -71,6 +73,8 @@ void WifiMenu::optionsMenu() {
     options.push_back({"TelNET", telnet_setup});
     options.push_back({"SSH", lambdaHelper(ssh_setup, String(""))});
     options.push_back({"Sniffer", sniffer_setup});
+    options.push_back({"Channel Analyzer", channel_analyzer_setup});
+    options.push_back({"Jam Detect", jam_detect_setup});
     options.push_back({"Scan Hosts", [=]() {
                            bool doScan = true;
                            if (!wifiConnected) doScan = wifiConnectMenu();

--- a/src/modules/wifi/channel_analyzer.cpp
+++ b/src/modules/wifi/channel_analyzer.cpp
@@ -1,0 +1,190 @@
+#if !defined(LITE_VERSION)
+#include "channel_analyzer.h"
+
+#include "esp_err.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "nvs_flash.h"
+
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/wifi/wifi_common.h"
+#include <Arduino.h>
+#include <globals.h>
+
+// 2.4GHz channels to sweep.
+static const uint8_t CA_CHANNELS[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+static const int CA_NCH = sizeof(CA_CHANNELS) / sizeof(CA_CHANNELS[0]);
+
+// Load% at/above which a bar is drawn solid (busy) instead of dimmed.
+static const uint8_t CA_BUSY_THRESHOLD = 50;
+
+// Counters updated from the promiscuous RX callback for the *current* channel.
+static volatile uint32_t ca_bytes = 0;
+static volatile uint32_t ca_pkts = 0;
+static volatile int8_t ca_rssi_peak = -128;
+
+// Keep the callback minimal: just accumulate. Airtime is estimated in the loop.
+static void IRAM_ATTR ca_rx_cb(void *buf, wifi_promiscuous_pkt_type_t type) {
+    const wifi_promiscuous_pkt_t *pkt = (const wifi_promiscuous_pkt_t *)buf;
+    if (!pkt) return;
+    ca_pkts++;
+    ca_bytes += pkt->rx_ctrl.sig_len;
+    if (pkt->rx_ctrl.rssi > ca_rssi_peak) ca_rssi_peak = pkt->rx_ctrl.rssi;
+}
+
+// Tolerant WiFi bring-up. Unlike the sniffer (ESP_ERROR_CHECK), we never abort:
+// if WiFi is already initialised/started we get ESP_ERR_WIFI_INIT_STATE (or
+// similar) and just carry on — promiscuous mode works regardless.
+static void ca_start_wifi() {
+    ensureWifiPlatform();
+    nvs_flash_init();
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_err_t e = esp_wifi_init(&cfg);
+    if (e != ESP_OK && e != ESP_ERR_WIFI_INIT_STATE)
+        Serial.printf("[ChAnalyzer] wifi_init: %s\n", esp_err_to_name(e));
+    esp_wifi_set_storage(WIFI_STORAGE_RAM);
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    e = esp_wifi_start();
+    if (e != ESP_OK && e != ESP_ERR_WIFI_INIT_STATE)
+        Serial.printf("[ChAnalyzer] wifi_start: %s\n", esp_err_to_name(e));
+    esp_wifi_set_promiscuous(true);
+    // Capture every frame type so the airtime estimate reflects real load.
+    wifi_promiscuous_filter_t filt = {};
+    filt.filter_mask = WIFI_PROMIS_FILTER_MASK_ALL;
+    esp_wifi_set_promiscuous_filter(&filt);
+    esp_wifi_set_promiscuous_rx_cb(ca_rx_cb);
+}
+
+static void ca_stop_wifi() {
+    esp_wifi_set_promiscuous(false);
+    esp_wifi_set_promiscuous_rx_cb(NULL);
+    esp_wifi_stop();
+    wifiDisconnect();
+    vTaskDelay(1 / portTICK_RATE_MS);
+}
+
+static void ca_draw(
+    const uint8_t *load, const uint8_t *peak, const int8_t *rssi, uint8_t curCh, uint16_t dwell
+) {
+    drawMainBorderWithTitle("Channel Analyzer");
+
+    const int x0 = 8;                  // left of bars
+    const int top = 26;                // below title
+    const int bottom = tftHeight - 16; // leave room for footer
+    const int avail = bottom - top;
+    const int rowH = avail / CA_NCH;
+    const int labelW = 30;                  // "Ch11"
+    const int valW = 30;                    // " 100%"
+    const int barX = x0 + labelW;
+    const int barW = tftWidth - barX - valW - 6;
+
+    tft.setTextSize(FP);
+    for (int i = 0; i < CA_NCH; i++) {
+        uint8_t ch = CA_CHANNELS[i];
+        int y = top + i * rowH;
+        bool isCur = (ch == curCh);
+
+        // label
+        tft.setTextColor(isCur ? bruceConfig.bgColor : bruceConfig.priColor, isCur ? bruceConfig.priColor : bruceConfig.bgColor);
+        tft.drawString("Ch" + String(ch), x0, y, 1);
+
+        // bar frame
+        int bh = rowH - 3;
+        if (bh < 4) bh = 4;
+        tft.drawRect(barX, y, barW, bh, bruceConfig.priColor);
+        // clear interior
+        tft.fillRect(barX + 1, y + 1, barW - 2, bh - 2, bruceConfig.bgColor);
+
+        // filled portion ~ load%
+        int fillW = (barW - 2) * load[ch] / 100;
+        if (fillW > 0) {
+            // solid above threshold, dimmed below
+            uint16_t c = (load[ch] >= CA_BUSY_THRESHOLD) ? bruceConfig.priColor : TFT_DARKGREY;
+            tft.fillRect(barX + 1, y + 1, fillW, bh - 2, c);
+        }
+        // peak-hold marker
+        int peakX = barX + 1 + (barW - 2) * peak[ch] / 100;
+        if (peakX > barX + 1) tft.drawFastVLine(peakX, y + 1, bh - 2, TFT_RED);
+
+        // value
+        tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+        tft.drawString(String(load[ch]) + "%", barX + barW + 4, y, 1);
+    }
+
+    // footer: current channel detail + signal meter + dwell
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    String foot = "Ch" + String(curCh) + " " + String(load[curCh]) + "% pk" + String(peak[curCh]) +
+                  "% " + String(rssi[curCh]) + "dBm  dwell " + String(dwell) + "ms";
+    tft.drawString(foot, x0, tftHeight - 13, 1);
+}
+
+void channel_analyzer_setup() {
+    returnToMenu = false;
+
+    uint8_t load[12] = {0};
+    uint8_t peak[12] = {0};
+    int8_t rssi[12];
+    for (int i = 0; i < 12; i++) rssi[i] = -128;
+
+    uint16_t dwell = 350; // ms per channel, adjustable with Up/Down
+    int idx = 0;
+
+    ca_start_wifi();
+
+    tft.fillScreen(bruceConfig.bgColor);
+    drawMainBorderWithTitle("Channel Analyzer");
+    tft.setTextSize(FP);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    padprintln("");
+    padprintln(" sweeping 1-11 ...");
+    delay(300);
+
+    for (;;) {
+        if (returnToMenu) break;
+        if (check(EscPress)) {
+            returnToMenu = true;
+            break;
+        }
+        if (check(UpPress) && dwell < 1000) dwell += 100;   // longer dwell = more accurate
+        if (check(DownPress) && dwell > 150) dwell -= 100;  // shorter dwell = faster sweep
+
+        uint8_t ch = CA_CHANNELS[idx];
+        esp_wifi_set_channel(ch, WIFI_SECOND_CHAN_NONE);
+
+        // reset counters for this dwell window
+        ca_bytes = 0;
+        ca_pkts = 0;
+        ca_rssi_peak = -128;
+
+        uint32_t t0 = millis();
+        while (millis() - t0 < dwell) {
+            if (check(EscPress)) {
+                returnToMenu = true;
+                break;
+            }
+            vTaskDelay(20 / portTICK_PERIOD_MS);
+        }
+        if (returnToMenu) break;
+
+        // Estimate airtime utilisation: bytes at a conservative ~6Mbps baseline
+        // plus per-frame preamble/IFS overhead. Clamp to 0-100%.
+        uint32_t airtime_us = (ca_bytes * 8UL) / 6UL + ca_pkts * 60UL;
+        uint32_t dwell_us = (uint32_t)dwell * 1000UL;
+        uint32_t l = dwell_us ? (airtime_us * 100UL / dwell_us) : 0;
+        if (l > 100) l = 100;
+
+        load[ch] = (uint8_t)l;
+        if (load[ch] > peak[ch]) peak[ch] = load[ch];
+        rssi[ch] = (ca_rssi_peak == -128) ? 0 : ca_rssi_peak;
+
+        ca_draw(load, peak, rssi, ch, dwell);
+
+        idx = (idx + 1) % CA_NCH;
+    }
+
+    ca_stop_wifi();
+}
+
+#endif

--- a/src/modules/wifi/channel_analyzer.h
+++ b/src/modules/wifi/channel_analyzer.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#if !defined(LITE_VERSION)
+
+// Real-time 2.4GHz channel utilization analyzer.
+// Hops channels 1-11 in promiscuous mode, estimates per-channel airtime load,
+// and draws solid-threshold bars with load %, peak hold and a signal meter.
+void channel_analyzer_setup();
+
+#endif

--- a/src/modules/wifi/jam_detect.cpp
+++ b/src/modules/wifi/jam_detect.cpp
@@ -1,0 +1,209 @@
+#if !defined(LITE_VERSION)
+#include "jam_detect.h"
+
+#include "esp_err.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "nvs_flash.h"
+
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/wifi/wifi_common.h"
+#include <Arduino.h>
+#include <globals.h>
+
+static const uint8_t JD_CHANNELS[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+static const int JD_NCH = sizeof(JD_CHANNELS) / sizeof(JD_CHANNELS[0]);
+
+// HARDWARE CONSTRAINT: the ESP32 has a single WiFi radio, so it can only be
+// tuned to one channel at a time — watching "all channels at once" is physically
+// impossible. We approximate full-band coverage by hopping rapidly with a very
+// short dwell, so a full sweep of channels 1-11 completes in ~1s. We also alert
+// the instant a deauth is seen on the current channel rather than waiting for the
+// dwell window to expire (see the sampling loop below).
+//
+// dwell per channel while hopping (ms). ~100ms * 11 channels ≈ 1.1s per sweep.
+static const uint16_t JD_DWELL = 100;
+
+// Counters for the current channel's dwell window.
+static volatile uint32_t jd_deauth = 0;
+static volatile uint32_t jd_total = 0;
+
+static void IRAM_ATTR jd_rx_cb(void *buf, wifi_promiscuous_pkt_type_t type) {
+    const wifi_promiscuous_pkt_t *pkt = (const wifi_promiscuous_pkt_t *)buf;
+    if (!pkt) return;
+    jd_total++;
+    if (pkt->rx_ctrl.sig_len < 2) return;
+    const uint8_t *f = pkt->payload;
+    uint16_t fc = (uint16_t)f[0] | ((uint16_t)f[1] << 8);
+    uint8_t ftype = (fc & 0x0C) >> 2; // 0 = management
+    uint8_t fsub = (fc & 0xF0) >> 4;  // 0x0C deauth, 0x0A disassoc
+    if (ftype == 0x00 && (fsub == 0x0C || fsub == 0x0A)) jd_deauth++;
+}
+
+static void jd_start_wifi() {
+    ensureWifiPlatform();
+    nvs_flash_init();
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_err_t e = esp_wifi_init(&cfg);
+    if (e != ESP_OK && e != ESP_ERR_WIFI_INIT_STATE)
+        Serial.printf("[JamDetect] wifi_init: %s\n", esp_err_to_name(e));
+    esp_wifi_set_storage(WIFI_STORAGE_RAM);
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    e = esp_wifi_start();
+    if (e != ESP_OK && e != ESP_ERR_WIFI_INIT_STATE)
+        Serial.printf("[JamDetect] wifi_start: %s\n", esp_err_to_name(e));
+    esp_wifi_disconnect(); // drop any STA association so channel hopping isn't locked to one channel
+    esp_wifi_set_promiscuous(true);
+    // CRITICAL: deauth/disassoc are management frames — capture MGMT (+DATA for
+    // an activity reference). Without this the default filter may drop them.
+    wifi_promiscuous_filter_t filt = {};
+    filt.filter_mask = WIFI_PROMIS_FILTER_MASK_MGMT | WIFI_PROMIS_FILTER_MASK_DATA;
+    esp_wifi_set_promiscuous_filter(&filt);
+    esp_wifi_set_promiscuous_rx_cb(jd_rx_cb);
+}
+
+static void jd_stop_wifi() {
+    esp_wifi_set_promiscuous(false);
+    esp_wifi_set_promiscuous_rx_cb(NULL);
+    esp_wifi_stop();
+    wifiDisconnect();
+    vTaskDelay(1 / portTICK_RATE_MS);
+}
+
+static void
+jd_draw(const uint16_t *dps, const uint16_t *peak, uint32_t thr, uint8_t curCh, int attackCh) {
+    drawMainBorderWithTitle("Jam Detect");
+    tft.setTextSize(FP);
+
+    const int x0 = 8;
+    int y = 26;
+
+    // status banner
+    bool attack = (attackCh >= 0);
+    uint16_t sc = attack ? TFT_RED : TFT_GREEN;
+    tft.fillRect(x0, y, tftWidth - 2 * x0, 18, sc);
+    tft.setTextColor(TFT_BLACK, sc);
+    String banner = attack ? ("ATTACK ch" + String(attackCh) + "  " + String(dps[attackCh]) + "/s")
+                           : "scanning... no jamming";
+    tft.drawCentreString(banner, tftWidth / 2, y + 3, 1);
+    y += 24;
+
+    // per-channel deauth bars
+    const int labelW = 28;
+    const int valW = 26;
+    const int barX = x0 + labelW;
+    const int bottom = tftHeight - 14;
+    const int rowH = (bottom - y) / JD_NCH;
+    const int barW = tftWidth - barX - valW - 6;
+    uint32_t scale = thr * 2;
+    if (scale < 4) scale = 4;
+
+    for (int i = 0; i < JD_NCH; i++) {
+        uint8_t ch = JD_CHANNELS[i];
+        int ry = y + i * rowH;
+        bool isCur = (ch == curCh);
+        bool over = (dps[ch] >= thr);
+
+        tft.setTextColor(
+            isCur ? bruceConfig.bgColor : bruceConfig.priColor,
+            isCur ? bruceConfig.priColor : bruceConfig.bgColor
+        );
+        tft.drawString("Ch" + String(ch), x0, ry, 1);
+
+        int bh = rowH - 3;
+        if (bh < 4) bh = 4;
+        tft.drawRect(barX, ry, barW, bh, bruceConfig.priColor);
+        tft.fillRect(barX + 1, ry + 1, barW - 2, bh - 2, bruceConfig.bgColor);
+        uint32_t fillW = (uint32_t)(barW - 2) * dps[ch] / scale;
+        if (fillW > (uint32_t)(barW - 2)) fillW = barW - 2;
+        if (fillW > 0) tft.fillRect(barX + 1, ry + 1, (int)fillW, bh - 2, over ? TFT_RED : bruceConfig.priColor);
+        // peak-hold marker
+        uint32_t pkX = (uint32_t)(barX + 1) + (uint32_t)(barW - 2) * peak[ch] / scale;
+        if (peak[ch] > 0 && pkX > (uint32_t)(barX + 1)) tft.drawFastVLine((int)pkX, ry + 1, bh - 2, TFT_YELLOW);
+
+        tft.setTextColor(over ? TFT_RED : bruceConfig.priColor, bruceConfig.bgColor);
+        tft.drawString(String(dps[ch]), barX + barW + 4, ry, 1);
+    }
+
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    tft.drawString("scan ch" + String(curCh) + " thr" + String(thr) + "/s  UP/DN  ESC", x0, tftHeight - 12, 1);
+}
+
+void jam_detect_setup() {
+    returnToMenu = false;
+
+    uint16_t dps[12] = {0};  // last measured deauth/s per channel (latched)
+    uint16_t peak[12] = {0}; // peak-hold
+    uint32_t threshold = 10; // deauth/s to flag (adjustable)
+    int idx = 0;
+
+    jd_start_wifi();
+    tft.fillScreen(bruceConfig.bgColor);
+
+    for (;;) {
+        if (returnToMenu) break;
+
+        uint8_t ch = JD_CHANNELS[idx];
+        esp_wifi_set_channel(ch, WIFI_SECOND_CHAN_NONE);
+        vTaskDelay(5 / portTICK_PERIOD_MS); // brief radio settle (kept short vs the dwell)
+
+        jd_deauth = 0;
+        jd_total = 0;
+
+        // Sample the current channel for one short dwell. The deauth/sec rate is
+        // extrapolated from however many frames we caught in this window:
+        //   rate = deauths * (1000 / dwell_ms)
+        // so even a single deauth in a ~100ms window registers strongly.
+        // IMMEDIATE ALERT: we poll the live counter inside the dwell and, the
+        // moment the extrapolated rate reaches the threshold, we latch the alert
+        // and redraw RIGHT AWAY instead of waiting for the dwell to finish.
+        bool tripped = false;
+        uint32_t t0 = millis();
+        while (millis() - t0 < JD_DWELL) {
+            if (check(EscPress)) {
+                returnToMenu = true;
+                break;
+            }
+            if (check(UpPress) && threshold < 250) threshold += 5;
+            if (check(DownPress) && threshold > 5) threshold -= 5;
+
+            // live extrapolated rate for the deauths seen so far this window
+            uint32_t live = (uint32_t)jd_deauth * 1000UL / JD_DWELL;
+            if (live >= threshold) {
+                tripped = true;
+                break; // detected — stop dwelling, draw immediately, then hop on
+            }
+            vTaskDelay(5 / portTICK_PERIOD_MS);
+        }
+        if (returnToMenu) break;
+
+        uint32_t d = (uint32_t)jd_deauth * 1000UL / JD_DWELL;
+        if (d > 65535) d = 65535;
+        dps[ch] = (uint16_t)d;
+        if (dps[ch] > peak[ch]) peak[ch] = dps[ch];
+
+        // worst channel currently at/over threshold (latched values persist
+        // across the sweep so an attack stays flagged after we hop away).
+        // `tripped` guarantees the channel we just left is considered even if a
+        // later channel happens to read higher this redraw.
+        int attackCh = -1;
+        uint16_t worst = 0;
+        for (int i = 0; i < JD_NCH; i++) {
+            uint8_t c = JD_CHANNELS[i];
+            if (dps[c] >= threshold && dps[c] >= worst) {
+                worst = dps[c];
+                attackCh = c;
+            }
+        }
+        if (tripped && attackCh < 0) attackCh = ch; // ensure the live trip is shown
+
+        jd_draw(dps, peak, threshold, ch, attackCh);
+        idx = (idx + 1) % JD_NCH;
+    }
+
+    jd_stop_wifi();
+}
+
+#endif

--- a/src/modules/wifi/jam_detect.h
+++ b/src/modules/wifi/jam_detect.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#if !defined(LITE_VERSION)
+
+// Deauth/disassoc flood ("jamming") detector.
+// Watches management-frame deauth rate on the selected channel and raises a
+// visual alert when it crosses a user-adjustable threshold.
+void jam_detect_setup();
+
+#endif


### PR DESCRIPTION
### Summary
Two new WiFi analysis modules for the WiFi menu.

### Channel Analyzer (`src/modules/wifi/channel_analyzer.*`)
- Real-time 2.4 GHz per-channel airtime utilization across channels 1-11 (promiscuous sweep, `MASK_ALL` filter).
- Solid-threshold load bars, peak-hold markers, and a per-channel signal meter.
- Up/Down adjusts dwell time; ESC exits.

### Jam Detect (`src/modules/wifi/jam_detect.*`)
- Detects deauth/disassoc floods. Rapidly hops channels 1-11 (~100 ms dwell, ~1.1 s/sweep) using a `MASK_MGMT | MASK_DATA` promiscuous filter (deauth/disassoc are management frames).
- **Immediate alert:** polls the live counter and trips the instant the extrapolated rate crosses a user-adjustable threshold mid-window, rather than waiting for the dwell to end.
- Per-channel deauth-rate bars (red over threshold) + a latched `ATTACK chN` banner. Drops any STA association so hopping isn't locked to one channel.
- A single radio can't watch all channels literally at once, so this approximates full-band coverage via fast hopping.

### Notes
- Both use a tolerant WiFi bring-up that ignores `ESP_ERR_WIFI_INIT_STATE` so they recover when WiFi is already initialised.
- Wired into `WifiMenu.cpp` (non-LITE), so they build for all board targets.

### Testing
Built and flashed on `m5stack-sticks3`, `lilygo-t-embed-cc1101`, and `m5stack-cardputer`. Both modules run; Jam Detect correctly reports deauth rate per channel and flags attacks (verified via serial frame counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)