### PR TITLE
fix(t-deck): correct swapped I2S BCLK/WCLK pins + enable NS4168 speaker

### DIFF
--- a/.github/workflows/PR_check.yml
+++ b/.github/workflows/PR_check.yml
@@ -1,18 +1,28 @@
 ---
 name: Build and Push OR check-PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:
-      - main, dev
+      - main
+      - dev
+    paths:
+        - "**.yml"
+        - "**.h"
+        - "**.cpp"
+        - "**.py"
+        - "**.html"
+        - "**.css"
+        - "**.js"
+        - "**.ini"
+        - "**.json"
+        - "**.csv"
+
   workflow_dispatch:
-    inputs:
-      board:
-        description: "Board to Compile"
-        type: choice
-        required: true
-        default: "M5Cardputer"
-        options: ["M5Cardputer", "M5StickCPlus2", "ESP32-S3"]
 
 jobs:
   compile_sketch:
@@ -49,7 +59,12 @@ jobs:
             }
           - {
               name: "ESP32-C5",
-              env: "esp32-c5",
+              env: "nm-cyd-c5",
+              partitions: { bootloader_addr: "0x2000" },
+            }
+          - {
+              name: "ESP32-C6",
+              env: "arduino-nesso-n1",
               partitions: { bootloader_addr: "0x2000" },
             }
     steps:
@@ -65,31 +80,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc-multilib libc6-dev-i386
-
-      # - name: Cache pip
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cache/pip
-      #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pip-
-
-      # - name: Cache PlatformIO
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: |
-      #       ~/.platformio
-      #     key: Bruce-platformio-${{ hashFiles('**/platformio.ini') }}
-      #     restore-keys: Bruce-platformio-
-
-      # - name: Restore PIO
-      #   uses: actions/cache/restore@v4
-      #   with:
-      #     path: |
-      #       ${{ github.workspace }}/.pio
-      #     key: Bruce-pio-${{ matrix.board.env }}-${{ github.run_id }}-${{ github.run_attempt }}
-      #     restore-keys: |
-      #           Bruce-pio-${{ matrix.board.env }}-
 
       - name: Install PlatformIO Core
         run: |
@@ -109,17 +99,6 @@ jobs:
       - name: Run Compile
         run: |
           platformio run -e ${{ matrix.board.env }}
-
-      # - name: Cache PIO
-      #   uses: actions/cache/save@v4
-      #   with:
-      #     path: |
-      #       ${{ github.workspace }}/.pio
-      #     key: Bruce-pio-${{ matrix.board.env }}-${{ github.run_id }}-${{ github.run_attempt }}
-
-      # - name: Merge Files
-      #   run: |
-      #    pio run -e ${{ matrix.board.env }} -t build-firmware
 
       - name: Upload ${{ matrix.board.name }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -1,10 +1,27 @@
 ---
 name: Build and Push Releases
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
-      - main, workflow
+      - main
+      - dev
+
+    paths:
+        - "**.yml"
+        - "**.h"
+        - "**.cpp"
+        - "**.py"
+        - "**.html"
+        - "**.css"
+        - "**.js"
+        - "**.ini"
+        - "**.json"
+        - "**.csv"
     tags:
       - "*"
   workflow_dispatch:

--- a/boards/lilygo-t-deck/lilygo-t-deck.ini
+++ b/boards/lilygo-t-deck/lilygo-t-deck.ini
@@ -50,9 +50,9 @@ build_flags =
 	;-DHAS_RTC=1
 
 	;Speaker to run music, compatible with NS4168
-	;-DHAS_NS4168_SPKR=1 ;uncomment to enable
-	-DBCLK=5
-	-DWCLK=7
+	-DHAS_NS4168_SPKR=1
+	-DBCLK=7
+	-DWCLK=5
 	-DDOUT=6
 	-DMCLK=48
 


### PR DESCRIPTION
## Problem

The T-Deck's onboard speaker has never produced sound under Bruce. Two issues:

1. **Swapped I2S clock pins.** Bruce's board config sets `BCLK=5` / `WCLK=7`, but the official LilyGO T-Deck pinout (`utilities.h`) is:
   ```
   #define BOARD_I2S_WS    5   // word-select
   #define BOARD_I2S_BCK   7   // bit-clock
   #define BOARD_I2S_DOUT  6
   ```
   With BCLK/WCLK swapped, the NS4168 amp gets a malformed I2S signal — playback runs but is **silent**.
2. **Speaker disabled.** `HAS_NS4168_SPKR` is commented out, so the entire audio module (`src/modules/others/audio.cpp` is wrapped in `#if defined(HAS_NS4168_SPKR)`) is compiled out and Config → Sound config is empty.

## Fix

- Swap `BCLK`/`WCLK` to match the LilyGO pinout (`BCLK=7`, `WCLK=5`).
- Enable `-DHAS_NS4168_SPKR=1`.

## Testing

Built from tag `1.15` for `lilygo-t-deck-pro` and flashed a **T-Deck Plus** (Rokland "Cypher M8K", 8000 mAh). After the fix:
- Config → Sound config populates (volume + on/off).
- `boot.wav`, the audio player, and RTTTL tones are all **audible**.

Before the pin swap, audio "played" (player progressed) but no sound came out — exactly the swapped bit-clock/word-select symptom.

Refs #1898.