### PR TITLE
fix(ethernet): make host port scan cancellable and bound per-port con…

### DIFF
--- a/.github/workflows/PR_check.yml
+++ b/.github/workflows/PR_check.yml
@@ -1,18 +1,28 @@
 ---
 name: Build and Push OR check-PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:
-      - main, dev
+      - main
+      - dev
+    paths:
+        - "**.yml"
+        - "**.h"
+        - "**.cpp"
+        - "**.py"
+        - "**.html"
+        - "**.css"
+        - "**.js"
+        - "**.ini"
+        - "**.json"
+        - "**.csv"
+
   workflow_dispatch:
-    inputs:
-      board:
-        description: "Board to Compile"
-        type: choice
-        required: true
-        default: "M5Cardputer"
-        options: ["M5Cardputer", "M5StickCPlus2", "ESP32-S3"]
 
 jobs:
   compile_sketch:
@@ -49,7 +59,12 @@ jobs:
             }
           - {
               name: "ESP32-C5",
-              env: "esp32-c5",
+              env: "nm-cyd-c5",
+              partitions: { bootloader_addr: "0x2000" },
+            }
+          - {
+              name: "ESP32-C6",
+              env: "arduino-nesso-n1",
               partitions: { bootloader_addr: "0x2000" },
             }
     steps:
@@ -65,31 +80,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc-multilib libc6-dev-i386
-
-      # - name: Cache pip
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cache/pip
-      #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pip-
-
-      # - name: Cache PlatformIO
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: |
-      #       ~/.platformio
-      #     key: Bruce-platformio-${{ hashFiles('**/platformio.ini') }}
-      #     restore-keys: Bruce-platformio-
-
-      # - name: Restore PIO
-      #   uses: actions/cache/restore@v4
-      #   with:
-      #     path: |
-      #       ${{ github.workspace }}/.pio
-      #     key: Bruce-pio-${{ matrix.board.env }}-${{ github.run_id }}-${{ github.run_attempt }}
-      #     restore-keys: |
-      #           Bruce-pio-${{ matrix.board.env }}-
 
       - name: Install PlatformIO Core
         run: |
@@ -109,17 +99,6 @@ jobs:
       - name: Run Compile
         run: |
           platformio run -e ${{ matrix.board.env }}
-
-      # - name: Cache PIO
-      #   uses: actions/cache/save@v4
-      #   with:
-      #     path: |
-      #       ${{ github.workspace }}/.pio
-      #     key: Bruce-pio-${{ matrix.board.env }}-${{ github.run_id }}-${{ github.run_attempt }}
-
-      # - name: Merge Files
-      #   run: |
-      #    pio run -e ${{ matrix.board.env }} -t build-firmware
 
       - name: Upload ${{ matrix.board.name }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -1,10 +1,27 @@
 ---
 name: Build and Push Releases
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
-      - main, workflow
+      - main
+      - dev
+
+    paths:
+        - "**.yml"
+        - "**.h"
+        - "**.cpp"
+        - "**.py"
+        - "**.html"
+        - "**.css"
+        - "**.js"
+        - "**.ini"
+        - "**.json"
+        - "**.csv"
     tags:
       - "*"
   workflow_dispatch:

--- a/src/modules/ethernet/HostInfo.cpp
+++ b/src/modules/ethernet/HostInfo.cpp
@@ -49,15 +49,15 @@ void HostInfo::client_stop() {
 #endif
 }
 
-void HostInfo::client_connect(IPAddress ip, int port) {
+void HostInfo::client_connect(IPAddress ip, int port, int timeout_ms) {
 #if !defined(LITE_VERSION)
     if (eth_client != nullptr) {
-        sockfd = eth_client->connect(ip, port, 3000);
+        sockfd = eth_client->connect(ip, port, timeout_ms);
     } else {
-        wifi_client->connect(ip, port);
+        wifi_client->connect(ip, port, timeout_ms);
     }
 #else
-    wifi_client->connect(ip, port);
+    wifi_client->connect(ip, port, timeout_ms);
 #endif
 }
 
@@ -118,16 +118,24 @@ void HostInfo::setup(const Host &host) {
             break;
         }
 
-        client_connect(host.ip, port);
+        client_connect(host.ip, port, TIMEOUT_MS);
         unsigned long startTime = millis();
 
         bool connected = false;
         while (millis() - startTime < TIMEOUT_MS) {
+            if (check(EscPress)) {
+                returnToMenu = true;
+                break;
+            }
             if (client_connected()) {
                 connected = true;
                 break;
             }
-            continue;
+        }
+
+        if (returnToMenu) {
+            client_stop();
+            break;
         }
 
         if (connected) {

--- a/src/modules/ethernet/HostInfo.h
+++ b/src/modules/ethernet/HostInfo.h
@@ -141,7 +141,7 @@ private:
         {49157, "Windows RPC"                                                      }
     }; */
     void client_stop();
-    void client_connect(IPAddress ip, int port);
+    void client_connect(IPAddress ip, int port, int timeout_ms = 3000);
     bool client_connected();
     int sockfd = -1;
 


### PR DESCRIPTION

The Host Info port scan only checked for ESC between ports, and the WiFi client connect had no timeout, so a filtered port could block the loop and ESC felt unresponsive. Poll ESC inside the per-port wait too, and pass the scan timeout to the connect so no single port can stall it.

