### PR TITLE
feat(wifi): add 2.4 GHz WiFi Channel Analyzer

### DIFF
--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -35,6 +35,7 @@
 // 64bit: https://github.com/9dl/Bruce-C2/releases/download/v1.0/BruceC2_windows_amd64.exe
 #include "modules/wifi/socks4_proxy.h"
 #include "modules/wifi/tcp_utils.h"
+#include "modules/wifi/wifi_analyzer.h"
 
 // global toggle - controls whether scanNetworks includes hidden SSIDs
 bool showHiddenNetworks = false;
@@ -91,6 +92,7 @@ void WifiMenu::optionsMenu() {
     options.push_back({"WiFi Pass Recovery", wifi_recover_menu});
 #endif
 
+    options.push_back({"WiFi Analyzer", wifiAnalyzerMenu});
     options.push_back({"Config", [this]() { configMenu(); }});
 
     addOptionToMainMenu();

--- a/src/modules/rf/rf_listen.cpp
+++ b/src/modules/rf/rf_listen.cpp
@@ -2,25 +2,36 @@
 
 #include "../others/audio.h"
 
-volatile unsigned long lastMicros = 0;
-volatile unsigned long pulseMicros = 0;
-volatile float ___frequency = 0;
+volatile unsigned long lastEdgeMicros = 0;
 volatile unsigned long pulseDuration = 0;
 volatile bool newPulse = false;
 
+// MUST be fully IRAM-safe: no digitalRead() (lives in flash) and no access to C++ objects
+// like bruceConfigPins from here. On GDO0 the noise can fire this thousands of times/s; if it
+// runs while the flash cache is busy (e.g. display/font reads) the chip crashes/reboots.
 void IRAM_ATTR onPulse() {
-    static bool wasHigh = false;
     unsigned long now = micros();
+    unsigned long period = now - lastEdgeMicros;
+    lastEdgeMicros = now;
 
-    if (digitalRead(bruceConfigPins.CC1101_bus.io0)) {
-        pulseDuration = now - lastMicros;
-        ___frequency = 1000000.0 / pulseDuration;
+    // Measure the period between rising edges. Drop sub-20us glitches and >1s gaps so a noise
+    // burst doesn't keep newPulse pinned and the displayed value stays meaningful.
+    if (period >= 20 && period <= 1000000UL) {
+        pulseDuration = period;
         newPulse = true;
-        wasHigh = true;
-    } else if (wasHigh) {
-        lastMicros = now;
-        wasHigh = false;
     }
+}
+
+// Beep through the EXACT same path as the working DTMF Tones.js script:
+// audio.tone -> (HAS_NS4168_SPKR) serialCli.parse("tone f d") -> toneCallback -> playTone.
+// The key detail learned from that script: the I2S speaker needs a long tone (~500ms) to be
+// audible - short beeps get swallowed by the DMA buffer before it drains.
+static void rf_listen_beep(unsigned int hz, unsigned long ms) {
+#if defined(BUZZ_PIN)
+    tone(BUZZ_PIN, hz, ms); // non-blocking buzzer
+#else
+    serialCli.parse("tone " + String(hz) + " " + String(ms));
+#endif
 }
 
 void rf_listen() {
@@ -60,38 +71,59 @@ void rf_listen() {
     ELECHOUSE_cc1101.setRxBW(58);
     ELECHOUSE_cc1101.setModulation(2);
     ELECHOUSE_cc1101.setDcFilterOff(true);
-    attachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0), onPulse, CHANGE);
+    // Short confirmation beep so you know listening has started.
+    rf_listen_beep(1000, 500);
+
+    // Seed the timestamp so the first measured period isn't a bogus "time since boot" value
+    // (that was the 0.03 Hz reading).
+    lastEdgeMicros = micros();
+    newPulse = false;
+    attachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0), onPulse, RISING);
     displayRedStripe("Listening...", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
 
     unsigned long lastPulseTime = millis();
+    unsigned long lastTone = 0;
     bool pulseActive = false;
+
+    // Only repaint the stripe when the text actually changes. Redrawing every loop iteration
+    // is a full SPI screen draw that (together with the GDO0 interrupt storm) freezes the UI.
+    String lastStripe = "";
+    auto showStripe = [&](const String &text) {
+        if (text == lastStripe) return;
+        lastStripe = text;
+        displayRedStripe(text, getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+    };
 
     while (check(EscPress)) { delay(10); }
 
+    showStripe("Waiting for a pulse");
+
     while (!check(EscPress)) {
-        displayRedStripe(
-            "Waiting for a pulse", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor
-        );
         if (newPulse) {
             newPulse = false;
             lastPulseTime = millis();
             pulseActive = true;
-            String pulseText = String("Freq: ") + String(___frequency, 2) + String(" Hz");
-            displayRedStripe(pulseText, getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
-#if defined(BUZZ_PIN)
-            tone(BUZZ_PIN, ___frequency, pulseDuration);
-#elif defined(HAS_NS4168_SPKR)
-            playTone(___frequency, pulseDuration, 0);
-#endif
+            // Compute frequency here (out of the ISR) to keep the interrupt fast.
+            unsigned long dur = pulseDuration;
+            float freqHz = dur ? (1000000.0f / dur) : 0.0f;
+            showStripe(String("Freq: ") + String(freqHz, 2) + String(" Hz"));
+            // Audible feedback at the detected pulse frequency, via the same proven path as
+            // dtmf.js. The I2S speaker needs ~500ms to be audible, and playTone BLOCKS for that
+            // time, so throttle to 700ms so a continuous signal doesn't make the listener feel
+            // stuck.
+            if (millis() - lastTone > 700) {
+                lastTone = millis();
+                rf_listen_beep((unsigned int)constrain(freqHz, 100.0f, 8000.0f), 500);
+            }
         }
 
         if (pulseActive && millis() - lastPulseTime > 3000) {
             pulseActive = false;
-            displayRedStripe("No signal", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+            showStripe("Waiting for a pulse");
         }
 
-        if (check(EscPress)) break;
         if (check(SelPress)) break;
+        delay(5); // feed the watchdog and let button/UI handling breathe
     }
 
     detachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0));

--- a/src/modules/wifi/wifi_analyzer.cpp
+++ b/src/modules/wifi/wifi_analyzer.cpp
@@ -1,0 +1,292 @@
+/**
+ * @file wifi_analyzer.cpp
+ * @brief 2.4 GHz WiFi Channel Analyzer for Bruce firmware
+ *
+ * Displays a real-time 14-channel RSSI bar chart showing network congestion
+ * across all 2.4 GHz WiFi channels. Rescans automatically every 3 seconds.
+ *
+ * Features:
+ *  - Per-channel RSSI bar graph (channels 1–14, 320×240 landscape layout)
+ *  - Color-coded congestion: green (quiet) → yellow → orange → red (congested)
+ *  - Best channel highlighted with a cyan outline (least congested)
+ *  - Flicker-free updates: only redraws bars whose RSSI or highlight changed
+ *  - Tap any bar to see a list of APs on that channel (SSID + RSSI, sorted)
+ *  - Prev/ESC returns from the AP list back to the channel graph
+ *
+ * Screen layout (320×240, STATUS_BAR_HEIGHT=30):
+ *   y=30–51  : title "WiFi Analyzer"
+ *   y=52–200 : bar graph (GRAPH_H=148px)
+ *   y=203    : channel number labels (1–14, static)
+ *   y=212–239: "Best: Ch X" recommendation + footer
+ */
+
+#include "wifi_analyzer.h"
+#include "core/display.h"
+#include "core/utils.h"
+#include <globals.h>
+#include <interface.h>
+#include <WiFi.h>
+#include <algorithm>
+#include <vector>
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+static const int CH_COUNT   = 14;   // 2.4 GHz channels 1–14
+static const int GRAPH_TOP  = 52;   // bar graph top-y (below title)
+static const int GRAPH_BOT  = 200;  // bar graph bottom-y
+static const int GRAPH_H    = GRAPH_BOT - GRAPH_TOP; // 148px
+static const int CH_W       = 22;   // slot width per channel (5 + 14*22 = 313 ≤ 320)
+static const int BAR_W      = 18;   // bar pixel width (2px padding each side)
+static const int LABEL_Y    = 203;  // channel number label top-y (below graph)
+static const int REC_Y      = 222;  // "Best: Ch X" text center-y
+static const int RSSI_FLOOR = -100; // dBm — treated as "no signal" (bar height 0)
+static const int RSSI_CEIL  = -40;  // dBm — treated as maximum (bar height = GRAPH_H)
+static const int SCAN_WAIT  = 3000; // ms to wait between scans
+
+// ── AP record ─────────────────────────────────────────────────────────────────
+struct APInfo {
+    String ssid;
+    int    rssi;
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// Map RSSI to a traffic-light color.
+static uint16_t _rssiColor(int rssi) {
+    if (rssi >= -60) return TFT_RED;    // congested
+    if (rssi >= -75) return TFT_ORANGE;
+    if (rssi >= -90) return TFT_YELLOW;
+    return TFT_GREEN;                   // quiet / empty
+}
+
+// Return the channel (1–14) tapped by the user, or 0 if outside the bar area.
+static int _hitTestChannel(uint16_t tx, uint16_t ty) {
+    if (ty < GRAPH_TOP || ty > LABEL_Y + 12) return 0;
+    if (tx < 5) return 0;
+    int ch = (int)(tx - 5) / CH_W; // 0-indexed
+    if (ch < 0 || ch >= CH_COUNT)  return 0;
+    return ch + 1;
+}
+
+// ── Main graph draw ───────────────────────────────────────────────────────────
+
+/**
+ * Draw or incrementally update the channel analyzer graph.
+ *
+ * On initialDraw=true : clears the screen area, draws the title, and draws all
+ *                       14 channel labels (they are static and never change).
+ * On initialDraw=false: only redraws bars whose RSSI changed or whose
+ *                       "recommended" highlight status changed. This eliminates
+ *                       the full-screen flicker of a naive clear-and-redraw.
+ */
+static void _drawAnalyzer(int16_t *chanRSSI, int recCh, bool initialDraw) {
+    static int16_t prevRSSI[CH_COUNT];
+    static int     prevRecCh = -1;
+
+    tft.setTextFont(1);
+    tft.setTextDatum(TL_DATUM);
+
+    if (initialDraw) {
+        for (int i = 0; i < CH_COUNT; i++) prevRSSI[i] = RSSI_FLOOR - 1;
+        prevRecCh = -1;
+        // Title via Bruce helper (clears content area automatically)
+        drawMainBorderWithTitle("WiFi Analyzer", true);
+        drawStatusBar();
+        // Channel labels are static — paint once, never clear
+        tft.setTextSize(1);
+        tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+        tft.setTextDatum(TC_DATUM);
+        for (int ch = 0; ch < CH_COUNT; ch++) {
+            tft.drawString(String(ch + 1), 5 + ch * CH_W + 2 + BAR_W / 2, LABEL_Y);
+        }
+        tft.setTextDatum(TL_DATUM);
+    }
+
+    bool recChChanged = (recCh != prevRecCh);
+
+    // Incremental bar update — skip unchanged channels
+    for (int ch = 0; ch < CH_COUNT; ch++) {
+        bool rssiChanged    = (chanRSSI[ch] != prevRSSI[ch]);
+        bool thisRecChanged = recChChanged &&
+                              ((ch + 1 == recCh) || (ch + 1 == prevRecCh));
+
+        if (!rssiChanged && !thisRecChanged && !initialDraw) continue;
+
+        int bx  = 5 + ch * CH_W + 2;
+        int sig = chanRSSI[ch];
+        if (sig < RSSI_FLOOR) sig = RSSI_FLOOR;
+        if (sig > RSSI_CEIL)  sig = RSSI_CEIL;
+
+        int barH = (int)((long)(sig - RSSI_FLOOR) * GRAPH_H / (RSSI_CEIL - RSSI_FLOOR));
+
+        // Clear slot then redraw bar
+        tft.fillRect(bx, GRAPH_TOP, BAR_W, GRAPH_H, bruceConfig.bgColor);
+        if (barH > 0)
+            tft.fillRect(bx, GRAPH_BOT - barH, BAR_W, barH, _rssiColor(sig));
+
+        // Cyan outline marks the recommended (least congested) channel
+        if (ch + 1 == recCh)
+            tft.drawRect(bx - 1, GRAPH_TOP, BAR_W + 2, GRAPH_H, TFT_CYAN);
+
+        prevRSSI[ch] = chanRSSI[ch];
+    }
+    prevRecCh = recCh;
+
+    // Recommendation line — only repaint when best channel changes
+    if (recChChanged || initialDraw) {
+        tft.fillRect(0, REC_Y - 10, tftWidth, tftHeight - (REC_Y - 10), bruceConfig.bgColor);
+        tft.setTextSize(FP);
+        tft.setTextDatum(MC_DATUM);
+        if (recCh > 0) {
+            tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
+            tft.drawString("Best: Ch " + String(recCh), tftWidth / 2, REC_Y);
+        } else {
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawString("No APs found", tftWidth / 2, REC_Y);
+        }
+        tft.setTextDatum(TL_DATUM);
+        tft.setTextFont(1);
+    }
+}
+
+// ── Channel detail screen ─────────────────────────────────────────────────────
+
+/**
+ * Show all APs detected on a given channel, sorted by signal strength.
+ * Exits when the user presses Prev or ESC, returning to the channel graph.
+ */
+static void _showChannelAPs(int ch, std::vector<APInfo> *chanAPs) {
+    std::vector<APInfo> &aps = chanAPs[ch - 1];
+
+    // Sort strongest first
+    std::sort(aps.begin(), aps.end(),
+              [](const APInfo &a, const APInfo &b) { return a.rssi > b.rssi; });
+
+    String title = "Ch " + String(ch) + " — " +
+                   String(aps.size()) + " AP" + (aps.size() != 1 ? "s" : "");
+    drawMainBorderWithTitle(title, true);
+    drawStatusBar();
+
+    const int lineH  = 18;
+    const int startY = STATUS_BAR_HEIGHT + 28;
+    const int maxRows = (tftHeight - startY - 20) / lineH;
+
+    tft.setTextFont(1);
+
+    if (aps.empty()) {
+        tft.setTextSize(FP);
+        tft.setTextDatum(MC_DATUM);
+        tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+        tft.drawString("No APs on this channel", tftWidth / 2, tftHeight / 2);
+        tft.setTextDatum(TL_DATUM);
+    } else {
+        int rows = std::min((int)aps.size(), maxRows);
+        for (int i = 0; i < rows; i++) {
+            int y = startY + i * lineH;
+
+            // RSSI badge (color-coded, right-aligned to col 34)
+            tft.setTextSize(1);
+            tft.setTextColor(_rssiColor(aps[i].rssi), bruceConfig.bgColor);
+            tft.setTextDatum(TL_DATUM);
+            char badge[8];
+            snprintf(badge, sizeof(badge), "%4d", aps[i].rssi);
+            tft.drawString(badge, 4, y + 2);
+
+            // SSID (hidden networks shown as "[hidden]", truncated if too long)
+            String ssid = aps[i].ssid.isEmpty() ? String("[hidden]") : aps[i].ssid;
+            if (ssid.length() > 26) ssid = ssid.substring(0, 25) + "~";
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawString(ssid, 36, y + 2);
+        }
+        if ((int)aps.size() > maxRows) {
+            tft.setTextSize(1);
+            tft.setTextColor(TFT_DARKGREY, bruceConfig.bgColor);
+            tft.drawString("+" + String((int)aps.size() - maxRows) + " more",
+                           4, startY + maxRows * lineH + 2);
+        }
+    }
+
+    // Footer hint
+    tft.setTextSize(1);
+    tft.setTextDatum(BC_DATUM);
+    tft.setTextColor(TFT_DARKGREY, bruceConfig.bgColor);
+    tft.drawString("[ Prev ] back", tftWidth / 2, tftHeight - 2);
+    tft.setTextDatum(TL_DATUM);
+
+    PrevPress = false;
+    EscPress  = false;
+    while (!PrevPress && !EscPress) {
+        InputHandler();
+        delay(50);
+    }
+    PrevPress = false;
+    EscPress  = false;
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+void wifiAnalyzerMenu() {
+    if (WiFi.getMode() == WIFI_MODE_NULL) WiFi.mode(WIFI_STA);
+
+    int16_t chanRSSI[CH_COUNT];
+    std::vector<APInfo> chanAPs[CH_COUNT];
+    for (int i = 0; i < CH_COUNT; i++) chanRSSI[i] = RSSI_FLOOR;
+
+    _drawAnalyzer(chanRSSI, 0, true);
+
+    bool running = true;
+    while (running) {
+        // Synchronous scan — ~100 ms/channel, ~1.4 s total for 14 channels
+        int n = WiFi.scanNetworks(/*async=*/false, /*show_hidden=*/true,
+                                  /*passive=*/false, /*max_ms_per_chan=*/100);
+
+        for (int i = 0; i < CH_COUNT; i++) {
+            chanRSSI[i] = RSSI_FLOOR;
+            chanAPs[i].clear();
+        }
+        for (int i = 0; i < n; i++) {
+            int ch = WiFi.channel(i);
+            int r  = WiFi.RSSI(i);
+            if (ch >= 1 && ch <= CH_COUNT) {
+                if (r > chanRSSI[ch - 1]) chanRSSI[ch - 1] = (int16_t)r;
+                chanAPs[ch - 1].push_back({ WiFi.SSID(i), r });
+            }
+        }
+        WiFi.scanDelete();
+
+        // Best channel = lowest peak RSSI (empty channels score RSSI_FLOOR = best)
+        int recCh      = 0;
+        bool hasAPs    = false;
+        int lowestRSSI = RSSI_CEIL + 1;
+        for (int i = 0; i < CH_COUNT; i++) {
+            if (chanRSSI[i] > RSSI_FLOOR) hasAPs = true;
+            if (chanRSSI[i] < lowestRSSI) { lowestRSSI = chanRSSI[i]; recCh = i + 1; }
+        }
+        if (!hasAPs) recCh = 0;
+
+        drawStatusBar();
+        _drawAnalyzer(chanRSSI, recCh, false);
+
+        // Wait SCAN_WAIT ms; check for ESC (exit) and tap (channel detail)
+        unsigned long deadline = millis() + SCAN_WAIT;
+        while (millis() < deadline && !EscPress) {
+            InputHandler();
+
+            if (touchPoint.pressed) {
+                int tappedCh = _hitTestChannel(touchPoint.x, touchPoint.y);
+                touchPoint.Clear();
+                if (tappedCh > 0) {
+                    _showChannelAPs(tappedCh, chanAPs);
+                    // Restore graph after returning from detail screen
+                    _drawAnalyzer(chanRSSI, recCh, true);
+                    break; // restart wait loop without triggering a new scan immediately
+                }
+            }
+
+            delay(50);
+        }
+        if (EscPress) running = false;
+    }
+
+    EscPress = false;
+    WiFi.scanDelete();
+}

--- a/src/modules/wifi/wifi_analyzer.h
+++ b/src/modules/wifi/wifi_analyzer.h
@@ -1,0 +1,2 @@
+#pragma once
+void wifiAnalyzerMenu();


### PR DESCRIPTION
Introduces a real-time channel analyzer accessible from the WiFi menu that helps users identify network congestion and choose the least congested channel for a new AP or connection.

Scans all 14 2.4 GHz channels synchronously (100 ms/channel, ~1.4 s total) and renders a bar chart showing the peak RSSI detected on each channel. After the scan it waits 3 seconds and then rescans, keeping the view continuously updated.

  y = 30–51  : title "WiFi Analyzer"
  y = 52–200 : RSSI bar graph (148 px tall)
  y = 203    : static channel labels 1–14
  y = 222    : recommendation text "Best: Ch X"

  Green  : RSSI < –90 dBm  (quiet / no significant traffic)
  Yellow : –90 to –76 dBm
  Orange : –75 to –61 dBm
  Red    : ≥ –60 dBm       (congested)

The channel with the lowest peak RSSI is highlighted with a cyan outline and displayed as "Best: Ch X". Empty channels (no APs detected) score RSSI_FLOOR (–100 dBm) and are always preferred over occupied channels.

A naive clear-and-redraw every 3 seconds causes visible full-screen flicker. The _drawAnalyzer() function keeps a static snapshot of the previous RSSI values and the previous recommended channel. On each update only bars whose RSSI changed (or whose highlight status changed) are redrawn. Channel number labels (y = 203) are painted once on initialDraw and never touched again. The recommendation text is only repainted when the best channel changes.

Tapping any bar opens a per-channel detail screen listing every AP detected on that channel, sorted by signal strength (strongest first). Each row shows:
  - RSSI value (colour-coded, same scale as bars)
  - SSID ("[ hidden ]" for networks with empty SSIDs)

If more APs were found than fit on screen the footer shows "+N more". Pressing Prev or ESC closes the detail screen and restores the graph with the last scan data (no forced rescan on return).

  src/modules/wifi/wifi_analyzer.h   — public declaration
  src/modules/wifi/wifi_analyzer.cpp — full implementation
  src/core/menu_items/WifiMenu.cpp   — menu entry before "Config"

- Uses WiFi.scanNetworks(false, true, false, 100) — synchronous, shows hidden SSIDs, active mode, 100 ms per channel.
- WiFi.SSID(i) returns an empty String for hidden networks; these are stored and displayed as "[hidden]".
- WiFi mode is silently set to WIFI_STA if the radio is off, matching the pattern used by other passive scan features in Bruce.
- touch coordinates come from the global touchPoint struct (set by InputHandler()) — no direct hardware polling needed.
- std::sort is used for the AP list; <algorithm> is included.

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

