### PR TITLE
fix(rf): prevent RF Listen freeze and restore audio on T-Embed CC1101

### DIFF
--- a/src/modules/rf/rf_listen.cpp
+++ b/src/modules/rf/rf_listen.cpp
@@ -2,25 +2,36 @@
 
 #include "../others/audio.h"
 
-volatile unsigned long lastMicros = 0;
-volatile unsigned long pulseMicros = 0;
-volatile float ___frequency = 0;
+volatile unsigned long lastEdgeMicros = 0;
 volatile unsigned long pulseDuration = 0;
 volatile bool newPulse = false;
 
+// MUST be fully IRAM-safe: no digitalRead() (lives in flash) and no access to C++ objects
+// like bruceConfigPins from here. On GDO0 the noise can fire this thousands of times/s; if it
+// runs while the flash cache is busy (e.g. display/font reads) the chip crashes/reboots.
 void IRAM_ATTR onPulse() {
-    static bool wasHigh = false;
     unsigned long now = micros();
+    unsigned long period = now - lastEdgeMicros;
+    lastEdgeMicros = now;
 
-    if (digitalRead(bruceConfigPins.CC1101_bus.io0)) {
-        pulseDuration = now - lastMicros;
-        ___frequency = 1000000.0 / pulseDuration;
+    // Measure the period between rising edges. Drop sub-20us glitches and >1s gaps so a noise
+    // burst doesn't keep newPulse pinned and the displayed value stays meaningful.
+    if (period >= 20 && period <= 1000000UL) {
+        pulseDuration = period;
         newPulse = true;
-        wasHigh = true;
-    } else if (wasHigh) {
-        lastMicros = now;
-        wasHigh = false;
     }
+}
+
+// Beep through the EXACT same path as the working DTMF Tones.js script:
+// audio.tone -> (HAS_NS4168_SPKR) serialCli.parse("tone f d") -> toneCallback -> playTone.
+// The key detail learned from that script: the I2S speaker needs a long tone (~500ms) to be
+// audible - short beeps get swallowed by the DMA buffer before it drains.
+static void rf_listen_beep(unsigned int hz, unsigned long ms) {
+#if defined(BUZZ_PIN)
+    tone(BUZZ_PIN, hz, ms); // non-blocking buzzer
+#else
+    serialCli.parse("tone " + String(hz) + " " + String(ms));
+#endif
 }
 
 void rf_listen() {
@@ -60,38 +71,59 @@ void rf_listen() {
     ELECHOUSE_cc1101.setRxBW(58);
     ELECHOUSE_cc1101.setModulation(2);
     ELECHOUSE_cc1101.setDcFilterOff(true);
-    attachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0), onPulse, CHANGE);
+    // Short confirmation beep so you know listening has started.
+    rf_listen_beep(1000, 500);
+
+    // Seed the timestamp so the first measured period isn't a bogus "time since boot" value
+    // (that was the 0.03 Hz reading).
+    lastEdgeMicros = micros();
+    newPulse = false;
+    attachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0), onPulse, RISING);
     displayRedStripe("Listening...", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
 
     unsigned long lastPulseTime = millis();
+    unsigned long lastTone = 0;
     bool pulseActive = false;
+
+    // Only repaint the stripe when the text actually changes. Redrawing every loop iteration
+    // is a full SPI screen draw that (together with the GDO0 interrupt storm) freezes the UI.
+    String lastStripe = "";
+    auto showStripe = [&](const String &text) {
+        if (text == lastStripe) return;
+        lastStripe = text;
+        displayRedStripe(text, getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+    };
 
     while (check(EscPress)) { delay(10); }
 
+    showStripe("Waiting for a pulse");
+
     while (!check(EscPress)) {
-        displayRedStripe(
-            "Waiting for a pulse", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor
-        );
         if (newPulse) {
             newPulse = false;
             lastPulseTime = millis();
             pulseActive = true;
-            String pulseText = String("Freq: ") + String(___frequency, 2) + String(" Hz");
-            displayRedStripe(pulseText, getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
-#if defined(BUZZ_PIN)
-            tone(BUZZ_PIN, ___frequency, pulseDuration);
-#elif defined(HAS_NS4168_SPKR)
-            playTone(___frequency, pulseDuration, 0);
-#endif
+            // Compute frequency here (out of the ISR) to keep the interrupt fast.
+            unsigned long dur = pulseDuration;
+            float freqHz = dur ? (1000000.0f / dur) : 0.0f;
+            showStripe(String("Freq: ") + String(freqHz, 2) + String(" Hz"));
+            // Audible feedback at the detected pulse frequency, via the same proven path as
+            // dtmf.js. The I2S speaker needs ~500ms to be audible, and playTone BLOCKS for that
+            // time, so throttle to 700ms so a continuous signal doesn't make the listener feel
+            // stuck.
+            if (millis() - lastTone > 700) {
+                lastTone = millis();
+                rf_listen_beep((unsigned int)constrain(freqHz, 100.0f, 8000.0f), 500);
+            }
         }
 
         if (pulseActive && millis() - lastPulseTime > 3000) {
             pulseActive = false;
-            displayRedStripe("No signal", getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
+            showStripe("Waiting for a pulse");
         }
 
-        if (check(EscPress)) break;
         if (check(SelPress)) break;
+        delay(5); // feed the watchdog and let button/UI handling breathe
     }
 
     detachInterrupt(digitalPinToInterrupt(bruceConfigPins.CC1101_bus.io0));


### PR DESCRIPTION
#### Proposed Changes ####

Fixes the RF → Listen screen freezing on the Lilygo T-Embed CC1101 (Plus) right after a frequency is selected, and restores audible feedback through the speaker.

Root causes addressed:

- **IRAM-unsafe ISR:** `onPulse()` runs as an `IRAM_ATTR` interrupt but called `digitalRead()` (a flash-resident function) and dereferenced C++ objects (`bruceConfigPins`). When GDO0 noise fires the ISR while the flash cache is busy (e.g. display/font reads) the chip crashes/reboots. Rewritten to be fully IRAM-safe, measuring the period between rising edges using only volatile globals.
- **Blocking audio with huge duration:** the pulse period (in microseconds) was passed as the duration to the blocking `playTone()`, freezing the listener for up to seconds per pulse on I2S-speaker boards (T-Embed).
- **Full screen redraw every loop:** the "Waiting for a pulse" stripe was redrawn over SPI on every loop iteration. It now repaints only when the text changes, with a small `delay()` to feed the watchdog.

Audio feedback is unified in a single `rf_listen_beep()` helper: a non-blocking buzzer where available, otherwise the same path as the `tone` command. The I2S speaker needs ~500 ms tones to be audible (shorter beeps are swallowed by the DMA buffer).

#### Types of Changes ####

Bugfix.

#### Verification ####

On a Lilygo T-Embed CC1101 (Plus): open RF → Listen, pick a frequency and press select. Previously the screen froze (and showed a bogus `0.03 Hz` or `0.00 Hz`); now it stays responsive, shows the detected pulse frequency, and ESC exits cleanly. With a 433.92 MHz OOK emitter the device beeps and displays the pulse frequency.

#### Testing ####

Manually tested on hardware (T-Embed CC1101 Plus with a 433.92 MHz emitter). No automated tests exist for this module.

#### Linked Issues ####

None.

#### User-Facing Change ####
```release-note
Fix RF Listen freezing on T-Embed CC1101 and restore speaker beep feedback.
```

#### Further Comments ####

The fixes are board-agnostic (no T-Embed-specific `#ifdef`s): the freeze fixes benefit any CC1101 board, and the audio path adapts to buzzer vs I2S speaker. The 500 ms beep duration is required for the I2S speaker to be audible and is harmless (non-blocking) on buzzer boards.

