### PR TITLE
feat(clock): persist software clock to NVS on boards without an RTC

### DIFF
--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 #include "core/wifi/wifi_common.h" //to return MAC addr
 #include "scrollableTextArea.h"
+#include <Preferences.h>
 #include <globals.h>
 
 /*********************************************************************
@@ -89,6 +90,52 @@ void updateClockTimezone() {
     struct timeval tv = {.tv_sec = localTime};
     settimeofday(&tv, nullptr);
 }
+
+#if !defined(HAS_RTC)
+// --- Persistent software clock (boards without an RTC chip) ---
+// Boards without an RTC lose a set time on a full power-off. Periodically save
+// the current epoch to NVS and restore it on boot, so the clock comes back
+// close to correct (it re-syncs exactly via NTP/GPS when available). NVS (not
+// the user filesystem) so it survives FS reformats and custom partition layouts.
+#define CLOCK_PERSIST_NS "clock"
+#define CLOCK_PERSIST_KEY "epoch"
+#define CLOCK_PERSIST_INTERVAL_MS 300000 // 5 min: bounds NVS wear, <=5 min drift after power loss
+
+static void time_persist_task(void *param) {
+    Preferences prefs;
+    uint32_t last_write_ms = 0;
+    bool saved = false;
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(60000)); // wake every minute
+        if (!clock_set) continue;
+        // Save promptly the first time the clock is set, then at most every 5 min.
+        if (saved && (millis() - last_write_ms) < CLOCK_PERSIST_INTERVAL_MS) continue;
+        if (prefs.begin(CLOCK_PERSIST_NS, false)) {
+            prefs.putULong(CLOCK_PERSIST_KEY, (uint32_t)rtc.getEpoch());
+            prefs.end();
+            last_write_ms = millis();
+            saved = true;
+        }
+    }
+}
+
+// Restore the last-saved time from NVS (if plausible) and start the periodic
+// save task. Call once from init_clock() on boards without an RTC.
+void restorePersistedClock() {
+    Preferences prefs;
+    if (prefs.begin(CLOCK_PERSIST_NS, true)) { // read-only
+        uint32_t epoch = prefs.getULong(CLOCK_PERSIST_KEY, 0);
+        prefs.end();
+        if (epoch > 1735689600UL) { // sanity: only restore a plausible time (after 2025-01-01)
+            rtc.setTime((unsigned long)epoch);
+            clock_set = true;
+            struct timeval tv = {.tv_sec = (time_t)epoch};
+            settimeofday(&tv, nullptr);
+        }
+    }
+    xTaskCreate(time_persist_task, "clockSave", 4096, NULL, 1, NULL);
+}
+#endif
 
 void updateTimeStr(struct tm timeInfo) {
     if (bruceConfig.clock24hr) {

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -6,6 +6,9 @@ void backToMenu();
 void addOptionToMainMenu();
 int getBattery() __attribute__((weak));
 void updateClockTimezone();
+#if !defined(HAS_RTC)
+void restorePersistedClock();
+#endif
 void updateTimeStr(struct tm timeInfo);
 void showDeviceInfo();
 String formatTimeDecimal(uint32_t totalMillis);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,6 +368,7 @@ void init_clock() {
     clock_set = true;
     struct timeval tv = {.tv_sec = epoch};
     settimeofday(&tv, nullptr);
+    restorePersistedClock(); // override the default with the last-saved time (NVS) + start periodic save
 #endif
 }
 


### PR DESCRIPTION
## What
Persist the software clock to NVS on boards without an RTC chip, and restore it on boot.

## Why
Boards like the T-Deck have no RTC, so a time set via manual/NTP/GPS is lost on a full
power-off and the clock resets to the build default on the next boot. This periodically
saves the current epoch to NVS and restores it at startup, so the clock comes back close
to correct even without WiFi/GPS at boot time.

Addresses part of #1866.

## How
- Adds `restore_persisted_time()` + `time_persist_task()` in `main.cpp`, guarded by
  `#if !defined(HAS_RTC)` so RTC builds are completely unaffected.
- Stored in **NVS** (via `Preferences`), not the user filesystem, so it survives FS
  reformats and custom/non-standard partition layouts.
- First save fires within ~60s of the clock being set, then at most every 5 min
  (bounds NVS wear; worst-case staleness ~5 min).
- On boot it restores the saved epoch (with a post-2025-01-01 sanity check) before the
  rest of `setup()`.

## Behavior / limitations
Without an RTC, elapsed time during a power-off cannot be tracked, so the clock restores
the **last-known** time and will be behind by however long the device was off; it re-syncs
to exact time via NTP/GPS when available. This is a best-effort "don't reset to the default
date" fallback, not a hardware-RTC replacement.

## Testing
Built and tested on a **LilyGO T-Deck Plus** (`lilygo-t-deck-pro`): set the time, fully
power-cycled, and the clock restored the last-known time instead of resetting to the build
default. Confirmed it survives a custom/dual-boot partition layout (NVS-backed). A 30-minute
power-off returned ~30 minutes behind, as expected for a no-RTC software clock. RTC builds
are unaffected (compiled out via `!defined(HAS_RTC)`).
