### PR TITLE
fix(mic): prevent START REC button being cut off on 135px screens

### DIFF
--- a/src/modules/others/mic.cpp
+++ b/src/modules/others/mic.cpp
@@ -508,13 +508,15 @@ bool mic_record_wav_to_path(
 void mic_record_app() {
 
     // ===== LAYOUT CONSTANTS =====
+    const bool isTinyScreen = (tftHeight <= 150); // e.g. Cardputer: 135px tall
     const int MARGIN = (tftWidth > 200) ? 10 : 5;
-    const int HEADER_HEIGHT = (tftHeight > 200) ? 35 : 25;
-    const int ITEM_HEIGHT = (tftHeight > 200) ? 30 : 22;
-    const int BUTTON_HEIGHT = (tftHeight > 200) ? 40 : 30;
+    const int HEADER_HEIGHT = (tftHeight > 200) ? 35 : (isTinyScreen ? 22 : 25);
+    const int ITEM_HEIGHT = (tftHeight > 200) ? 30 : (isTinyScreen ? 18 : 22);
+    const int ITEM_GAP = isTinyScreen ? 4 : 8;
+    const int BUTTON_HEIGHT = (tftHeight > 200) ? 40 : (isTinyScreen ? 22 : 30);
     const int TEXT_SIZE_LARGE = (tftWidth > 200) ? 2 : 1;
     const int TEXT_SIZE_SMALL = 1;
-    const int START_Y = HEADER_HEIGHT + ((tftHeight > 200) ? 15 : 8);
+    const int START_Y = HEADER_HEIGHT + (tftHeight > 200 ? 15 : (isTinyScreen ? 5 : 8));
 
     // UI Parameters
     int selected_item = 0;
@@ -542,9 +544,9 @@ void mic_record_app() {
 
         // Calculate Y based on the item
         if (itemIndex < ITEM_START) {
-            yPos = START_Y + itemIndex * (ITEM_HEIGHT + 8);
+            yPos = START_Y + itemIndex * (ITEM_HEIGHT + ITEM_GAP);
         } else {
-            yPos = START_Y + 2 * (ITEM_HEIGHT + 8) + ITEM_HEIGHT + 15;
+            yPos = START_Y + 2 * (ITEM_HEIGHT + ITEM_GAP) + ITEM_HEIGHT + (isTinyScreen ? 5 : 15);
         }
 
         // 1. CLEAN: Delete only the area of ​​this specific item


### PR DESCRIPTION
## Summary

- On devices with a 135px tall display in landscape (Cardputer, StickC Plus/Plus2, StickC-S3, Dinmeter), the mic recorder UI layout overflowed the screen by ~25px, causing the START REC button to be completely cut off at the bottom
- Adds an `isTinyScreen` flag (`tftHeight <= 150`) with tighter spacing constants so all four items fit within the available display height
- No change in behaviour on medium (150–200px) or large (>200px) screens

## Root cause

The layout total height required was ~160px but the Cardputer's logical screen height is 135px (physical `TFT_WIDTH=135` maps to `tftHeight` in landscape rotation). The existing `tftHeight > 200` breakpoint only handled large vs small — there was no path for very small screens.

## Test plan

- [x] Navigate to Others → Mic Recorder on Cardputer/ADV — START REC button is fully visible
- [x] Verify Time, Gain, Stealth items all render correctly and are selectable
- [x] Confirm recording starts and stops correctly
- [ ] Verify no visual regression on larger screen devices (T-Deck, M5Core, CYD, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)