### PR TITLE
Quick fix: BLE_spam.cpp bug

### DIFF
--- a/lib/Bad_Usb_Lib/USBHID.cpp
+++ b/lib/Bad_Usb_Lib/USBHID.cpp
@@ -21,6 +21,12 @@
 
 #define USB_HID_DEVICES_MAX 10
 
+#ifdef CFG_TUD_ENDPOINT_SIZE
+#define BRUCE_TUD_EP_SIZE CFG_TUD_ENDPOINT_SIZE
+#else
+#define BRUCE_TUD_EP_SIZE CFG_TUD_ENDOINT_SIZE
+#endif
+
 ESP_EVENT_DEFINE_BASE(ARDUINO_USB_HID_EVENTS);
 esp_err_t arduino_usb_event_post(
     esp_event_base_t event_base, int32_t event_id, void *event_data, size_t event_data_size,
@@ -214,7 +220,7 @@ extern "C" uint16_t tusb_hid_load_descriptor(uint8_t *dst, uint8_t *itf) {
             tinyusb_hid_device_descriptor_len,
             ep_out,
             (uint8_t)(0x80 | ep_in),
-            CFG_TUD_ENDOINT_SIZE,
+            BRUCE_TUD_EP_SIZE,
             1
         )
     };

--- a/lib/Bad_Usb_Lib/USBHID.cpp
+++ b/lib/Bad_Usb_Lib/USBHID.cpp
@@ -21,12 +21,6 @@
 
 #define USB_HID_DEVICES_MAX 10
 
-#ifdef CFG_TUD_ENDPOINT_SIZE
-#define BRUCE_TUD_EP_SIZE CFG_TUD_ENDPOINT_SIZE
-#else
-#define BRUCE_TUD_EP_SIZE CFG_TUD_ENDOINT_SIZE
-#endif
-
 ESP_EVENT_DEFINE_BASE(ARDUINO_USB_HID_EVENTS);
 esp_err_t arduino_usb_event_post(
     esp_event_base_t event_base, int32_t event_id, void *event_data, size_t event_data_size,
@@ -220,7 +214,7 @@ extern "C" uint16_t tusb_hid_load_descriptor(uint8_t *dst, uint8_t *itf) {
             tinyusb_hid_device_descriptor_len,
             ep_out,
             (uint8_t)(0x80 | ep_in),
-            BRUCE_TUD_EP_SIZE,
+            CFG_TUD_ENDPOINT_SIZE,
             1
         )
     };

--- a/lib/Bad_Usb_Lib/USBHID.cpp
+++ b/lib/Bad_Usb_Lib/USBHID.cpp
@@ -214,7 +214,7 @@ extern "C" uint16_t tusb_hid_load_descriptor(uint8_t *dst, uint8_t *itf) {
             tinyusb_hid_device_descriptor_len,
             ep_out,
             (uint8_t)(0x80 | ep_in),
-            CFG_TUD_ENDPOINT_SIZE,
+            CFG_TUD_ENDOINT_SIZE,
             1
         )
     };

--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -1619,7 +1619,7 @@ bleSpamConfigScreen(const BleSpamSelection &selection, BleSpamConfig &config, bo
         if (redrawRows) {
             int rowH = max(12, FP * LH + 4);
             int rowStart = BORDER_PAD_Y + FM * LH + 10;
-            int startRowY = rowStart + rowH * 4 + (tftHeight > 135) ? rowH : 0;
+            int startRowY = rowStart + rowH * 4 + ((tftHeight > 135) ? rowH : 0);
 
             bleSpamRenderConfigRows(config, cursor, editState, rowStart, rowH);
 
@@ -1677,7 +1677,7 @@ bleSpamConfigScreen(const BleSpamSelection &selection, BleSpamConfig &config, bo
                     config.gap_ms = bleSpamAdjustMs(config.gap_ms, 1);
                     configChanged = true;
                 } else if (editState.edit_row == 2) {
-                    config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 1) % 4);
+                    config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 3) % 4);
                     configChanged = true;
                 } else if (editState.edit_row == 3) {
                     config.mac_rand_mode = static_cast<BleSpamMacRandMode>((config.mac_rand_mode + 1) % 8);
@@ -1692,7 +1692,7 @@ bleSpamConfigScreen(const BleSpamSelection &selection, BleSpamConfig &config, bo
                     config.gap_ms = bleSpamAdjustMs(config.gap_ms, -1);
                     configChanged = true;
                 } else if (editState.edit_row == 2) {
-                    config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 3) % 4);
+                    config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 1) % 4);
                     configChanged = true;
                 } else if (editState.edit_row == 3) {
                     config.mac_rand_mode = static_cast<BleSpamMacRandMode>((config.mac_rand_mode + 7) % 8);
@@ -1912,7 +1912,7 @@ static void bleSpamRunScreen(const BleSpamSelection &selection, BleSpamConfig &c
                     } else if (editState.edit_row == 1) {
                         config.gap_ms = bleSpamAdjustMs(config.gap_ms, 1);
                     } else if (editState.edit_row == 2) {
-                        config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 1) % 4);
+                        config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 3) % 4);
                     } else if (editState.edit_row == 3) {
                         config.mac_rand_mode =
                             static_cast<BleSpamMacRandMode>((config.mac_rand_mode + 1) % 8);
@@ -1925,7 +1925,7 @@ static void bleSpamRunScreen(const BleSpamSelection &selection, BleSpamConfig &c
                     } else if (editState.edit_row == 1) {
                         config.gap_ms = bleSpamAdjustMs(config.gap_ms, -1);
                     } else if (editState.edit_row == 2) {
-                        config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 3) % 4);
+                        config.tx_power = static_cast<BleSpamTxPower>((config.tx_power + 1) % 4);
                     } else if (editState.edit_row == 3) {
                         config.mac_rand_mode =
                             static_cast<BleSpamMacRandMode>((config.mac_rand_mode + 7) % 8);


### PR DESCRIPTION
Fixes:
BLE spam start button position fix (caused by Ram revamp (https://github.com/BruceDevices/firmware/pull/2622). It was way too high, now it is fixed for all screen sizes)
BLE spam TX slider being incorrectly inverted on rotary encoder