### PR TITLE
Fix rotary encoder skipping on rotary-equipped devices (such as t-embed)

### DIFF
--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -5,10 +5,10 @@
 #include <interface.h>
 
 // Rotary encoder
-#include <RotaryEncoder.h>
-extern RotaryEncoder *encoder;
-RotaryEncoder *encoder = nullptr;
-IRAM_ATTR void checkPosition() { encoder->tick(); }
+#include <rotary_decoder.h>
+extern RotaryDecoder *encoder;
+RotaryDecoder *encoder = nullptr;
+void pollEncoder(void) { encoder->poll(); }
 
 // Battery libs
 #if defined(T_EMBED_1101)
@@ -104,9 +104,10 @@ void _setup_gpio() {
     pinMode(BK_BTN, INPUT);
 #endif
     pinMode(ENCODER_KEY, INPUT);
-    encoder = new RotaryEncoder(ENCODER_INA, ENCODER_INB, RotaryEncoder::LatchMode::TWO03);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INA), checkPosition, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INB), checkPosition, CHANGE);
+    pinMode(ENCODER_INA, INPUT_PULLUP);
+    pinMode(ENCODER_INB, INPUT_PULLUP);
+    encoder = new RotaryDecoder();
+    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
 }
 
 /***************************************************************************************

--- a/boards/lilygo-t-embed-cc1101/lilygo-t-embed-cc1101.ini
+++ b/boards/lilygo-t-embed-cc1101/lilygo-t-embed-cc1101.ini
@@ -20,4 +20,3 @@ build_flags =
 lib_deps =
 	${env.lib_deps}
 	lewisxhe/XPowersLib @^0.3.3
-	mathertel/RotaryEncoder @1.5.3

--- a/boards/lilygo-t-embed-cc1101/lilygo-t-embed.ini
+++ b/boards/lilygo-t-embed-cc1101/lilygo-t-embed.ini
@@ -21,4 +21,3 @@ build_flags =
 lib_deps =
 	${env.lib_deps}
 	lewisxhe/XPowersLib @0.2.6
-	mathertel/RotaryEncoder @1.5.3

--- a/boards/lilygo-t-lora-pager/interface.cpp
+++ b/boards/lilygo-t-lora-pager/interface.cpp
@@ -7,10 +7,10 @@
 #include <interface.h>
 
 // Rotary encoder
-#include <RotaryEncoder.h>
-extern RotaryEncoder *encoder;
-RotaryEncoder *encoder = nullptr;
-IRAM_ATTR void checkPosition() { encoder->tick(); }
+#include <rotary_decoder.h>
+extern RotaryDecoder *encoder;
+RotaryDecoder *encoder = nullptr;
+void pollEncoder(void) { encoder->poll(); }
 
 // Charger chip
 #define XPOWERS_CHIP_BQ25896
@@ -212,9 +212,10 @@ void _setup_gpio() {
 
     // Encoder
     pinMode(ENCODER_KEY, INPUT);
-    encoder = new RotaryEncoder(ENCODER_INA, ENCODER_INB, RotaryEncoder::LatchMode::FOUR3);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INA), checkPosition, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INB), checkPosition, CHANGE);
+    pinMode(ENCODER_INA, INPUT_PULLUP);
+    pinMode(ENCODER_INB, INPUT_PULLUP);
+    encoder = new RotaryDecoder();
+    encoder->begin(ENCODER_INA, ENCODER_INB, 4);
 
     // Haptic driver
     if (!drv.begin(Wire, SDA, SCL)) {

--- a/boards/lilygo-t-lora-pager/lilygo-t-lora-pager.ini
+++ b/boards/lilygo-t-lora-pager/lilygo-t-lora-pager.ini
@@ -16,7 +16,6 @@ lib_deps =
 	${env.lib_deps}
 	lewisxhe/XPowersLib @0.3.0
 	lewisxhe/SensorLib@0.3.4
-	mathertel/RotaryEncoder @1.5.3
 	adafruit/Adafruit TCA8418 @ ^1.0.2
 	# renovate: datasource=github-tags depName=pschatzmann_arduino-audio-driver packageName=pschatzmann/arduino-audio-driver
     https://github.com/pschatzmann/arduino-audio-driver/archive/v0.1.3.zip

--- a/boards/m5stack-dinmeter/interface.cpp
+++ b/boards/m5stack-dinmeter/interface.cpp
@@ -4,9 +4,9 @@
 #include <interface.h>
 
 // Rotary encoder
-#include <RotaryEncoder.h>
-RotaryEncoder *encoder = nullptr;
-IRAM_ATTR void checkPosition() { encoder->tick(); }
+#include <rotary_decoder.h>
+RotaryDecoder *encoder = nullptr;
+void pollEncoder(void) { encoder->poll(); }
 
 /***************************************************************************************
 ** Function name: _setup_gpio()
@@ -18,9 +18,10 @@ void _setup_gpio() {
     setSysI2CBus(M5.In_I2C.getPort() == I2C_NUM_1 ? &Wire1 : &Wire);
     bruceConfig.colorInverted = 0;
     pinMode(ENCODER_KEY, INPUT);
-    encoder = new RotaryEncoder(ENCODER_INA, ENCODER_INB, RotaryEncoder::LatchMode::TWO03);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INA), checkPosition, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INB), checkPosition, CHANGE);
+    pinMode(ENCODER_INA, INPUT_PULLUP);
+    pinMode(ENCODER_INB, INPUT_PULLUP);
+    encoder = new RotaryDecoder();
+    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
 }
 /*********************************************************************
 ** Function: setBrightness

--- a/boards/m5stack-dinmeter/platformio.ini
+++ b/boards/m5stack-dinmeter/platformio.ini
@@ -116,7 +116,6 @@ build_flags =
 
 lib_deps =
 	${env.lib_deps}
-	mathertel/RotaryEncoder @1.5.3
 	m5stack/M5Unified
 
 lib_ignore =

--- a/boards/marauder-touch/interface.cpp
+++ b/boards/marauder-touch/interface.cpp
@@ -5,9 +5,9 @@
 CYD28_TouchR touch(320, 240);
 
 #ifdef WAVESENTRY
-#include <RotaryEncoder.h>
-RotaryEncoder *encoder = nullptr;
-IRAM_ATTR void checkPosition() { encoder->tick(); }
+#include <rotary_decoder.h>
+RotaryDecoder *encoder = nullptr;
+void pollEncoder(void) { encoder->poll(); }
 #endif
 
 /***************************************************************************************
@@ -21,9 +21,10 @@ void _setup_gpio() {
     pinMode(TFT_BL, OUTPUT);
 #ifdef WAVESENTRY
     pinMode(ENCODER_KEY, INPUT);
-    encoder = new RotaryEncoder(ENCODER_INA, ENCODER_INB, RotaryEncoder::LatchMode::TWO03);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INA), checkPosition, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(ENCODER_INB), checkPosition, CHANGE);
+    pinMode(ENCODER_INA, INPUT_PULLUP);
+    pinMode(ENCODER_INB, INPUT_PULLUP);
+    encoder = new RotaryDecoder();
+    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
 #endif
 }
 

--- a/boards/marauder-touch/marauder-touch.ini
+++ b/boards/marauder-touch/marauder-touch.ini
@@ -84,7 +84,6 @@ build_flags =
 	-D HAS_ENCODER=1
 lib_deps =
 	${env.lib_deps}
-	mathertel/RotaryEncoder @1.5.3
 
 [env:LAUNCHER_WaveSentry-R1]
 extends = env:WaveSentry-R1
@@ -95,5 +94,4 @@ build_flags =
 
 lib_deps =
 	${env_light.lib_deps}
-	mathertel/RotaryEncoder @1.5.3
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -233,6 +233,22 @@ extern inline bool check(volatile bool &btn, bool resetButtonStatus = true) {
 
 #ifndef USE_TFT_eSPI_TOUCH
     if (!btn) return false;
+#ifdef HAS_ENCODER
+    // NextPress/PrevPress here are rotary-encoder-derived, not raw mechanical
+    // button reads -- the encoder's own quadrature decode already rejects
+    // bounce, so the extra software debounce delay below is redundant for
+    // these two flags and only adds latency to every scroll step. Skip it
+    // for them; every other flag (SelPress, EscPress, etc.) keeps the
+    // original suspend+delay+resume debounce untouched.
+    if (&btn == &NextPress || &btn == &PrevPress) {
+        if (resetButtonStatus) {
+            btn = false;
+            AnyKeyPress = false;
+            SerialCmdPress = false;
+        }
+        return true;
+    }
+#endif
     vTaskSuspend(xHandle);
     if (resetButtonStatus) {
         btn = false;

--- a/include/interface.h
+++ b/include/interface.h
@@ -38,6 +38,16 @@ void _setBrightness(uint8_t brightval);
 **********************************************************************/
 void InputHandler(void);
 
+/*********************************************************************
+** Function: pollEncoder
+** location: interface.cpp (per board)
+** Samples the rotary encoder A/B lines unconditionally, every task tick,
+** decoupled from AnyKeyPress consumption -- mirrors how the Flipper
+** port's encoder_poll() is never gated behind whether the previous
+** input event was consumed. No-op on boards without HAS_ENCODER.
+**********************************************************************/
+void __attribute__((weak)) pollEncoder(void);
+
 
 /*********************************************************************
 ** Function: powerOff

--- a/include/rotary_decoder.h
+++ b/include/rotary_decoder.h
@@ -1,0 +1,116 @@
+#pragma once
+#include <Arduino.h>
+
+/*
+ * Quadrature rotary encoder decoder.
+ *
+ * Faithful port of the Flipper-Zero-ESP32-Port target_input.c encoder
+ * driver (encoder_poll()), including its sampling model, not just its
+ * decode math:
+ *
+ *   - This is PURE POLLING, not interrupt-driven, exactly like Flipper's
+ *     driver. poll() must be called from a fixed-cadence loop -- Flipper
+ *     runs encoder_poll() on its own dedicated thread every 4ms,
+ *     decoupled from GUI/app work; here poll() is called the same way,
+ *     from a small dedicated FreeRTOS task (see taskEncoderPoll() in
+ *     main.cpp) at a higher priority than the render loop, every 4ms,
+ *     so a busy redraw can never delay sampling A/B. No attachInterrupt/
+ *     ISR is used anywhere here.
+ *   - Each poll() call takes exactly one gpio level sample of A and B
+ *     and compares it against the level remembered from the previous
+ *     poll() call. There is no edge queue and no loop inside poll() --
+ *     it is a single compare-and-return, matching Flipper's function
+ *     body exactly.
+ *   - A direct, deliberate consequence of that (same as Flipper): if the
+ *     encoder is spun fast enough to pass through more than one
+ *     transition between two poll() calls, the intermediate transitions
+ *     are simply never observed -- not queued, not caught up on later,
+ *     just gone. This is not a speed check; it falls straight out of
+ *     sample-based (not event-based) reading at a fixed cadence, same
+ *     as the original.
+ *   - Mechanical encoders bounce; naively reacting to "A changed, check
+ *     B" produces false reverse steps. This tracks all 4 valid AB
+ *     transitions via a lookup table and only counts a step on a
+ *     *valid* transition, skipping (ignoring) anything else as bounce.
+ *   - Steps are accumulated and a position change is only committed
+ *     once a full detent's worth of valid transitions has been seen,
+ *     blocking partial/half-detent noise from ever reaching callers.
+ *   - No time-based idle/staleness reset exists here, same as Flipper --
+ *     it does not exist in target_input.c's encoder logic either.
+ *
+ * Drop-in replacement for the RotaryEncoder library's getPosition():
+ * call poll() once per fixed-rate InputHandler() pass, and read
+ * getPosition() exactly as before.
+ */
+
+// Indexed by (old_AB << 2 | new_AB): 0 = invalid/bounce,
+// +1 = CW quarter-step, -1 = CCW quarter-step.
+//
+// Sign is mirrored relative to Flipper's own table: Flipper's convention
+// was tuned to their board's A/B wiring, which doesn't match how
+// ENCODER_INA/ENCODER_INB are wired here, nor the sign the old
+// RotaryEncoder library produced (which the existing InputHandler()
+// direction logic -- posDifference > 0 => PrevPress, etc. -- was tuned
+// against). Flipping it here, once, keeps direction correct without
+// touching any per-board InputHandler() code.
+static const int8_t ROTARY_DECODER_ENC_TABLE[16] = {
+    /*          new: 00  01  10  11  */
+    /* old 00 */  0, +1, -1,  0,
+    /* old 01 */ -1,  0,  0, +1,
+    /* old 10 */ +1,  0,  0, -1,
+    /* old 11 */  0, -1, +1,  0,
+};
+
+class RotaryDecoder {
+public:
+    void begin(uint8_t pinA, uint8_t pinB, uint8_t stepsPerDetent = 2) {
+        _pinA = pinA;
+        _pinB = pinB;
+        _stepsPerDetent = stepsPerDetent;
+        bool a = digitalRead(_pinA);
+        bool b = digitalRead(_pinB);
+        _abState = (a << 1) | b;
+        _accum = 0;
+        _position = 0;
+    }
+
+    // Call once per fixed-cadence poll pass (e.g. once per InputHandler()
+    // call). Takes a single level sample of A/B -- exactly like Flipper's
+    // encoder_poll(), this is NOT called from an interrupt.
+    void poll() {
+        bool a = digitalRead(_pinA);
+        bool b = digitalRead(_pinB);
+        uint8_t newAb = (a << 1) | b;
+
+        if (newAb == _abState) return; // no change since last poll
+
+        int8_t delta = ROTARY_DECODER_ENC_TABLE[(_abState << 2) | newAb];
+        _abState = newAb;
+
+        if (delta == 0) return; // invalid transition (bounce) -- skip it
+
+        _accum += delta;
+
+        if (_accum >= _stepsPerDetent) {
+            _accum = 0;
+            _position++;
+        } else if (_accum <= -_stepsPerDetent) {
+            _accum = 0;
+            _position--;
+        }
+    }
+
+    int32_t getPosition() { return _position; }
+
+private:
+    uint8_t _pinA = 0;
+    uint8_t _pinB = 0;
+    uint8_t _stepsPerDetent = 2;
+    uint8_t _abState = 0;
+    int8_t _accum = 0;
+    // Written by the dedicated encoder-poll task, read by InputHandler()
+    // on a different task -- must be volatile so the reader can't cache
+    // a stale value across the task boundary. Single 32-bit aligned word,
+    // so plain reads/writes stay atomic on ESP32 without extra locking.
+    volatile int32_t _position = 0;
+};

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -629,7 +629,14 @@ int loopOptions(
             }
             redraw = true;
         }
+#ifdef HAS_ENCODER
+        // Match the rotary encoder's own poll cadence here instead of the
+        // generic 10ms menu-loop pacing, so a backed-up run of detents can
+        // drain without an artificial per-iteration floor on top of it.
+        vTaskDelay(4 / portTICK_PERIOD_MS);
+#else
         vTaskDelay(10 / portTICK_PERIOD_MS);
+#endif
 
         /* Select and run function
         forceMenuOption is set by a SerialCommand to force a selection within the menu

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,25 @@ TouchPoint touchPoint;
 
 keyStroke KeyStroke;
 
+#ifdef HAS_ENCODER
+// Default no-op: boards that define HAS_ENCODER but don't implement
+// pollEncoder() (shouldn't happen, but keeps the linker happy either way).
+void __attribute__((weak)) pollEncoder(void) {}
+
+// Dedicated, high-priority, tight-cadence task that does nothing but sample
+// the rotary encoder A/B lines -- mirrors the Flipper port's input_srv,
+// which runs encoder_poll() on its own thread every 4ms, decoupled from
+// GUI/app work so the raw quadrature read is never delayed by rendering
+// or by whether the previous input event has been consumed yet. Only
+// exists on HAS_ENCODER boards; other boards pay zero cost for this.
+static void taskEncoderPoll(void *parameter) {
+    while (true) {
+        pollEncoder();
+        vTaskDelay(pdMS_TO_TICKS(4));
+    }
+}
+#endif
+
 TaskHandle_t xHandle;
 void __attribute__((weak)) taskInputHandler(void *parameter) {
     auto timer = millis();
@@ -500,6 +519,19 @@ void setup() {
         2,                             // Task priority (0 to 3), loopTask has priority 2.
         &xHandle                       // Task handle (not used)
     );
+#ifdef HAS_ENCODER
+    // Dedicated encoder sampling task, higher priority than loopTask so a
+    // busy render/redraw pass can never delay reading the A/B lines.
+    // Only created on boards with a rotary encoder.
+    xTaskCreate(
+        taskEncoderPoll, // Task function
+        "EncoderPoll",   // Task Name
+        2048,            // Stack size
+        NULL,            // Task parameters
+        3,               // Task priority (0 to 3), higher than loopTask's 2
+        NULL             // Task handle (not used)
+    );
+#endif
     // #endif
 #if defined(HAS_SCREEN)
     bruceConfig.openThemeFile(bruceConfig.themeFS(), bruceConfig.themePath, false);


### PR DESCRIPTION
#### Proposed Changes ####
Swapped the RotaryEncoder library for a custom decoder that copies how the Flipper Zero ESP32 port (the one that Sor3nt made) reads its rotary encoder: same state table for filtering bounce, same per-detent counting, same polling model instead of interrupts. Encoder polling now runs on its own dedicated task so a busy screen redraw can't delay or drop rotation events.

Also found and fixed two extra sources of input lag, both only active on HAS_ENCODER boards so other boards aren't affected:
- check() had an extra 10ms delay on every consumed press that isn't needed for encoder input
- the menu loop's fixed delay was too slow for how often the encoder updates

Removed the unused RotaryEncoder dependency from the board .ini files.

Applies to: T-Embed CC1101, T-Embed, T-Lora-Pager, M5Stack DinMeter, and the WaveSentry variant of marauder-touch.

#### Types of Changes ####
Bugfix/ux-enhancement

#### Verification ####
Tested on the T-Embed CC1101 Plus. Quick rotary wheel turns no longer drop or reverse inputs, and menu navigation feels way more responsive than before. Other boards use the same code path but haven't been tested on hardware. (Please test if you are able to)

#### Testing ####
Manual testing on t-embed cc1101 plus

#### Linked Issues ####
Many people have been having this issue, mostly with the t-embeds.

#### User-Facing Change ####

```release-note
Fixed and improved rotary encoder scroll skipping on rotary-enabled devices (such as the t-embed)
```

#### Further Comments ####
All changes to shared code are wrapped in #ifdef HAS_ENCODER, so boards without a rotary encoder are unaffected.