### PR TITLE
Rotary-input PR edit (needs this edit)

### DIFF
--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -152,6 +152,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -107,7 +107,7 @@ void _setup_gpio() {
     pinMode(ENCODER_INA, INPUT_PULLUP);
     pinMode(ENCODER_INB, INPUT_PULLUP);
     encoder = new RotaryDecoder();
-    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
+    encoder->begin(ENCODER_INA, ENCODER_INB, 4);
 }
 
 /***************************************************************************************

--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -107,7 +107,7 @@ void _setup_gpio() {
     pinMode(ENCODER_INA, INPUT_PULLUP);
     pinMode(ENCODER_INB, INPUT_PULLUP);
     encoder = new RotaryDecoder();
-    encoder->begin(ENCODER_INA, ENCODER_INB, 4);
+    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
 }
 
 /***************************************************************************************

--- a/boards/lilygo-t-lora-pager/interface.cpp
+++ b/boards/lilygo-t-lora-pager/interface.cpp
@@ -309,6 +309,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/boards/m5stack-dinmeter/interface.cpp
+++ b/boards/m5stack-dinmeter/interface.cpp
@@ -54,6 +54,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/boards/m5stack-dinmeter/interface.cpp
+++ b/boards/m5stack-dinmeter/interface.cpp
@@ -21,7 +21,7 @@ void _setup_gpio() {
     pinMode(ENCODER_INA, INPUT_PULLUP);
     pinMode(ENCODER_INB, INPUT_PULLUP);
     encoder = new RotaryDecoder();
-    encoder->begin(ENCODER_INA, ENCODER_INB, 4);
+    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
 }
 /*********************************************************************
 ** Function: setBrightness

--- a/boards/m5stack-dinmeter/interface.cpp
+++ b/boards/m5stack-dinmeter/interface.cpp
@@ -21,7 +21,7 @@ void _setup_gpio() {
     pinMode(ENCODER_INA, INPUT_PULLUP);
     pinMode(ENCODER_INB, INPUT_PULLUP);
     encoder = new RotaryDecoder();
-    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
+    encoder->begin(ENCODER_INA, ENCODER_INB, 4);
 }
 /*********************************************************************
 ** Function: setBrightness

--- a/boards/marauder-touch/interface.cpp
+++ b/boards/marauder-touch/interface.cpp
@@ -104,6 +104,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/boards/marauder-touch/interface.cpp
+++ b/boards/marauder-touch/interface.cpp
@@ -24,7 +24,7 @@ void _setup_gpio() {
     pinMode(ENCODER_INA, INPUT_PULLUP);
     pinMode(ENCODER_INB, INPUT_PULLUP);
     encoder = new RotaryDecoder();
-    encoder->begin(ENCODER_INA, ENCODER_INB, 4);
+    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
 #endif
 }
 

--- a/boards/marauder-touch/interface.cpp
+++ b/boards/marauder-touch/interface.cpp
@@ -24,7 +24,7 @@ void _setup_gpio() {
     pinMode(ENCODER_INA, INPUT_PULLUP);
     pinMode(ENCODER_INB, INPUT_PULLUP);
     encoder = new RotaryDecoder();
-    encoder->begin(ENCODER_INA, ENCODER_INB, 2);
+    encoder->begin(ENCODER_INA, ENCODER_INB, 4);
 #endif
 }
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -148,9 +148,9 @@ struct keyStroke { // DO NOT CHANGE IT!!!!!
         fn = false;
         del = false;
         enter = false;
-        alt = false;
-        ctrl = false;
-        gui = false;
+        bool alt = false;
+        bool ctrl = false;
+        bool gui = false;
         modifiers = 0;
         word.clear();
         hid_keys.clear();
@@ -226,6 +226,25 @@ extern String menuOptionLabel;
 
 #ifdef HAS_ENCODER_LED
 extern volatile int EncoderLedChange;
+#endif
+
+#ifdef HAS_ENCODER
+// Net signed rotary encoder steps not yet applied to any menu/list index,
+// independent from the single-shot NextPress/PrevPress bools. Written by
+// each board's InputHandler() every time it reads a new encoder position;
+// drained by a consumer (e.g. loopOptions()) with drainRotarySteps() below.
+// This lets a consumer apply the *entire* pending backlog in one pass
+// instead of being limited to one step per redraw, so a fast spin followed
+// by an equal spin back lands on the exact same item instead of drifting.
+extern volatile int32_t RotaryNetSteps;
+
+// Atomically reads and clears the pending step count, without losing any
+// steps that get added concurrently between the read and the clear.
+static inline int32_t drainRotarySteps() {
+    int32_t steps = RotaryNetSteps;
+    RotaryNetSteps -= steps;
+    return steps;
+}
 #endif
 
 extern TaskHandle_t xHandle;

--- a/include/rotary_decoder.h
+++ b/include/rotary_decoder.h
@@ -63,10 +63,7 @@ static const int8_t ROTARY_DECODER_ENC_TABLE[16] = {
 
 class RotaryDecoder {
 public:
-    // Default of 4 matches a standard quadrature encoder (4 raw transitions
-    // per mechanical detent). Only override this if a board's specific
-    // hardware genuinely latches twice as often.
-    void begin(uint8_t pinA, uint8_t pinB, uint8_t stepsPerDetent = 4) {
+    void begin(uint8_t pinA, uint8_t pinB, uint8_t stepsPerDetent = 2) {
         _pinA = pinA;
         _pinB = pinB;
         _stepsPerDetent = stepsPerDetent;
@@ -108,7 +105,7 @@ public:
 private:
     uint8_t _pinA = 0;
     uint8_t _pinB = 0;
-    uint8_t _stepsPerDetent = 4;
+    uint8_t _stepsPerDetent = 2;
     uint8_t _abState = 0;
     int8_t _accum = 0;
     // Written by the dedicated encoder-poll task, read by InputHandler()

--- a/include/rotary_decoder.h
+++ b/include/rotary_decoder.h
@@ -63,7 +63,10 @@ static const int8_t ROTARY_DECODER_ENC_TABLE[16] = {
 
 class RotaryDecoder {
 public:
-    void begin(uint8_t pinA, uint8_t pinB, uint8_t stepsPerDetent = 2) {
+    // Default of 4 matches a standard quadrature encoder (4 raw transitions
+    // per mechanical detent). Only override this if a board's specific
+    // hardware genuinely latches twice as often.
+    void begin(uint8_t pinA, uint8_t pinB, uint8_t stepsPerDetent = 4) {
         _pinA = pinA;
         _pinB = pinB;
         _stepsPerDetent = stepsPerDetent;
@@ -105,7 +108,7 @@ public:
 private:
     uint8_t _pinA = 0;
     uint8_t _pinB = 0;
-    uint8_t _stepsPerDetent = 2;
+    uint8_t _stepsPerDetent = 4;
     uint8_t _abState = 0;
     int8_t _accum = 0;
     // Written by the dedicated encoder-poll task, read by InputHandler()

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -51,6 +51,7 @@ void displayScrollingText(const String &text, Opt_Coord &coord) {
             bruceConfig.bgColor
         ); // Clear display area
         tft.setCursor(coord.x, coord.y);
+        tft.setCursor(coord.x, coord.y);
         tft.print(scrollingPart);
         if (i >= scrollLen - coord.size) i = -1; // Loop back
         _lastmillis = millis();
@@ -128,40 +129,8 @@ bool wakeUpScreen() {
 }
 
 /***************************************************************************************
-** Function name: wrapText
-** Description:   Wrap text to fit within a maximum width, returning vector of lines
-***************************************************************************************/
-std::vector<String> wrapText(const String& text, int maxCharsPerLine) {
-    std::vector<String> lines;
-    if (maxCharsPerLine <= 0) return lines;
-    
-    String remaining = text;
-    while (remaining.length() > 0) {
-        if (remaining.length() <= maxCharsPerLine) {
-            lines.push_back(remaining);
-            break;
-        }
-        // Find last space within maxCharsPerLine
-        int splitPos = -1;
-        for (int i = maxCharsPerLine - 1; i >= 0; i--) {
-            if (remaining[i] == ' ' || remaining[i] == '-' || remaining[i] == '_') {
-                splitPos = i;
-                break;
-            }
-        }
-        if (splitPos <= 0) {
-            // No word boundary found, force split at max
-            splitPos = maxCharsPerLine;
-        }
-        lines.push_back(remaining.substring(0, splitPos));
-        remaining = remaining.substring(splitPos + 1);
-    }
-    return lines;
-}
-
-/***************************************************************************************
 ** Function name: displayRedStripe
-** Description:   Display Red Stripe with information (supports multi-line text wrapping)
+** Description:   Display Red Stripe with information
 ***************************************************************************************/
 void displayRedStripe(const String &text, uint16_t fgcolor, uint16_t bgcolor) {
     // detect if not running in interactive mode -> show nothing onscreen and return immediately
@@ -169,40 +138,23 @@ void displayRedStripe(const String &text, uint16_t fgcolor, uint16_t bgcolor) {
 
     int size;
     if (fgcolor == bgcolor && fgcolor == TFT_WHITE) fgcolor = TFT_BLACK;
-    
-    // Calculate max chars per line based on font size
-    int maxCharsFM = (tftWidth - 20) / (LW * FM);
-    int maxCharsFP = (tftWidth - 20) / (LW * FP);
-    
-    // Determine if we need to wrap the text
-    std::vector<String> wrappedLines;
-    int boxHeight = 26;  // Default height for single line
-    
-    if (text.length() * LW * FM < (tftWidth - 2 * FM * LW)) {
-        // Text fits with FM font
-        size = FM;
-        wrappedLines = wrapText(text, maxCharsFM);
-    } else {
-        // Text needs FP font or larger
-        size = FP;
-        wrappedLines = wrapText(text, maxCharsFP);
-    }
-    
-    // Adjust box height based on number of lines
-    if (wrappedLines.size() > 1) {
-        boxHeight = 13 + (wrappedLines.size() * (size == FM ? 8 : 10));
-    }
-    
+    if (text.length() * LW * FM < (tftWidth - 2 * FM * LW)) size = FM;
+    else size = FP;
     tft.drawPixel(0, 0, 0);
-    tft.fillRoundRect(10, tftHeight / 2 - boxHeight / 2, tftWidth - 20, boxHeight, 7, bgcolor);
+    tft.fillRoundRect(10, tftHeight / 2 - 13, tftWidth - 20, 26, 7, bgcolor);
     tft.setTextColor(fgcolor, bgcolor);
-    tft.setTextSize(size);
-    
-    // Draw each line centered
-    int lineHeight = size == FM ? 8 : 10;
-    int startY = tftHeight / 2 - (wrappedLines.size() * lineHeight) / 2;
-    for (size_t i = 0; i < wrappedLines.size(); i++) {
-        tft.drawCentreString(wrappedLines[i], tftWidth / 2, startY + i * lineHeight);
+    if (size == FM) {
+        tft.setTextSize(FM);
+        tft.drawCentreString(text, tftWidth / 2, tftHeight / 2 - 8);
+    } else {
+        tft.setTextSize(FP);
+        int text_size = text.length();
+        if (text_size < (tftWidth - 20) / (LW * FP))
+            tft.drawCentreString(text, tftWidth / 2, tftHeight / 2 - 8);
+        else {
+            tft.drawCentreString(text.substring(0, text_size / 2), tftWidth / 2, tftHeight / 2 - 9);
+            tft.drawCentreString(text.substring(text_size / 2), tftWidth / 2, tftHeight / 2 + 1);
+        }
     }
 }
 
@@ -331,8 +283,8 @@ void displayWarning(const String &txt, bool waitKeyPress) {
     while (waitKeyPress && !check(AnyKeyPress)) vTaskDelay(10 / portTICK_PERIOD_MS);
 }
 
-
 void displayInfo(const String &txt, bool waitKeyPress) {
+    // todo: add newlines to txt if too long
     displayRedStripe(txt, TFT_WHITE, TFT_BLUE);
     Serial.println("INFO: " + txt);
 #ifndef HAS_SCREEN
@@ -344,6 +296,7 @@ void displayInfo(const String &txt, bool waitKeyPress) {
 }
 
 void displaySuccess(const String &txt, bool waitKeyPress) {
+    // todo: add newlines to txt if too long
     displayRedStripe(txt, TFT_WHITE, TFT_DARKGREEN);
     Serial.println("SUCCESS: " + txt);
 #ifndef HAS_SCREEN
@@ -354,6 +307,7 @@ void displaySuccess(const String &txt, bool waitKeyPress) {
 }
 
 void displayTextLine(const String &txt, bool waitKeyPress) {
+    // todo: add newlines to txt if too long
     displayRedStripe(txt, getComplementaryColor2(bruceConfig.priColor), bruceConfig.priColor);
     Serial.println("MESSAGE: " + txt);
 #ifndef HAS_SCREEN
@@ -625,6 +579,52 @@ int loopOptions(
             break;
         }
 
+#ifdef HAS_ENCODER
+        // Drain the exact number of pending encoder steps in one pass, so a
+        // fast spin (in either direction) applies its true net movement
+        // before the next redraw, instead of being limited to one item per
+        // redraw pass. Turning N steps one way then N steps back always
+        // lands back on the same item, since findNextEnabled(+1)/(-1) are
+        // exact inverses and every real step gets applied, none skipped.
+        //
+        // PrevPress/NextPress/UpPress/DownPress can also be set by
+        // non-encoder sources on some boards (a physical keyboard on
+        // T-Lora-Pager, a touchscreen on the WaveSentry variant) which
+        // don't feed the step counter. If the counter is empty but one of
+        // those flags was set, fall back to a single step exactly like the
+        // original per-press behavior, so those input sources are unaffected.
+        bool altPrev = PrevPress || UpPress;
+        bool altNext = NextPress || DownPress;
+        int32_t steps = drainRotarySteps();
+        check(PrevPress);
+        check(NextPress);
+        check(UpPress);
+        check(DownPress);
+        if (steps == 0) {
+            if (altPrev) steps = 1;
+            else if (altNext) steps = -1;
+        }
+        if (steps != 0) devModeCounter = 0;
+        while (steps > 0) {
+            int prevEnabled = findNextEnabled(index, -1);
+            if (prevEnabled < 0) break;
+            index = prevEnabled;
+            steps--;
+            redraw = true;
+        }
+        while (steps < 0) {
+            int nextEnabled = findNextEnabled(index, +1);
+            if (nextEnabled < 0) break;
+            if (!bruceConfig.devMode && nextEnabled <= index) devModeCounter++;
+            index = nextEnabled;
+            steps++;
+            redraw = true;
+        }
+        // Match the rotary encoder's own poll cadence here instead of the
+        // generic 10ms menu-loop pacing, so a backed-up run of detents can
+        // drain without an artificial per-iteration floor on top of it.
+        vTaskDelay(4 / portTICK_PERIOD_MS);
+#else
         if (PrevPress || check(UpPress)) {
             devModeCounter = 0;
 #ifdef HAS_KEYBOARD
@@ -634,7 +634,6 @@ int loopOptions(
             redraw = true;
 #else
             long _tmp = millis();
-#ifndef HAS_ENCODER // T-Embed doesn't need it
             LongPress = true;
             while (PrevPress && menuType != MENU_TYPE_MAIN) {
                 if (millis() - _tmp > 200)
@@ -654,7 +653,6 @@ int loopOptions(
                 tftWidth / 2, tftHeight / 2, 25, 15, 0, 360, bruceConfig.bgColor, bruceConfig.bgColor
             );
             LongPress = false;
-#endif
             if (millis() - _tmp > 700) { // longpress detected to exit
                 index = -1;
                 break;
@@ -675,12 +673,6 @@ int loopOptions(
             }
             redraw = true;
         }
-#ifdef HAS_ENCODER
-        // Match the rotary encoder's own poll cadence here instead of the
-        // generic 10ms menu-loop pacing, so a backed-up run of detents can
-        // drain without an artificial per-iteration floor on top of it.
-        vTaskDelay(4 / portTICK_PERIOD_MS);
-#else
         vTaskDelay(10 / portTICK_PERIOD_MS);
 #endif
 
@@ -755,6 +747,7 @@ Opt_Coord drawOptions(
             fgcolor
         );
     }
+
     tft.setTextColor(fgcolor, bgcolor);
     tft.setTextSize(FM);
     tft.setCursor(tftWidth * 0.10 + 5, tftHeight / 2 - menuSize * (FM * 8 + 4) / 2);
@@ -764,30 +757,8 @@ Opt_Coord drawOptions(
     int cont = 1;
     menuSize = options.size();
     if (index >= MAX_MENU_SIZE) init = index - MAX_MENU_SIZE + 1;
-    
-    // Calculate selection highlight position
-    int selectedItemPos = -1;
-    for (int j = 0; j < index; j++) {
-        if (j >= init && cont <= MAX_MENU_SIZE) cont++;
-    }
-    selectedItemPos = cont - 1;
-    cont = 1;
-    
     for (i = 0; i < menuSize; i++) {
         if (i >= init) {
-            // Draw selection highlight bar
-            if (i == index) {
-                int16_t cursorY = tft.getCursorY();
-                tft.fillRoundRect(
-                    tftWidth * 0.10 + 2,
-                    cursorY + 2,
-                    tftWidth * 0.8 - 4,
-                    FM * 8,
-                    3,
-                    bruceConfig.priColor
-                );
-            }
-            
             if (options[i].selected) tft.setTextColor(selcolor, bgcolor); // if selected, change Text color
             else tft.setTextColor(fgcolor, bgcolor);
             if (!options[i].enabled) tft.setTextColor(TFT_DARKGREY, bgcolor);
@@ -803,16 +774,7 @@ Opt_Coord drawOptions(
             } else text += " ";
             text += String(options[i].label) + "              ";
             tft.setCursor(tftWidth * 0.10 + 5, tft.getCursorY() + 4);
-            
-            // Draw text with appropriate colors for selection
-            if (i == index) {
-                tft.setTextColor(bgcolor, bruceConfig.priColor);
-            }
             tft.println(text.substring(0, (tftWidth * 0.8 - 10) / (LW * FM) - 1));
-            
-            // Reset text color for next item
-            tft.setTextColor(fgcolor, bgcolor);
-            
             cont++;
         }
         if (cont > MAX_MENU_SIZE) goto Exit;

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -1193,10 +1193,33 @@ String generalKeyboard(
             if ((check(SelPress) || selection_made) && touchPoint.pressed == false) {
                 LongPress = false;
                 selection_made = true;
+            } else if (touchPoint.pressed) {
+                // Touchscreen is prioritized on boards with both -- discard
+                // any encoder movement that piled up while touch was active
+                // instead of queuing it up to suddenly fire once released.
+                drainRotarySteps();
+                check(NextPress);
+                check(PrevPress);
             } else {
-                /* NEXT "Btn" to move forward on th X axis (to the right) */
+                // Drain the exact number of pending encoder steps in one
+                // pass, same idea as the menu list navigation, so a fast
+                // spin moves the cursor by its true net amount before the
+                // next redraw, and a spin forward then back lands on the
+                // same key. Falls back to a single step if NextPress/
+                // PrevPress was set by something other than the encoder.
+                bool altNext = NextPress;
+                bool altPrev = PrevPress;
+                int32_t steps = drainRotarySteps();
+                check(NextPress);
+                check(PrevPress);
+                if (steps == 0) {
+                    if (altNext) steps = -1;
+                    else if (altPrev) steps = 1;
+                }
+
                 // if ESC is pressed while NEXT or PREV is received, then we navigate on the Y axis instead
-                if (check(NextPress) && touchPoint.pressed == false) {
+                auto stepNext = [&]() {
+                    /* NEXT "Btn" to move forward on th X axis (to the right) */
                     if (EscPress) {
                         y++;
                     } else if ((x >= buttons_number - 1 && y <= -1) || (x >= KeyboardWidth - 1 && y >= 0)) {
@@ -1228,11 +1251,9 @@ String generalKeyboard(
                             }
                         }
                     }
-
-                    redraw = true;
-                }
-                /* PREV "Btn" to move backwards on th X axis (to the left) */
-                if (check(PrevPress) && touchPoint.pressed == false) {
+                };
+                auto stepPrev = [&]() {
+                    /* PREV "Btn" to move backwards on th X axis (to the left) */
                     if (EscPress) {
                         y--;
                     } else if (x <= 0) {
@@ -1263,7 +1284,16 @@ String generalKeyboard(
                             }
                         }
                     }
+                };
 
+                while (steps < 0) {
+                    stepNext();
+                    steps++;
+                    redraw = true;
+                }
+                while (steps > 0) {
+                    stepPrev();
+                    steps--;
                     redraw = true;
                 }
             }

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -1321,6 +1321,16 @@ String generalKeyboard(
 
             last_input_time = millis();
         }
+#ifdef HAS_ENCODER
+        // Without this, this loop spins as fast as the CPU allows, which can
+        // outrun InputHandler()'s own writes: it updates RotaryNetSteps and
+        // the NextPress/PrevPress bools in separate steps, not atomically,
+        // so a tight loop can observe them torn across two iterations and
+        // count the same physical detent twice (once via the drained step
+        // count, once via the bool fallback). Pacing this loop the same as
+        // the menu list's own loop closes that window.
+        vTaskDelay(4 / portTICK_PERIOD_MS);
+#endif
     }
 
     // Resets screen when finished writing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,8 @@ TouchPoint touchPoint;
 keyStroke KeyStroke;
 
 #ifdef HAS_ENCODER
+volatile int32_t RotaryNetSteps = 0;
+
 // Default no-op: boards that define HAS_ENCODER but don't implement
 // pollEncoder() (shouldn't happen, but keeps the linker happy either way).
 void __attribute__((weak)) pollEncoder(void) {}


### PR DESCRIPTION
The other PR already got merged, but I forgot to say in the PR that I was still working on this implementation, oops sorry.

This one should also be merged now:
It provides better and more robust input tracking for the very recent rotary encoder edits that are already merged in my other PR.

tested on t-embed cc1101 plus

@bmorcelli quick merge would be clean, thanks