### PR TITLE
Add exact-drain rotary encoder navigation (Rotary-input-edit)

### DIFF
--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -152,6 +152,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/boards/lilygo-t-lora-pager/interface.cpp
+++ b/boards/lilygo-t-lora-pager/interface.cpp
@@ -309,6 +309,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/boards/m5stack-dinmeter/interface.cpp
+++ b/boards/m5stack-dinmeter/interface.cpp
@@ -54,6 +54,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/boards/marauder-touch/interface.cpp
+++ b/boards/marauder-touch/interface.cpp
@@ -104,6 +104,11 @@ void InputHandler(void) {
     int newPos = encoder->getPosition();
     if (newPos != lastPos) {
         posDifference += (newPos - lastPos);
+        // Independent running total for consumers that want to apply the
+        // full pending backlog in one pass instead of one step at a time
+        // (see drainRotarySteps() in globals.h). Never cleared by the
+        // stale-drop below -- it's drained exactly, not time-limited.
+        RotaryNetSteps += (newPos - lastPos);
         lastPos = newPos;
         lastEncoderMoveMs = millis();
     } else if (posDifference != 0 && millis() - lastEncoderMoveMs > 30) {

--- a/include/globals.h
+++ b/include/globals.h
@@ -228,6 +228,18 @@ extern String menuOptionLabel;
 extern volatile int EncoderLedChange;
 #endif
 
+#ifdef HAS_ENCODER
+// Net pending rotary encoder steps, independent from NextPress/PrevPress,
+// so a consumer can apply a whole backlog at once instead of one per redraw.
+extern volatile int32_t RotaryNetSteps;
+
+static inline int32_t drainRotarySteps() {
+    int32_t steps = RotaryNetSteps;
+    RotaryNetSteps -= steps;
+    return steps;
+}
+#endif
+
 extern TaskHandle_t xHandle;
 extern inline bool check(volatile bool &btn, bool resetButtonStatus = true) {
 

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -625,64 +625,85 @@ int loopOptions(
             break;
         }
 
-        if (PrevPress || check(UpPress)) {
-            devModeCounter = 0;
-#ifdef HAS_KEYBOARD
+#ifdef HAS_ENCODER
+        int32_t rotarySteps = drainRotarySteps();
+        if (rotarySteps != 0) {
             check(PrevPress);
-            int prevEnabled = findNextEnabled(index, -1);
-            if (prevEnabled >= 0) index = prevEnabled;
-            redraw = true;
-#else
-            long _tmp = millis();
-#ifndef HAS_ENCODER // T-Embed doesn't need it
-            LongPress = true;
-            while (PrevPress && menuType != MENU_TYPE_MAIN) {
-                if (millis() - _tmp > 200)
-                    tft.drawArc(
-                        tftWidth / 2,
-                        tftHeight / 2,
-                        25,
-                        15,
-                        0,
-                        360 * (millis() - (_tmp + 200)) / 500,
-                        getColorVariation(bruceConfig.priColor),
-                        bruceConfig.bgColor
-                    );
-                vTaskDelay(10 / portTICK_RATE_MS);
+            check(NextPress);
+            check(UpPress);
+            check(DownPress);
+            devModeCounter = 0;
+            while (rotarySteps > 0) {
+                int prevEnabled = findNextEnabled(index, -1);
+                if (prevEnabled < 0) break;
+                index = prevEnabled;
+                rotarySteps--;
+                redraw = true;
             }
-            tft.drawArc(
-                tftWidth / 2, tftHeight / 2, 25, 15, 0, 360, bruceConfig.bgColor, bruceConfig.bgColor
-            );
-            LongPress = false;
+            while (rotarySteps < 0) {
+                int nextEnabled = findNextEnabled(index, +1);
+                if (nextEnabled < 0) break;
+                if (!bruceConfig.devMode && nextEnabled <= index) devModeCounter++;
+                index = nextEnabled;
+                rotarySteps++;
+                redraw = true;
+            }
+            vTaskDelay(4 / portTICK_PERIOD_MS);
+        } else
 #endif
-            if (millis() - _tmp > 700) { // longpress detected to exit
-                index = -1;
-                break;
-            } else {
+        {
+            if (PrevPress || check(UpPress)) {
+                devModeCounter = 0;
+#ifdef HAS_KEYBOARD
                 check(PrevPress);
                 int prevEnabled = findNextEnabled(index, -1);
                 if (prevEnabled >= 0) index = prevEnabled;
                 redraw = true;
-            }
-#endif
-        }
-        /* DW Btn to next item */
-        if (check(NextPress) || check(DownPress)) {
-            int nextEnabled = findNextEnabled(index, +1);
-            if (nextEnabled >= 0) {
-                if (!bruceConfig.devMode && nextEnabled <= index) devModeCounter++;
-                index = nextEnabled;
-            }
-            redraw = true;
-        }
-#ifdef HAS_ENCODER
-        // Match the rotary encoder's own poll cadence here instead of the
-        // generic 10ms menu-loop pacing, so a backed-up run of detents can
-        // drain without an artificial per-iteration floor on top of it.
-        vTaskDelay(4 / portTICK_PERIOD_MS);
 #else
-        vTaskDelay(10 / portTICK_PERIOD_MS);
+                long _tmp = millis();
+#ifndef HAS_ENCODER // T-Embed doesn't need it
+                LongPress = true;
+                while (PrevPress && menuType != MENU_TYPE_MAIN) {
+                    if (millis() - _tmp > 200)
+                        tft.drawArc(
+                            tftWidth / 2,
+                            tftHeight / 2,
+                            25,
+                            15,
+                            0,
+                            360 * (millis() - (_tmp + 200)) / 500,
+                            getColorVariation(bruceConfig.priColor),
+                            bruceConfig.bgColor
+                        );
+                    vTaskDelay(10 / portTICK_RATE_MS);
+                }
+                tft.drawArc(
+                    tftWidth / 2, tftHeight / 2, 25, 15, 0, 360, bruceConfig.bgColor, bruceConfig.bgColor
+                );
+                LongPress = false;
 #endif
+                if (millis() - _tmp > 700) { // longpress detected to exit
+                    index = -1;
+                    break;
+                } else {
+                    check(PrevPress);
+                    int prevEnabled = findNextEnabled(index, -1);
+                    if (prevEnabled >= 0) index = prevEnabled;
+                    redraw = true;
+                }
+#endif
+            }
+            /* DW Btn to next item */
+            if (check(NextPress) || check(DownPress)) {
+                int nextEnabled = findNextEnabled(index, +1);
+                if (nextEnabled >= 0) {
+                    if (!bruceConfig.devMode && nextEnabled <= index) devModeCounter++;
+                    index = nextEnabled;
+                }
+                redraw = true;
+            }
+            vTaskDelay(10 / portTICK_PERIOD_MS);
+        }
 
         /* Select and run function
         forceMenuOption is set by a SerialCommand to force a selection within the menu

--- a/src/core/mykeyboard.cpp
+++ b/src/core/mykeyboard.cpp
@@ -1194,77 +1194,143 @@ String generalKeyboard(
                 LongPress = false;
                 selection_made = true;
             } else {
-                /* NEXT "Btn" to move forward on th X axis (to the right) */
-                // if ESC is pressed while NEXT or PREV is received, then we navigate on the Y axis instead
-                if (check(NextPress) && touchPoint.pressed == false) {
-                    if (EscPress) {
-                        y++;
-                    } else if ((x >= buttons_number - 1 && y <= -1) || (x >= KeyboardWidth - 1 && y >= 0)) {
-                        // if we are at the end of the current line
-                        y++;   // next line
-                        x = 0; // reset to first key
-                    } else x++;
+                int32_t rotarySteps = drainRotarySteps();
+                if (rotarySteps != 0 && touchPoint.pressed == false) {
+                    check(NextPress);
+                    check(PrevPress);
+                    while (rotarySteps < 0) {
+                        if (EscPress) {
+                            y++;
+                        } else if ((x >= buttons_number - 1 && y <= -1) || (x >= KeyboardWidth - 1 && y >= 0)) {
+                            y++;
+                            x = 0;
+                        } else x++;
 
-                    if (y >= KeyboardHeight)
-                        y = -1; // if we are at the end of the keyboard, then return to the top
+                        if (y >= KeyboardHeight) y = -1;
+                        if (y == -1 && x >= buttons_number) x = 0;
 
-                    // If we move to a new line using the ESC-press navigation and the previous x coordinate
-                    // is greater than the number of available buttons_strings on the new line, reset x to
-                    // avoid out-of-bounds behavior, this can only happen when switching to the first line, as
-                    // the others have all the same number of keys
-                    if (y == -1 && x >= buttons_number) x = 0;
-
-                    // Skip over keys with '\0' value
-                    if (y >= 0 && y < KeyboardHeight && x >= 0 && x < KeyboardWidth) {
-                        while (keys[y][x][caps] == '\0') {
-                            x++;
-                            if (x >= KeyboardWidth) {
-                                x = 0;
-                                y++;
-                                if (y >= KeyboardHeight) {
-                                    y = -1;
-                                    break;
+                        if (y >= 0 && y < KeyboardHeight && x >= 0 && x < KeyboardWidth) {
+                            while (keys[y][x][caps] == '\0') {
+                                x++;
+                                if (x >= KeyboardWidth) {
+                                    x = 0;
+                                    y++;
+                                    if (y >= KeyboardHeight) {
+                                        y = -1;
+                                        break;
+                                    }
                                 }
                             }
                         }
+
+                        rotarySteps++;
+                        redraw = true;
                     }
+                    while (rotarySteps > 0) {
+                        if (EscPress) {
+                            y--;
+                        } else if (x <= 0) {
+                            y--;
+                            if (y == -1) x = buttons_number - 1;
+                            else x = KeyboardWidth - 1;
+                        } else x--;
 
-                    redraw = true;
-                }
-                /* PREV "Btn" to move backwards on th X axis (to the left) */
-                if (check(PrevPress) && touchPoint.pressed == false) {
-                    if (EscPress) {
-                        y--;
-                    } else if (x <= 0) {
-                        y--;
-                        if (y == -1) x = buttons_number - 1;
-                        else x = KeyboardWidth - 1;
-                    } else x--;
+                        if (y < -1) {
+                            y = KeyboardHeight - 1;
+                            x = KeyboardWidth - 1;
+                        }
 
-                    if (y < -1) { // go back to the bottom right of the keyboard
-                        y = KeyboardHeight - 1;
-                        x = KeyboardWidth - 1;
-                    }
-                    // else if (y == -1 && x >= buttons_number) x = buttons_number - 1;
-                    // else if (x < 0) x = KeyboardWidth - 1;
-
-                    // Skip over keys with '\0' value when moving backwards
-                    if (y >= 0 && y < KeyboardHeight && x >= 0 && x < KeyboardWidth) {
-                        while (keys[y][x][caps] == '\0') {
-                            x--;
-                            if (x < 0) {
-                                x = KeyboardWidth - 1;
-                                y--;
-                                if (y < 0) {
-                                    y = -1;
-                                    x = buttons_number - 1;
-                                    break;
+                        if (y >= 0 && y < KeyboardHeight && x >= 0 && x < KeyboardWidth) {
+                            while (keys[y][x][caps] == '\0') {
+                                x--;
+                                if (x < 0) {
+                                    x = KeyboardWidth - 1;
+                                    y--;
+                                    if (y < 0) {
+                                        y = -1;
+                                        x = buttons_number - 1;
+                                        break;
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    redraw = true;
+                        rotarySteps--;
+                        redraw = true;
+                    }
+                } else {
+                    /* NEXT "Btn" to move forward on th X axis (to the right) */
+                    // if ESC is pressed while NEXT or PREV is received, then we navigate on the Y axis instead
+                    if (check(NextPress) && touchPoint.pressed == false) {
+                        if (EscPress) {
+                            y++;
+                        } else if ((x >= buttons_number - 1 && y <= -1) || (x >= KeyboardWidth - 1 && y >= 0)) {
+                            // if we are at the end of the current line
+                            y++;   // next line
+                            x = 0; // reset to first key
+                        } else x++;
+
+                        if (y >= KeyboardHeight)
+                            y = -1; // if we are at the end of the keyboard, then return to the top
+
+                        // If we move to a new line using the ESC-press navigation and the previous x coordinate
+                        // is greater than the number of available buttons_strings on the new line, reset x to
+                        // avoid out-of-bounds behavior, this can only happen when switching to the first line, as
+                        // the others have all the same number of keys
+                        if (y == -1 && x >= buttons_number) x = 0;
+
+                        // Skip over keys with '\0' value
+                        if (y >= 0 && y < KeyboardHeight && x >= 0 && x < KeyboardWidth) {
+                            while (keys[y][x][caps] == '\0') {
+                                x++;
+                                if (x >= KeyboardWidth) {
+                                    x = 0;
+                                    y++;
+                                    if (y >= KeyboardHeight) {
+                                        y = -1;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        redraw = true;
+                    }
+                    /* PREV "Btn" to move backwards on th X axis (to the left) */
+                    if (check(PrevPress) && touchPoint.pressed == false) {
+                        if (EscPress) {
+                            y--;
+                        } else if (x <= 0) {
+                            y--;
+                            if (y == -1) x = buttons_number - 1;
+                            else x = KeyboardWidth - 1;
+                        } else x--;
+
+                        if (y < -1) { // go back to the bottom right of the keyboard
+                            y = KeyboardHeight - 1;
+                            x = KeyboardWidth - 1;
+                        }
+                        // else if (y == -1 && x >= buttons_number) x = buttons_number - 1;
+                        // else if (x < 0) x = KeyboardWidth - 1;
+
+                        // Skip over keys with '\0' value when moving backwards
+                        if (y >= 0 && y < KeyboardHeight && x >= 0 && x < KeyboardWidth) {
+                            while (keys[y][x][caps] == '\0') {
+                                x--;
+                                if (x < 0) {
+                                    x = KeyboardWidth - 1;
+                                    y--;
+                                    if (y < 0) {
+                                        y = -1;
+                                        x = buttons_number - 1;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        redraw = true;
+                    }
                 }
             }
 #endif
@@ -1291,6 +1357,9 @@ String generalKeyboard(
 
             last_input_time = millis();
         }
+#ifdef HAS_ENCODER
+        vTaskDelay(4 / portTICK_PERIOD_MS);
+#endif
     }
 
     // Resets screen when finished writing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,8 @@ TouchPoint touchPoint;
 keyStroke KeyStroke;
 
 #ifdef HAS_ENCODER
+volatile int32_t RotaryNetSteps = 0;
+
 // Default no-op: boards that define HAS_ENCODER but don't implement
 // pollEncoder() (shouldn't happen, but keeps the linker happy either way).
 void __attribute__((weak)) pollEncoder(void) {}


### PR DESCRIPTION
#### Proposed Changes ####

Adds RotaryNetSteps, a signed counter tracking pending encoder detents independent from the single-shot NextPress/PrevPress bools. Consumers (loopOptions() menu navigation and the on-screen keyboard) drain the full pending count in one pass before redrawing, instead of applying at most one step per redraw pass. This means a fast spin applies its true net movement immediately, and turning N steps one way then N back always lands on the exact same item/key, since the underlying findNextEnabled()/step functions are exact inverses of each other.

Falls back to the exact original per-press code when NextPress/PrevPress/UpPress/DownPress is set by a non-encoder source (T-Lora-Pager's physical keyboard, the WaveSentry touchscreen), so those input paths are unaffected.

Also fixes a race in the on-screen keyboard: its input loop had no pacing delay, so it could occasionally observe RotaryNetSteps and the NextPress/PrevPress bools torn across two loop iterations (since InputHandler() writes them in separate, non-atomic steps), causing an occasional double-step. Pacing the loop the same as the menu list closes that window.

All changes are gated behind #ifdef HAS_ENCODER; no other input path or non-encoder board is affected.

#### Types of Changes ####

Bugfix
feeature add

#### Verification ####

Spin the encoder fast in the menu and on the keyboard: selection should move by the exact amount, no skips, no backwards jumps. Spin N steps one way then N back and confirm you land on the same item/key. Consume input via a physical keyboard or touchscreen on boards that have one, and confirm it behaves exactly as before.

#### Testing ####

Only tested on t-embed (I don't own any other bruce devices)
NEEDS TESTING on button devices and other rotary-enabled devices

#### Linked Issues ####
Follow-up to the rotary encoder fix already merged in dev.

#### User-Facing Change ####
```release-note
Rotary encoder navigation no longer loses or doubles steps.
```