### PR TITLE
 fix(wifi): stop beacon spam from leaking garbage MACs and malformed frames

### DIFF
--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -83,19 +83,26 @@ const uint8_t beaconPacketTemplate[BEACON_PKT_LEN] = {
 };
 // clang-format on
 
-static inline void prepareBeaconPacket(
+// Tags after the SSID (Rates, DS Param/channel, RSN) in the template, starting right after
+// the 32-byte SSID placeholder. Kept as a named offset so the channel byte position below
+// stays correct if the template layout changes.
+constexpr size_t BEACON_TAIL_OFFSET = 70;
+constexpr size_t BEACON_TAIL_LEN = BEACON_PKT_LEN - BEACON_TAIL_OFFSET;
+constexpr size_t BEACON_TAIL_CHANNEL_OFFSET = 82 - BEACON_TAIL_OFFSET;
+
+static inline size_t prepareBeaconPacket(
     uint8_t outPacket[BEACON_PKT_LEN], const uint8_t macAddr[6], const char *ssid, uint8_t ssidLen,
     uint8_t channel, bool setWPAflag = true
 ) {
-    memcpy(outPacket, beaconPacketTemplate, BEACON_PKT_LEN);
+    if (ssidLen > 32) ssidLen = 32;
+    memcpy(outPacket, beaconPacketTemplate, 38);
     memcpy(&outPacket[10], macAddr, 6);
     memcpy(&outPacket[16], macAddr, 6);
-    memset(&outPacket[38], 0x20, 32);
-    if (ssidLen > 32) ssidLen = 32;
     outPacket[37] = ssidLen;
     if (ssidLen > 0) { memcpy(&outPacket[38], ssid, ssidLen); }
-    outPacket[82] = channel;
-    outPacket[34] = 0x31;
+    memcpy(&outPacket[38 + ssidLen], &beaconPacketTemplate[BEACON_TAIL_OFFSET], BEACON_TAIL_LEN);
+    outPacket[38 + ssidLen + BEACON_TAIL_CHANNEL_OFFSET] = channel;
+    return 38 + ssidLen + BEACON_TAIL_LEN;
 }
 
 const uint8_t channels[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
@@ -663,6 +670,7 @@ void target_atk(const String &tssid, const String &mac, uint8_t channel) {
 }
 
 void generateRandomWiFiMac(uint8_t *mac) {
+    mac[0] = (random(0, 255) & 0xFC) | 0x02;
     for (int i = 1; i < 6; i++) { mac[i] = random(0, 255); }
 }
 
@@ -755,9 +763,9 @@ void beaconSpamList(const char list[]) {
         } while (tmp != '\n' && i + j < ssidsLen);
         uint8_t ssidLen = (j > 32) ? 32 : j - 1;
         generateRandomWiFiMac(macAddr);
-        prepareBeaconPacket(beaconPacket, macAddr, ssidBuf, ssidLen, wifi_channel, true);
+        size_t pktLen = prepareBeaconPacket(beaconPacket, macAddr, ssidBuf, ssidLen, wifi_channel, true);
         for (int k = 0; k < 2; k++) {
-            wifiRawTx(WIFI_IF_STA, beaconPacket, BEACON_PKT_LEN);
+            wifiRawTx(WIFI_IF_STA, beaconPacket, pktLen);
             vTaskDelay(1 / portTICK_PERIOD_MS);
         }
         i += j;
@@ -775,9 +783,10 @@ void beaconSpamSingle(String baseSSID) {
         if (currentSSID.length() > 32) { currentSSID = currentSSID.substring(0, 32); }
         uint8_t ssidLen = currentSSID.length();
         generateRandomWiFiMac(macAddr);
-        prepareBeaconPacket(beaconPacket, macAddr, currentSSID.c_str(), ssidLen, wifi_channel, true);
+        size_t pktLen =
+            prepareBeaconPacket(beaconPacket, macAddr, currentSSID.c_str(), ssidLen, wifi_channel, true);
         for (int k = 0; k < 2; k++) {
-            wifiRawTx(WIFI_IF_STA, beaconPacket, BEACON_PKT_LEN);
+            wifiRawTx(WIFI_IF_STA, beaconPacket, pktLen);
             vTaskDelay(1 / portTICK_PERIOD_MS);
         }
         counter++;
@@ -796,7 +805,7 @@ void beaconAttack() {
     String txt = "";
     String singleSSID = "";
     for (int i = 0; i < 32; i++) emptySSID[i] = ' ';
-    randomSeed(1);
+    srand(millis()); // seeds rand() (used by randomSSID()) without disabling random()'s hardware RNG
     options = {
         {"Funny SSID", [&]() { BeaconMode = 0; txt = "Spamming Funny"; }},
         {"Ricky Roll", [&]() { BeaconMode = 1; txt = "Spamming Ricky"; }},


### PR DESCRIPTION
#### Proposed Changes ####

Three related fixes to the WiFi Beacon Spam attack in `wifi_atks.cpp`:

- `generateRandomWiFiMac()` never touched `mac[0]`, so it kept whatever was
  left over on the stack instead of being random. Now it's forced to a
  valid locally-administered/unicast byte.
- `prepareBeaconPacket()` wrote the real SSID length into the SSID IE but
  still padded the SSID field to a fixed 32 bytes, which desynced every IE
  after it (Rates, channel, RSN) for any SSID shorter than 32 characters.
  Depending on the exact SSID length, this made most spoofed APs show up
  as WEP-only, or hidden completely from stricter clients (tested on a
  Samsung S24 Ultra). The frame is now built at its real length instead of
  always padded to 32.
- `randomSeed(1)` in `beaconAttack()` reseeded with a constant every run,
  which also disables the ESP32's hardware RNG for the rest of the session
  as a side effect (Arduino's `randomSeed()` flips `s_useRandomHW` in
  `WMath.cpp`). Seeded `rand()` directly with `millis()` instead, so
  `random()` keeps using the hardware RNG.

#### Types of Changes ####

Bugfix.

#### Verification ####

Tested on a real LilyGo T-Embed CC1101 Plus (ESP32-S3), using a separate
Linux laptop in monitor mode (`airodump-ng`/`tshark`) plus a Samsung Galaxy
S24 Ultra (One UI 8.5) to check what actually shows up in a client's scan:

- Before: same first MAC byte on every spoofed AP within a boot
  (uninitialized stack memory, not randomized), most SSIDs classified as
  WEP by `airodump-ng`, only a handful visible on the phone.
- After: MAC varies correctly per packet and across reboots, every SSID
  classifies as WPA2/CCMP/PSK, channel is read back correctly, and all
  spoofed SSIDs show up on the phone.
- Also verified standalone, running on battery only (no USB/serial host
  attached) , still works correctly.
- Compiles clean on `lilygo-t-embed-cc1101`, `m5stack-cardputer`
  (ESP32-S3) and `CYD-2432S028` (original ESP32), confirming the fix
  isn't board-specific.

#### Testing ####

No automated tests for this module; verified manually on hardware as
described above.

#### Linked Issues ####

Relates to #2608 (same device, same "beacon spam not working" symptom,
fixed by this PR).

Relates to #2618 that report attributes beacon spam breakage to `-flto`
starving the WiFi driver task, and states `prepareBeaconPacket()` is
unchanged/well-formed. In our testing, `-flto` was enabled throughout
(unmodified `platformio.ini`) and only the source changes in this PR
flipped WEP→WPA2 classification, including in standalone/battery-only
operation, so at least on the T-Embed CC1101 Plus, this fix is sufficient
on its own. Haven't tested on M5Stack Stick S3, so can't say whether an
additional LTO/scheduling issue also applies there.

#### User-Facing Change ####
```release-note
Fixed WiFi Beacon Spam broadcasting spoofed APs with a non-random MAC
address byte and malformed SSID frames that made most fake networks
invisible or misclassified as WEP on modern devices.