### PR TITLE
fix(sniffer): resolve beacon channel mismatch

### DIFF
--- a/src/modules/wifi/sniffer.cpp
+++ b/src/modules/wifi/sniffer.cpp
@@ -527,7 +527,7 @@ static void registerBeacon(const uint8_t *apAddr) {
     if (!apAddr) return;
     BeaconList beacon;
     memcpy(beacon.MAC, apAddr, sizeof(beacon.MAC));
-    beacon.channel = ch;
+    beacon.channel = all_wifi_channels[ch];
     registeredBeacons.insert(beacon);
 }
 
@@ -1349,8 +1349,8 @@ void sniffer_setup() {
             if (registeredBeacons.size() > 40)
                 registeredBeacons.clear(); // Clear registered beacons to restart search and avoid restarts
             Serial.println("<<---- Starting Deauthentication Process ---->>");
-            for (auto registeredBeacon : registeredBeacons) {
-                if (registeredBeacon.channel == ch) {
+            for (const auto &registeredBeacon : registeredBeacons) {
+                if (registeredBeacon.channel == all_wifi_channels[ch]) {
                     memcpy(&ap_record.bssid, registeredBeacon.MAC, 6);
                     wsl_bypasser_send_raw_frame(
                         &ap_record, registeredBeacon.channel
@@ -1359,7 +1359,7 @@ void sniffer_setup() {
                     send_raw_frame(deauth_frame, 26);
                     deauth_sent = true;
                     deauth_counter++;
-                    vTaskDelay(2 / portTICK_RATE_MS);
+                    vTaskDelay(pdMS_TO_TICKS(2));
                 }
             }
 


### PR DESCRIPTION
#### Proposed Changes ####

`registerBeacon()` was storing the channel index (`ch`) rather than the actual Wi‑Fi channel number. This caused two downstream bugs:

1. `countActiveBeaconsOnChannel()` and `recentSsidsOnChannel()` compared the stored index against a real channel number, so the check never matched – both functions effectively returned empty results.
2. The deauth loop passed the index to `wsl_bypasser_send_raw_frame()`, which called `esp_wifi_set_channel()` with a value of 0–11 instead of a valid 1–12 channel, sending deauth frames on the wrong frequency.

The fix stores `all_wifi_channels[ch]` so beacon records always hold a real channel number. This automatically corrects the comparison in `countActiveBeaconsOnChannel`, `recentSsidsOnChannel`, and the deauth path.

Two other review items from Copilot were addressed in the same area:
- The deauth loop now iterates by `const auto &` to avoid copying each `BeaconList`.
- `vTaskDelay(2 / portTICK_RATE_MS)` was replaced with `pdMS_TO_TICKS(2)` for correctness on any tick rate.

#### Types of Changes ####

- Bugfix

#### Verification ####

1. Build with `platformio run -e reaper` (or the target board) – no warnings.
2. Flash and run the sniffer; check that handshake capture counts are non-zero on channels with active APs.
3. Trigger the periodic deauth and verify it deauthenticates clients on the correct channel.

#### Testing ####

Existing build pipeline only; no unit tests are currently in place for the sniffer module.

#### Linked Issues ####

PR #2667 – Copilot review comments

#### User-Facing Change ####

```release-note
Fix beacon channel storage so handshake capture and deauth work on the correct channel