### PR TITLE
feat: Add a "Skip" button to Quick Remote Setup

### DIFF
--- a/src/modules/ir/ir_read.cpp
+++ b/src/modules/ir/ir_read.cpp
@@ -140,7 +140,9 @@ void IrRead::setup() {
 }
 
 void IrRead::loop() {
+    returnToMenu = false;
     while (1) {
+        if (returnToMenu) break;
         if (check(EscPress)) {
             returnToMenu = true;
             button_pos = 0;
@@ -162,7 +164,14 @@ void IrRead::loop() {
                 save_signal();
             }
         } else {
-            if (check(NextPress)) save_signal();
+            if (check(NextPress)) {
+                if (quickloop && !_read_signal) {
+                    button_pos++;
+                    if (button_pos < quickButtons.size()) begin();
+                } else {
+                    save_signal();
+                }
+            }
             if (quickloop && button_pos == quickButtons.size()) save_device();
             if (check(SelPress)) {
                 if (_read_signal) emulate_signal();
@@ -181,6 +190,7 @@ void IrRead::begin() {
     display_banner();
     if (quickloop) {
         padprintln("Waiting for signal of button: " + String(quickButtons[button_pos]));
+        padprintln("Button " + String(button_pos + 1) + " of " + String(quickButtons.size()));
     } else {
         padprintln("Waiting for signal...");
     }
@@ -220,6 +230,7 @@ void IrRead::display_btn_options() {
         padprintln("Press [NEXT] to save signal");
         padprintln("Press [PREV] to discard");
     } else {
+        if (quickloop) padprintln("Press [NEXT] to skip button");
         if (signals_read > 0) { padprintln("Press [OK]   to save device"); }
     }
     padprintln("Press [ESC]  to exit");
@@ -422,6 +433,12 @@ void IrRead::save_device() {
         displaySuccess("File saved to " + String((fs == &SD) ? "SD Card" : "LittleFS") + ".", true);
         signals_read = 0;
         strDeviceContent = "";
+        if (quickloop) {
+            button_pos = 0;
+            quickloop = false;
+            returnToMenu = true;
+            return;
+        }
     } else displayError(fs ? "Error writing file." : "No storage available.", true);
 
     delay(1000);


### PR DESCRIPTION
#### Proposed Changes ####

Add a **Skip** button for Quick Remote Setup in the IR module. When a template (TV/AC/FAN/etc.) lists a button that the user's remote doesn't have, they can now press **NEXT** to skip it and move to the next button.

Also add a progress indicator ("Button 3 of 12") so the user knows where they are in the list.

#### Types of Changes ####

- New feature (skip button in Quick Remote Setup)

#### Verification ####

1. Enter IR → Quick Remote Setup → pick a template (e.g. FAN)
2. On a button your remote doesn't have, press **NEXT** (→) to skip it
3. Observe progress indicator: "Button X of Y"
4. After all buttons are captured/skipped, enter filename, save → automatically returns to main menu

#### Testing ####

Tested on my DIY Reaper Board.

#### User-Facing Change ####

```release-note
IR Quick Remote Setup: press NEXT to skip a button, progress indicator added.
