### PR TITLE
fix(evil_portal): detect captive portal on Windows and Linux

### DIFF
--- a/src/modules/wifi/evil_portal.cpp
+++ b/src/modules/wifi/evil_portal.cpp
@@ -174,12 +174,16 @@ void EvilPortal::setupRoutes() {
         request->send(response);
     });
 
-    webServer.on("/ncsi.txt", HTTP_GET, [](AsyncWebServerRequest *request) {
-        request->send(200, "text/plain", "Microsoft NCSI");
+    webServer.on("/ncsi.txt", HTTP_GET, [this](AsyncWebServerRequest *request) {
+        AsyncWebServerResponse *response = request->beginResponse(302);
+        response->addHeader("Location", "http://" + WiFi.softAPIP().toString() + "/");
+        request->send(response);
     });
 
-    webServer.on("/connecttest.txt", HTTP_GET, [](AsyncWebServerRequest *request) {
-        request->send(200, "text/plain", "Microsoft Connect Test");
+    webServer.on("/connecttest.txt", HTTP_GET, [this](AsyncWebServerRequest *request) {
+        AsyncWebServerResponse *response = request->beginResponse(302);
+        response->addHeader("Location", "http://" + WiFi.softAPIP().toString() + "/");
+        request->send(response);
     });
 
     webServer.on("/redirect", HTTP_GET, [this](AsyncWebServerRequest *request) {
@@ -188,8 +192,10 @@ void EvilPortal::setupRoutes() {
         request->send(response);
     });
 
-    webServer.on("/success.txt", HTTP_GET, [](AsyncWebServerRequest *request) {
-        request->send(200, "text/plain", "success");
+    webServer.on("/success.txt", HTTP_GET, [this](AsyncWebServerRequest *request) {
+        AsyncWebServerResponse *response = request->beginResponse(302);
+        response->addHeader("Location", "http://" + WiFi.softAPIP().toString() + "/");
+        request->send(response);
     });
 
     webServer.on("/canonical.html", HTTP_GET, [this](AsyncWebServerRequest *request) {
@@ -204,8 +210,10 @@ void EvilPortal::setupRoutes() {
         request->send(response);
     });
 
-    webServer.on("/detectportal.firefox.com/success.txt", HTTP_GET, [](AsyncWebServerRequest *request) {
-        request->send(200, "text/plain", "success");
+    webServer.on("/detectportal.firefox.com/success.txt", HTTP_GET, [this](AsyncWebServerRequest *request) {
+        AsyncWebServerResponse *response = request->beginResponse(302);
+        response->addHeader("Location", "http://" + WiFi.softAPIP().toString() + "/");
+        request->send(response);
     });
 
     webServer.on("/client.msftconnecttest.com/redirect", HTTP_GET, [this](AsyncWebServerRequest *request) {
@@ -241,7 +249,10 @@ void EvilPortal::setupRoutes() {
         String url = request->url();
         if (url.indexOf("detectportal") != -1 || url.indexOf("connecttest") != -1 ||
             url.indexOf("success") != -1 || url.indexOf("generate") != -1 ||
-            url.indexOf("msftconnecttest") != -1 || url.indexOf("clients3.google.com") != -1) {
+            url.indexOf("msftconnecttest") != -1 || url.indexOf("clients3.google.com") != -1 ||
+            url.indexOf("ncsi") != -1 || url.indexOf("nmcheck") != -1 || url.indexOf("gnome") != -1 ||
+            url.indexOf("ubuntu") != -1 || url.indexOf("canonical") != -1 ||
+            url.indexOf("networkcheck") != -1 || url.indexOf("hotspot") != -1) {
             AsyncWebServerResponse *response = request->beginResponse(302);
             response->addHeader("Location", "http://" + WiFi.softAPIP().toString() + "/");
             request->send(response);
@@ -647,6 +658,14 @@ void EvilPortal::loadDefaultHtml() {
 }
 
 void EvilPortal::portalController(AsyncWebServerRequest *request) {
+    String apIp = WiFi.softAPIP().toString();
+    String host = request->host();
+    if (host.length() && host != apIp) {
+        AsyncWebServerResponse *response = request->beginResponse(302);
+        response->addHeader("Location", "http://" + apIp + "/");
+        request->send(response);
+        return;
+    }
     recordPageView();
     if (isDefaultHtml) request->send(200, "text/html", htmlPage);
     else { request->send(*fsHtmlFile, htmlFileName, "text/html"); }


### PR DESCRIPTION
#### Proposed Changes ####

Makes the Evil Portal captive-portal detection work on Windows and Linux, not just Android.

Only Android's `/generate_204` probe was being redirected. Windows and Linux hit their own connectivity-check endpoints, got the "you're online" answer, and so never opened the sign-in page:

- `/ncsi.txt`, `/connecttest.txt` and `/success.txt` returned the expected bodies (`Microsoft NCSI` / `Microsoft Connect Test` / `success`), so Windows and Firefox/Linux thought the network had real internet.
- The Ubuntu/NetworkManager probe reaches `/` carrying the original domain in the `Host` header and was served the portal HTML with `200`, which isn't reliably read as a captive portal.

What changed:

- `/ncsi.txt`, `/connecttest.txt`, `/success.txt` and the Firefox success probe now return `302` to the AP instead of `200`.
- `portalController`: requests whose `Host` header is a domain name (not the AP IP) are treated as OS connectivity probes and get a `302` to the portal; real page loads (`Host` = AP IP) still receive the HTML.
- `onNotFound`: broadened the redirected-probe keywords (`ncsi`, `nmcheck`, `gnome`, `ubuntu`, `canonical`, `networkcheck`, `hotspot`).

#### Types of Changes ####

Bugfix.

#### Verification ####

Start an Evil Portal, connect a client to the AP, and the OS should offer the captive-portal sign-in instead of reporting normal internet access.

- **Windows 11**: the portal opens automatically on connect.
- **Android, iOS and Linux (GNOME/Zorin)**: a captive-portal sign-in notification appears and opens the portal once tapped.
- **macOS**: could not be tested, no device available.

#### Testing ####

Manually tested on a LilyGO T-Embed CC1101 across the devices listed above. No automated test added.

#### Linked Issues ####

Closes #2646

#### User-Facing Change ####

```release-note
Evil Portal now triggers the captive-portal sign-in on Windows and Linux, not only Android.
