### PR TITLE
fix(rf): smoother Custom SubGhz sending (keep folder + no key-press wait)

### DIFF
--- a/src/modules/rf/rf_send.cpp
+++ b/src/modules/rf/rf_send.cpp
@@ -338,7 +338,7 @@ bool txSubFile(RfCodes &selected_code, bool hideDefaultUI) {
     }
 
     Serial.printf("\nSent %d of %d signals\n", sent, total);
-    if (!hideDefaultUI) { displayTextLine("Sent " + String(sent) + "/" + String(total), true); }
+    if (!hideDefaultUI) { displayTextLine("Sent " + String(sent) + "/" + String(total), false); }
 
     // Reset vectors
     bitList.clear();

--- a/src/modules/rf/rf_send.cpp
+++ b/src/modules/rf/rf_send.cpp
@@ -44,12 +44,17 @@ void sendCustomRF() {
     returnToMenu = false;
     filepath = "";
 
+    String startPath = "/BruceRF";
+
     while (!returnToMenu) {
         num_steps_keeloq = 1;
         num_signal_repeat = 4;
         delay(200);
-        filepath = loopSD(*filesystem, true, "SUB", "/BruceRF");
+        filepath = loopSD(*filesystem, true, "SUB", startPath);
         if (filepath == "" || check(EscPress)) return; //  cancelled
+
+        startPath = filepath.substring(0, filepath.lastIndexOf("/"));
+        if (startPath == "") startPath = "/";
 
         RfCodes data{};
 


### PR DESCRIPTION
#### Proposed Changes ####

Two small but annoying usability issues in the Custom SubGhz (RF) file sending flow. If you send several signals from the same device folder, both of them add up and make it a pretty tedious job.

**1. The picker jumps back to the root after every send.**

In `sendCustomRF` the file picker is opened in a loop with a hardcoded root path:

```cpp
filepath = loopSD(*filesystem, true, "SUB", "/BruceRF");
```

So every time you send a .sub and the loop comes back around, it drops you at /BruceRF again and you have to re-navigate the whole tree (brand -> model -> …) just to send another signal from the same device. Now it remembers the folder of the last selected file and reopens the picker there. You can still go back up to other folders with the picker's back entry. This is the same approach already used by Custom IR (custom_ir.cpp), which doesn't have this problem.

**2. The "Sent x/x" message is confusing and blocks on a key press.**

After transmitting, txSubFile shows "Sent x/x" with displayTextLine(..., true), and that true makes it block until you press any key. The full sequence was: a short wait, then it blocks waiting for a key press, and then another wait after you press before the message finally clears. Because nothing happened right when you pressed, you couldn't really tell if the button was doing anything.

RF transmission is instant and the result is already on screen, so this manual confirmation isn't adding anything. Dropping the key-press wait lets the picker reopen on its own after briefly showing "Sent x/x".

### Types of Changes ###

Bugfix.

### Verification ###

RF -> Custom SubGhz -> SD Card -> navigate into a subfolder -> select and send a .sub. The "Sent" message clears on its own after 1s aprox and the picker reopens in the same subfolder, ready to send another signal without re-navigating or pressing anything.

### Testing ###

Manually tested on a LilyGO T-Embed CC1101.

### Linked Issues ###

Refs #852, reported the folder-jumping behaviour and was closed as completed, but the bug is still present in dev (regression).

### User-Facing Change ###

```release-note
Custom SubGhz sending now stays in the current folder and no longer waits for a button press after each signal.
```