### PR TITLE
fix(menu): let Hide/Show Apps re-enable a hidden menu again

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "mifare_keys_manager.h"
 #include "sd_functions.h"
+#include <algorithm>
 
 JsonDocument BruceConfig::toJson() const {
     JsonDocument jsonDoc;
@@ -824,8 +825,15 @@ void BruceConfig::validateMifareKeysItems() {
 }
 
 void BruceConfig::addDisabledMenu(String value) {
-    // TODO: check if duplicate
+    if (std::find(disabledMenus.begin(), disabledMenus.end(), value) != disabledMenus.end()) return;
     disabledMenus.push_back(value);
+    saveFile();
+}
+
+void BruceConfig::removeDisabledMenu(String value) {
+    auto it = std::find(disabledMenus.begin(), disabledMenus.end(), value);
+    if (it == disabledMenus.end()) return;
+    disabledMenus.erase(it);
     saveFile();
 }
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -198,7 +198,7 @@ public:
     void validateBadUSBBLEKeyDelay();
     void setBadUSBBLEShowOutput(bool value);
     void addDisabledMenu(String value);
-    // TODO: removeDisabledMenu(String value);
+    void removeDisabledMenu(String value);
 
     void addWebUISession(const String &token);
     void removeWebUISession(const String &token);

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -76,17 +76,25 @@ void MainMenu::begin(void) {
 
 void MainMenu::hideAppsMenu() {
     auto items = this->getItems();
+    int index = 0;
 RESTART: // using gotos to avoid stackoverflow after many choices
     options.clear();
     for (auto item : items) {
         String label = item->getName();
         std::vector<String> l = bruceConfig.disabledMenus;
         bool enabled = find(l.begin(), l.end(), label) == l.end();
-        options.push_back({label, [this, label]() { bruceConfig.addDisabledMenu(label); }, enabled});
+        options.push_back(
+            {label,
+             [this, label, enabled]() {
+                 if (enabled) bruceConfig.addDisabledMenu(label);
+                 else bruceConfig.removeDisabledMenu(label);
+             },
+             enabled}
+        );
     }
     options.push_back({"Show All", [=]() { bruceConfig.disabledMenus.clear(); }, true});
     addOptionToMainMenu();
-    loopOptions(options);
+    index = loopOptions(options, index);
     bruceConfig.saveFile();
     if (!returnToMenu) goto RESTART;
 }


### PR DESCRIPTION
The Hide/Show Apps menu could only ever disable entries: selecting any item always called addDisabledMenu(), so a hidden menu could not be re-enabled individually. addDisabledMenu() also had no duplicate check, so re-selecting a hidden menu appended it again.

- Implement removeDisabledMenu() and make addDisabledMenu() skip duplicates.
- Toggle the entry on selection: enable -> disable, disabled -> enable.
- Keep the cursor on the toggled entry when the list is rebuilt, instead of jumping back to the top on every change.

#### Proposed Changes ####

The Hide/Show Apps menu could only ever disable entries: selecting any item
always called `addDisabledMenu()`, so a hidden menu could not be re-enabled
individually, only "Show All" could bring everything back. `addDisabledMenu()`
also had no duplicate check, so re-selecting a hidden menu appended it again,
leaving duplicate entries in `disabledMenus` (visible in `bruce.conf`).

- Implement `removeDisabledMenu()` and make `addDisabledMenu()` skip duplicates.
- Toggle the entry on selection: enabled -> disable, disabled -> enable.
- Keep the cursor on the toggled entry when the list is rebuilt, instead of
  jumping back to the top on every change.

#### Types of Changes ####

Bugfix (with a small UX improvement).

#### Verification ####

On a LilyGo T-Embed CC1101: Config -> Hide/Show Apps.
- Disable a menu, then select it again -> it is re-enabled (previously it stayed
  hidden forever unless "Show All" was used).
- Toggle the same menu several times -> `disabledMenus` in `bruce.conf` no longer
  accumulates duplicates.
- After toggling an entry, the cursor stays on that entry instead of jumping back
  to the top of the list.
- "Show All" and exiting via "Main Menu" still work as before.
- Hidden menus are absent from the main menu and re-enabled ones reappear.

#### Testing ####

Verified manually on hardware as described above, also, the bruce.conf file works fine with these new changes not adding dupplicate entries and deleting the corresponding ones.

#### Linked Issues ####

None.

#### User-Facing Change ####
```release-note
Fixed the Hide/Show Apps menu so a hidden app can be re-enabled individually,
because previously only "Show All" could restore it, and it no longer stores duplicate entries.
```

#### Further Comments ####

None.
