### PR TITLE
feat(boards): add LilyGO TTGO T4 v1.3 support

### DIFF
--- a/.github/workflows/PR_All_envs.yml
+++ b/.github/workflows/PR_All_envs.yml
@@ -52,6 +52,7 @@ jobs:
           - { env: "lilygo-t-display-s3-touch-mmc",   family: "ESP32-S3",}
           - { env: "lilygo-t-display-S3-pro",         family: "ESP32-S3",}
           - { env: "lilygo-t-display-ttgo",           family: "ESP32",}
+          - { env: "lilygo-t4",                       family: "ESP32",}
           - { env: "lilygo-t-hmi",                    family: "ESP32-S3",}
           - { env: "lilygo-t-lora-pager",             family: "ESP32-S3",}
           - { env: "smoochiee-board",                 family: "ESP32-S3",}

--- a/.github/workflows/buil_parallel.yml
+++ b/.github/workflows/buil_parallel.yml
@@ -74,6 +74,7 @@ jobs:
           - { env: "lilygo-t-display-s3-touch-mmc",   family: "ESP32-S3",}
           - { env: "lilygo-t-display-S3-pro",         family: "ESP32-S3",}
           - { env: "lilygo-t-display-ttgo",           family: "ESP32",}
+          - { env: "lilygo-t4",                       family: "ESP32",}
           - { env: "lilygo-t-hmi",                    family: "ESP32-S3",}
           - { env: "lilygo-t-lora-pager",             family: "ESP32-S3",}
           - { env: "elecrow-24B",                     family: "ESP32",}

--- a/.github/workflows/manual_build_sel_env.yml
+++ b/.github/workflows/manual_build_sel_env.yml
@@ -49,6 +49,7 @@ on:
           - "lilygo-t-display-s3-touch-mmc"
           - "lilygo-t-display-s3-pro"
           - "lilygo-t-display-ttgo"
+          - "lilygo-t4"
           - "lilygo-t-hmi"
           - "lilygo-t-lora-pager"
           - "smoochiee-board"

--- a/boards/_boards_json/lilygo-t4.json
+++ b/boards/_boards_json/lilygo-t4.json
@@ -1,0 +1,42 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32_DEV",
+      "-DLILYGO_T4",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "pinouts"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "LilyGO TTGO T4 v1.3",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "http://www.lilygo.cn/",
+  "vendor": "LilyGO"
+}

--- a/boards/lilygo-t4/connections.md
+++ b/boards/lilygo-t4/connections.md
@@ -1,0 +1,46 @@
+# LilyGO TTGO T4 v1.3 — Pinouts to use Bruce
+
+ESP32-WROVER board with a 2.4" ILI9341 320x240 SPI display, a microSD slot and
+three front buttons. The display and the SD card sit on **two separate SPI
+buses**.
+
+## Display (ILI9341, VSPI)
+
+| Signal | MOSI | MISO | SCLK | CS | DC | RST | BL |
+| ---    | :--: | :--: | :--: | :-:| :-:| :-: | :-:|
+| TFT    | 23   | 12   | 18   | 27 | 32 |  5  |  4 |
+
+## SD Card (HSPI)
+
+| Device  | SCK | MISO | MOSI | CS |
+| ---     | :-: | :--: | :--: | :-:|
+| SD Card | 14  |  2   | 15   | 13 |
+
+## Buttons (active LOW, on input-only GPIOs with external pull-ups)
+
+| Button | GPIO | Action                                   |
+| ---    | :--: | ---                                      |
+| LEFT   | 38   | Previous / Up                            |
+| CENTER | 37   | Select (click), Escape (double / hold)   |
+| RIGHT  | 39   | Next / Down                              |
+
+## I2C (Grove) — FM Radio, PN532, other I2C devices
+
+| Signal | SDA | SCL |
+| ---    | :-: | :-: |
+| I2C    | 21  | 22  |
+
+## External RF modules (no module fitted by default)
+
+`ALLOW_ALL_GPIO_FOR_IR_RF` is enabled, so IR/RF pins can be chosen at runtime.
+Suggested defaults on free GPIOs:
+
+| Device | SCK | MISO | MOSI | CS/SS | GDO0/CE |
+| ---    | :-: | :--: | :--: | :---: | :-----: |
+| CC1101 | 25  | 33   | 26   | 17    | 34      |
+| NRF24  | 25  | 33   | 26   | 17    | 35      |
+
+IR TX default: 26 · IR RX default: 25
+
+Free GPIOs available for single-pin modules (FS1000A, IR LED/receiver, etc.):
+17, 25, 26, 33 and the input-only pins 34/35/36.

--- a/boards/lilygo-t4/interface.cpp
+++ b/boards/lilygo-t4/interface.cpp
@@ -1,0 +1,138 @@
+#include "core/powerSave.h"
+#include "core/utils.h"
+#include <Button.h>
+
+#include <globals.h>
+#include <interface.h>
+
+volatile bool nxtPress = false;
+volatile bool prvPress = false;
+volatile bool ecPress = false;
+volatile bool slPress = false;
+
+// LEFT (UP_BTN) -> Previous
+static void onPrevSingleClickCb(void *button_handle, void *usr_data) { prvPress = true; }
+// RIGHT (DW_BTN) -> Next
+static void onNextSingleClickCb(void *button_handle, void *usr_data) { nxtPress = true; }
+// CENTER (SEL_BTN) -> Select on click, Escape on double-click or hold
+static void onSelSingleClickCb(void *button_handle, void *usr_data) { slPress = true; }
+static void onSelDoubleClickCb(void *button_handle, void *usr_data) { ecPress = true; }
+static void onSelHoldCb(void *button_handle, void *usr_data) { ecPress = true; }
+
+Button *btnPrev;
+Button *btnNext;
+Button *btnSel;
+
+/***************************************************************************************
+** Function name: _setup_gpio()
+** Description:   initial setup for the device
+***************************************************************************************/
+void _setup_gpio() {
+    // The three front buttons are on ESP32 input-only GPIOs (37/38/39), which
+    // cannot use the internal pull-ups - the T4 board provides external ones,
+    // so they are configured as plain INPUT and read as active LOW.
+    pinMode(UP_BTN, INPUT);
+    pinMode(DW_BTN, INPUT);
+    pinMode(SEL_BTN, INPUT);
+
+    button_config_t btPrev = {
+        .type = BUTTON_TYPE_GPIO,
+        .long_press_time = 600,
+        .short_press_time = 120,
+        .gpio_button_config =
+            {
+                       .gpio_num = UP_BTN,
+                       .active_level = 0,
+                       },
+    };
+    button_config_t btNext = {
+        .type = BUTTON_TYPE_GPIO,
+        .long_press_time = 600,
+        .short_press_time = 120,
+        .gpio_button_config =
+            {
+                       .gpio_num = DW_BTN,
+                       .active_level = 0,
+                       },
+    };
+    button_config_t btSel = {
+        .type = BUTTON_TYPE_GPIO,
+        .long_press_time = 600,
+        .short_press_time = 120,
+        .gpio_button_config =
+            {
+                       .gpio_num = SEL_BTN,
+                       .active_level = 0,
+                       },
+    };
+
+    btnPrev = new Button(btPrev);
+    btnPrev->attachSingleClickEventCb(&onPrevSingleClickCb, NULL);
+
+    btnNext = new Button(btNext);
+    btnNext->attachSingleClickEventCb(&onNextSingleClickCb, NULL);
+
+    btnSel = new Button(btSel);
+    btnSel->attachSingleClickEventCb(&onSelSingleClickCb, NULL);
+    btnSel->attachDoubleClickEventCb(&onSelDoubleClickCb, NULL);
+    btnSel->attachLongPressStartEventCb(&onSelHoldCb, NULL);
+
+    // Start with default IR and RF configs; the T4 has no on-board modules.
+    bruceConfigPins.irRx = RXLED;
+    bruceConfigPins.irTx = TXLED;
+
+    Serial.begin(115200);
+}
+
+/*********************************************************************
+**  Function: setBrightness
+**  set brightness value
+**********************************************************************/
+void _setBrightness(uint8_t brightval) {
+    if (brightval == 0) {
+        analogWrite(TFT_BL, brightval);
+    } else {
+        int bl = MINBRIGHT + round(((255 - MINBRIGHT) * brightval / 100));
+        analogWrite(TFT_BL, bl);
+    }
+}
+
+/*********************************************************************
+** Function: InputHandler
+** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
+**********************************************************************/
+void InputHandler(void) {
+    static unsigned long tm = 0;
+    static bool btn_pressed = false;
+    if (nxtPress || prvPress || ecPress || slPress) btn_pressed = true;
+
+    if (millis() - tm > 200 || LongPress) {
+        if (btn_pressed) {
+            btn_pressed = false;
+            tm = millis();
+            if (!wakeUpScreen()) AnyKeyPress = true;
+            else return;
+            SelPress = slPress;
+            EscPress = ecPress;
+            NextPress = nxtPress;
+            PrevPress = prvPress;
+
+            nxtPress = false;
+            prvPress = false;
+            ecPress = false;
+            slPress = false;
+        }
+    }
+}
+
+/*********************************************************************
+** Function: powerOff
+** Turns off the device (deep sleep, wake on the center button)
+**********************************************************************/
+void powerOff() {
+    tft.fillScreen(bruceConfig.bgColor);
+    digitalWrite(TFT_BL, LOW);
+    tft.writecommand(0x10); // ILI9341 enter sleep
+    esp_sleep_enable_ext0_wakeup((gpio_num_t)SEL_BTN, BTN_ACT);
+    esp_deep_sleep_start();
+}

--- a/boards/lilygo-t4/lilygo-t4.ini
+++ b/boards/lilygo-t4/lilygo-t4.ini
@@ -13,6 +13,10 @@ build_flags =
 	-DDISABLE_ALL_LIBRARY_WARNINGS
 	-DDEVICE_NAME='"Lilygo T4 v1.3"'
 
+	; This T4 ILI9341 panel renders correctly without color inversion,
+	; unlike most Bruce panels which default to inverted.
+	-DDEFAULT_COLOR_INVERTED=0
+
 lib_deps =
 	${env.lib_deps}
 	https://github.com/bmorcelli/ESP32_Button

--- a/boards/lilygo-t4/lilygo-t4.ini
+++ b/boards/lilygo-t4/lilygo-t4.ini
@@ -1,0 +1,21 @@
+[env:lilygo-t4]
+board = lilygo-t4
+board_build.partitions = custom_4Mb_full.csv
+build_src_filter =${env.build_src_filter} +<../boards/lilygo-t4>
+build_flags =
+	${env.build_flags}
+	${env_4mb.build_flags}
+	-Iboards/lilygo-t4
+	-DREDRAW_DELAY=1 # Used to improve navigation on menus for this device
+
+	-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+
+	-DDISABLE_ALL_LIBRARY_WARNINGS
+	-DDEVICE_NAME='"Lilygo T4 v1.3"'
+
+lib_deps =
+	${env.lib_deps}
+	https://github.com/bmorcelli/ESP32_Button
+
+lib_ignore =
+	${env_4mb.lib_ignore}

--- a/boards/lilygo-t4/pins_arduino.h
+++ b/boards/lilygo-t4/pins_arduino.h
@@ -73,7 +73,7 @@ static const uint8_t SCK = SPI_SCK_PIN;
 
 // ------------------------------------------------------------------ Display setup
 #define HAS_SCREEN
-#define ROTATION 0 // Portrait, buttons at the bottom edge
+#define ROTATION 1 // Landscape, buttons on the right edge
 #define MINBRIGHT (uint8_t)1
 
 // Font sizes

--- a/boards/lilygo-t4/pins_arduino.h
+++ b/boards/lilygo-t4/pins_arduino.h
@@ -1,0 +1,112 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+// LilyGO TTGO T4 v1.3 (ESP32-WROVER, 2.4" ILI9341 320x240, microSD, 3 buttons)
+// Display and SD live on two separate SPI buses:
+//   * TFT  -> VSPI  (MOSI 23, MISO 12, SCLK 18)
+//   * SD   -> HSPI  (MOSI 15, MISO  2, SCLK 14)
+
+// ------------------------------------------------------------------ Battery
+// The T4 v1.3 has no dedicated on-board battery ADC divider, so getBattery()
+// falls back to the shared default implementation in the core.
+
+// ------------------------------------------------------------------ Main I2C (Grove)
+#define GROVE_SDA 21
+#define GROVE_SCL 22
+static const uint8_t SDA = GROVE_SDA;
+static const uint8_t SCL = GROVE_SCL;
+
+// ------------------------------------------------------------------ Secondary SPI (external RF modules)
+// No RF module is fitted on the T4; these are sane defaults on free GPIOs so
+// CC1101 / NRF24 modules can be wired manually. ALLOW_ALL_GPIO_FOR_IR_RF lets
+// the user re-map any of these at runtime.
+#define SPI_SCK_PIN 25
+#define SPI_MOSI_PIN 26
+#define SPI_MISO_PIN 33
+#define SPI_SS_PIN 17
+
+// Arduino default SPI globals (used by a bare SPI.begin())
+static const uint8_t SS = SPI_SS_PIN;
+static const uint8_t MOSI = SPI_MOSI_PIN;
+static const uint8_t MISO = SPI_MISO_PIN;
+static const uint8_t SCK = SPI_SCK_PIN;
+
+#define USE_CC1101_VIA_SPI
+#define CC1101_GDO0_PIN 34 // input-only, fine for GDO0 (input)
+#define CC1101_SS_PIN SPI_SS_PIN
+#define CC1101_MOSI_PIN SPI_MOSI_PIN
+#define CC1101_SCK_PIN SPI_SCK_PIN
+#define CC1101_MISO_PIN SPI_MISO_PIN
+
+#define USE_NRF24_VIA_SPI
+#define NRF24_CE_PIN 35 // input-only, fine for CE (input)
+#define NRF24_SS_PIN SPI_SS_PIN
+#define NRF24_MOSI_PIN SPI_MOSI_PIN
+#define NRF24_SCK_PIN SPI_SCK_PIN
+#define NRF24_MISO_PIN SPI_MISO_PIN
+
+// ------------------------------------------------------------------ SD card (HSPI)
+#define SDCARD_CS 13
+#define SDCARD_SCK 14
+#define SDCARD_MISO 2
+#define SDCARD_MOSI 15
+
+// ------------------------------------------------------------------ TFT_eSPI display (ILI9341, VSPI)
+#define USER_SETUP_LOADED
+#define ILI9341_DRIVER
+#define TFT_WIDTH 240
+#define TFT_HEIGHT 320
+#define TFT_MISO 12
+#define TFT_MOSI 23
+#define TFT_SCLK 18
+#define TFT_CS 27
+#define TFT_DC 32
+#define TFT_RST 5
+#define TFT_BL 4              // Display backlight control pin
+#define TFT_BACKLIGHT_ON HIGH // HIGH or LOW are options
+#define SMOOTH_FONT 1
+#define SPI_FREQUENCY 40000000     // Maximum for ILI9341
+#define SPI_READ_FREQUENCY 16000000
+
+// ------------------------------------------------------------------ Display setup
+#define HAS_SCREEN
+#define ROTATION 0 // Portrait, buttons at the bottom edge
+#define MINBRIGHT (uint8_t)1
+
+// Font sizes
+#define FP 1
+#define FM 2
+#define FG 3
+
+// ------------------------------------------------------------------ Serial / GPS / BadUSB
+// Default to the Grove pins; can be re-mapped from Bruce's settings.
+#define SERIAL_TX GROVE_SDA
+#define SERIAL_RX GROVE_SCL
+#define GPS_SERIAL_TX SERIAL_TX
+#define GPS_SERIAL_RX SERIAL_RX
+#define BAD_TX GROVE_SDA
+#define BAD_RX GROVE_SCL
+
+// ------------------------------------------------------------------ Buttons & navigation
+// The three front buttons sit on ESP32 input-only GPIOs (34-39), so they rely
+// on the board's external pull-ups and are active LOW. See interface.cpp.
+//   LEFT   (38) -> Previous / Up
+//   CENTER (37) -> Select (click) / Escape (double-click or hold)
+//   RIGHT  (39) -> Next / Down
+#define BTN_ALIAS "\"Sel\""
+#define HAS_3_BUTTONS
+#define UP_BTN 38
+#define SEL_BTN 37
+#define DW_BTN 39
+#define BTN_ACT LOW
+
+// ------------------------------------------------------------------ IR default pins
+#define TXLED 26
+#define RXLED 25
+#define LED_ON HIGH
+#define LED_OFF LOW
+
+#endif /* Pins_Arduino_h */

--- a/boards/pinouts/pins_arduino.h
+++ b/boards/pinouts/pins_arduino.h
@@ -40,6 +40,8 @@
 #include "../lilygo-t-display-s3-pro/pins_arduino.h"
 #elif TTGO
 #include "../lilygo-t-display-ttgo/pins_arduino.h"
+#elif LILYGO_T4
+#include "../lilygo-t4/pins_arduino.h"
 #elif MARAUDER_TOUCH
 #include "../marauder-touch/pins_arduino.h"
 #elif MARAUDER_MINI

--- a/docker/run_all_envs.sh
+++ b/docker/run_all_envs.sh
@@ -40,6 +40,7 @@ DEFAULT_ENVS=(
   lilygo-t-display-s3-touch-mmc
   lilygo-t-display-S3-pro
   lilygo-t-display-ttgo
+  lilygo-t4
   lilygo-t-hmi
   lilygo-t-lora-pager
   elecrow-24B

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,7 @@ default_envs =
 	;lilygo-t-display-s3-touch-mmc
 	;lilygo-t-display-S3-pro
 	;lilygo-t-display-ttgo
+	;lilygo-t4
 	;lilygo-t-hmi
 	;lilygo-t-lora-pager
 	;smoochiee-board

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -9,6 +9,12 @@
 #include <set>
 #include <vector>
 
+// Most panels want the framebuffer inverted; boards whose panel does not
+// (e.g. the LilyGO T4 ILI9341) can override this default from their build flags.
+#ifndef DEFAULT_COLOR_INVERTED
+#define DEFAULT_COLOR_INVERTED 1
+#endif
+
 enum EvilPortalPasswordMode { FULL_PASSWORD = 0, FIRST_LAST_CHAR = 1, HIDE_PASSWORD = 2, SAVE_LENGTH = 3 };
 
 class BruceConfig : public BruceTheme {
@@ -86,7 +92,7 @@ public:
     String wigleBasicToken = "";
     String wdgwarsApiKey = "your 64-char hex key from wdgwars.pl/profile";
     int devMode = 0;
-    int colorInverted = 1;
+    int colorInverted = DEFAULT_COLOR_INVERTED;
     int badUSBBLEKeyboardLayout = 0;
     uint16_t badUSBBLEKeyDelay = 10;
     bool badUSBBLEShowOutput = true;


### PR DESCRIPTION
## Summary

Adds a board target for the **LilyGO TTGO T4 v1.3** — ESP32-WROVER with a 2.4″ ILI9341 320×240 SPI display, microSD slot and three front buttons. There was no existing T4 target (the closest, `lilygo-t-display-ttgo`, is a different ST7789 135×240 device).

## ✅ Tested on real hardware

This board target was flashed to and verified on a physical **LilyGO TTGO T4 v1.3**:

- Boots straight into the Bruce menu (replacing the factory demo firmware).
- Display renders full-screen in landscape with the correct Bruce theme colors (dark background, purple/pink accents).
- All three front buttons navigate the menu.
- Flashed via `esptool --chip esp32 write_flash -z 0x0 Bruce-lilygo-t4.bin` after a full `erase_flash`.

The two follow-up commits (color inversion + rotation) are the corrections found during this on-device bring-up.

## What's included

- `boards/lilygo-t4/pins_arduino.h` — full pin map, ILI9341, landscape `ROTATION 1`
- `boards/lilygo-t4/interface.cpp` — 3-button navigation (top = previous, middle = select / escape on double-click or hold, bottom = next), backlight PWM, deep-sleep power-off with wake on the middle button
- `boards/lilygo-t4/lilygo-t4.ini` — PlatformIO env (4 MB, `custom_4Mb_full.csv`)
- `boards/lilygo-t4/connections.md` — pinout documentation
- `boards/_boards_json/lilygo-t4.json` — ESP32 board definition (`-DLILYGO_T4`)
- `boards/pinouts/pins_arduino.h` — dispatcher branch for `LILYGO_T4`
- Registered `lilygo-t4` in `platformio.ini`, `PR_All_envs.yml`, `buil_parallel.yml`, `manual_build_sel_env.yml` and `docker/run_all_envs.sh`

## One small core change

`src/core/config.h` gains an overridable default:

```c
#ifndef DEFAULT_COLOR_INVERTED
#define DEFAULT_COLOR_INVERTED 1
#endif
...
int colorInverted = DEFAULT_COLOR_INVERTED;
```

`begin_tft()` applies `tft.invertDisplay(bruceConfig.colorInverted)` at runtime, so a compile-time TFT setup alone can't fix a panel that shouldn't be inverted. The default stays `1` for every existing board; this T4 panel sets `-DDEFAULT_COLOR_INVERTED=0` in its `.ini`. Without it the T4 renders with a white background and green accents.

## Pin map

| Function | Pins |
| --- | --- |
| TFT (ILI9341, VSPI) | MOSI 23, MISO 12, SCLK 18, CS 27, DC 32, RST 5, BL 4 (active HIGH), 240×320, `ROTATION 1` |
| SD card (HSPI) | CS 13, SCK 14, MISO 2, MOSI 15 |
| Buttons (active LOW) | 38, 37, 39 |
| I2C (Grove) | SDA 21, SCL 22 |

The three buttons sit on ESP32 input-only GPIOs (37/38/39), which cannot use internal pull-ups — they rely on the board's external pull-ups and are read as active LOW.

Pins were cross-checked against the official [LilyGO TTGO-T4-DEMO](https://github.com/LilyGO/TTGO-T4-DEMO) and the TFT_eSPI `Setup22_TTGO_T4_v1.3` profile.

## Build

`pio run -e lilygo-t4` builds clean — Flash 85.3%, RAM 30.5%, produces `Bruce-lilygo-t4.bin`.