### PR TITLE
fix(nrf24): recover auxiliary SPI after failed probe

### DIFF
--- a/src/core/bus_HAL.cpp
+++ b/src/core/bus_HAL.cpp
@@ -336,3 +336,16 @@ SPIClass *acquireSPIBus(gpio_num_t sck, gpio_num_t miso, gpio_num_t mosi) {
     // SPI controller, shared across every other peripheral one owner at a time.
     return acquireSharedSPI(sck, miso, mosi);
 }
+
+bool restartAuxSPIBus(SPIClass *bus, gpio_num_t sck, gpio_num_t miso, gpio_num_t mosi) {
+    if (bus != &AUX_SPI) return false;
+    if (sck == GPIO_NUM_NC || miso == GPIO_NUM_NC || mosi == GPIO_NUM_NC) return false;
+
+    AUX_SPI.end();
+    delay(2);
+    AUX_SPI.begin((int8_t)sck, (int8_t)miso, (int8_t)mosi);
+    sharedSpiSck = sck;
+    sharedSpiMiso = miso;
+    sharedSpiMosi = mosi;
+    return true;
+}

--- a/src/core/bus_HAL.h
+++ b/src/core/bus_HAL.h
@@ -80,3 +80,8 @@ bool trylockSysI2CBus();
 // bus only when the requested pins differ from whoever last used it). Returns nullptr if sck,
 // miso or mosi is unset, or if the pins matched the display's bus but the board is headless.
 SPIClass *acquireSPIBus(gpio_num_t sck, gpio_num_t miso, gpio_num_t mosi);
+
+// Reinitializes the auxiliary SPI controller on the requested pins. This is intended as a
+// recovery path for peripherals whose first probe failed after another driver previously owned
+// the auxiliary controller. Display/SD buses are never reset by this function.
+bool restartAuxSPIBus(SPIClass *bus, gpio_num_t sck, gpio_num_t miso, gpio_num_t mosi);

--- a/src/modules/NRF24/nrf_common.cpp
+++ b/src/modules/NRF24/nrf_common.cpp
@@ -60,15 +60,46 @@ bool nrf_start(NRF24_MODE mode) {
     }
     delay(10);
 
-    if (NRFradio.begin(
-            NRFSPI,
-            rf24_gpio_pin_t(bruceConfigPins.NRF24_bus.io0),
-            rf24_gpio_pin_t(bruceConfigPins.NRF24_bus.cs)
-        )) {
-        result = true;
-    } else {
+    const rf24_gpio_pin_t ce = rf24_gpio_pin_t(bruceConfigPins.NRF24_bus.io0);
+    const rf24_gpio_pin_t cs = rf24_gpio_pin_t(bruceConfigPins.NRF24_bus.cs);
+
+    result = NRFradio.begin(NRFSPI, ce, cs);
+    if (!result && restartAuxSPIBus(
+                       NRFSPI,
+                       bruceConfigPins.NRF24_bus.sck,
+                       bruceConfigPins.NRF24_bus.miso,
+                       bruceConfigPins.NRF24_bus.mosi
+                   )) {
+        // M5StickC Plus/Plus2 legacy modules share the auxiliary controller with CC1101.
+        // Reclaiming the same pin tuple used to skip begin(), even when the previous owner had
+        // left the controller or GPIO matrix unusable. A clean controller restart makes the
+        // probe deterministic without replacing any of the newer NRF24 feature code.
+        pinMode(bruceConfigPins.NRF24_bus.cs, OUTPUT);
+        digitalWrite(bruceConfigPins.NRF24_bus.cs, HIGH);
+        pinMode(bruceConfigPins.NRF24_bus.io0, OUTPUT);
+        digitalWrite(bruceConfigPins.NRF24_bus.io0, LOW);
+        delay(10);
+        result = NRFradio.begin(NRFSPI, ce, cs);
+    }
+    if (!result) {
+        Serial.printf(
+            "NRF24 probe failed (SCK=%d MISO=%d MOSI=%d CS=%d CE=%d)\n",
+            (int)bruceConfigPins.NRF24_bus.sck,
+            (int)bruceConfigPins.NRF24_bus.miso,
+            (int)bruceConfigPins.NRF24_bus.mosi,
+            (int)bruceConfigPins.NRF24_bus.cs,
+            (int)bruceConfigPins.NRF24_bus.io0
+        );
         return false;
     }
+    Serial.printf(
+        "NRF24 detected (SCK=%d MISO=%d MOSI=%d CS=%d CE=%d)\n",
+        (int)bruceConfigPins.NRF24_bus.sck,
+        (int)bruceConfigPins.NRF24_bus.miso,
+        (int)bruceConfigPins.NRF24_bus.mosi,
+        (int)bruceConfigPins.NRF24_bus.cs,
+        (int)bruceConfigPins.NRF24_bus.io0
+    );
     return result;
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

Retry a failed NRF24 probe after cleanly restarting the auxiliary SPI controller. The recovery helper only accepts the auxiliary bus, so display and SD buses are never reset. Also emit the resolved NRF24 pin tuple on probe success or failure to make hardware reports easier to diagnose.

This fixes a regression on the M5StickC Plus2 legacy NRF24 connection where 1.14 worked but 1.15+ and dev reported "NRF24 not found".

#### Types of Changes ####

Bugfix.

#### Verification ####

Tested on a physical M5StickC Plus2 with an NRF24L01 connected through the legacy pin mapping:

- SCK: GPIO 0
- MISO: GPIO 33
- MOSI: GPIO 32
- CS: GPIO 26
- CE: GPIO 25

The radio was detected successfully in Spectrum and again in MouseJack after leaving and re-entering NRF24 tools. The flashed image was verified by esptool.

#### Testing ####

- uv tool run platformio run -e m5stack-cplus2
- Physical Spectrum startup and exit
- Physical MouseJack scan startup and exit
- Repeated NRF24 initialization across tool changes

#### Linked Issues ####

Related to #1655.

#### User-Facing Change ####

```release-note
Fix NRF24 detection on M5StickC Plus/Plus2 legacy auxiliary SPI connections.
```

#### Further Comments ####

The first probe is retained. The auxiliary SPI restart is only used as a recovery path after that probe fails.