### PR TITLE
fix: ScrollableTextArea exit not responding to key press

### DIFF
--- a/src/core/scrollableTextArea.cpp
+++ b/src/core/scrollableTextArea.cpp
@@ -73,12 +73,14 @@ size_t ScrollableTextArea::getMaxLines() { return linesBuffer.size(); }
 
 void ScrollableTextArea::show(bool force) {
     draw(force);
+    delay(200); // drain input buffer
 
-    while (check(SelPress)) {
-        update(force);
-        yield();
-    }
+    // Flush any stale SelPress
+    while (check(SelPress)) { update(force); }
+
+    // Wait for SelPress or EscPress to exit
     while (!check(SelPress)) {
+        if (check(EscPress)) break;
         update(force);
         yield();
     }


### PR DESCRIPTION
## Description

The ScrollableTextArea `show()` function (used by Host Info screen) could become unresponsive to the Enter key due to a race condition with the input handler.

## Root Cause

The `check()` function suspends the input handler task (`xHandle`) for ~10ms each time it is called. In `ScrollableTextArea::show()`, the `update()` function calls `check()` multiple times (PrevPress, NextPress) before each `draw()`, creating brief windows where keyboard input is not being scanned. A quick tap of Enter during one of these suspension windows was silently swallowed, making the screen appear frozen.

## Fix

1. **Added `delay(200)`** before the wait loop to drain any buffered input after the content is displayed
2. **Added EscPress exit path** — pressing the ESC key now also exits the screen, giving a reliable fallback

## Testing

- [ ] Open Host Info from Scan Hosts menu
- [ ] Press Enter to exit — should return to host options menu
- [ ] Press ESC to exit — should also work