### PR TITLE
Auto Deep Sleep (Deep Sleep Time)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 default_envs =
-	;m5stack-cardputer
+	m5stack-cardputer
 	;m5stack-sticks3
 	;m5stack-cplus2
 	;m5stack-cplus1_1
@@ -35,7 +35,7 @@ default_envs =
 	;LAUNCHER_CYD-2432W328C
 	;LAUNCHER_CYD-3248S035R
 	;LAUNCHER_CYD-3248S035C
-	lilygo-t-embed-cc1101
+	;lilygo-t-embed-cc1101
 	;lilygo-t-embed
 	;lilygo-t-deck
 	;lilygo-t-watch-s3

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 default_envs =
-	m5stack-cardputer
+	;m5stack-cardputer
 	;m5stack-sticks3
 	;m5stack-cplus2
 	;m5stack-cplus1_1
@@ -35,7 +35,7 @@ default_envs =
 	;LAUNCHER_CYD-2432W328C
 	;LAUNCHER_CYD-3248S035R
 	;LAUNCHER_CYD-3248S035C
-	;lilygo-t-embed-cc1101
+	lilygo-t-embed-cc1101
 	;lilygo-t-embed
 	;lilygo-t-deck
 	;lilygo-t-watch-s3

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -13,6 +13,7 @@ JsonDocument BruceConfig::toJson() const {
     setting["themeOnSd"] = theme.fs;
 
     setting["dimmerSet"] = dimmerSet;
+    setting["autoDeepSleepSet"] = autoDeepSleepSet;
     setting["bright"] = bright;
     setting["automaticTimeUpdateViaNTP"] = automaticTimeUpdateViaNTP;
     setting["tmz"] = tmz;
@@ -154,6 +155,12 @@ void BruceConfig::fromFile(bool checkFS) {
 
     if (!setting["dimmerSet"].isNull()) {
         dimmerSet = setting["dimmerSet"].as<int>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
+    if (!setting["autoDeepSleepSet"].isNull()) {
+        autoDeepSleepSet = setting["autoDeepSleepSet"].as<int>();
     } else {
         count++;
         log_e("Fail");
@@ -466,6 +473,7 @@ void BruceConfig::factoryReset() {
 
 void BruceConfig::validateConfig() {
     validateDimmerValue();
+    validateAutoDeepSleepValue();
     validateBrightValue();
     validateTmzValue();
     validateSoundEnabledValue();
@@ -504,6 +512,24 @@ void BruceConfig::setDimmer(int value) {
 void BruceConfig::validateDimmerValue() {
     if (dimmerSet < 0) dimmerSet = 10;
     if (dimmerSet > 60) dimmerSet = 0;
+}
+
+void BruceConfig::setAutoDeepSleep(int value) {
+    autoDeepSleepSet = value;
+    validateAutoDeepSleepValue();
+    saveFile();
+}
+
+void BruceConfig::validateAutoDeepSleepValue() {
+    switch (autoDeepSleepSet) {
+        case 0:
+        case 60:
+        case 300:
+        case 900:
+        case 1800:
+        case 3600: return;
+        default:   autoDeepSleepSet = 0;
+    }
 }
 
 void BruceConfig::setBright(uint8_t value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -37,6 +37,7 @@ public:
 
     //  Settings
     int dimmerSet = 60;
+    int autoDeepSleepSet = 0; // seconds of inactivity before deep sleep, 0 = disabled
     int bright = 100;
     bool automaticTimeUpdateViaNTP = true;
     float tmz = 0;
@@ -126,6 +127,8 @@ public:
     // Settings
     void setDimmer(int value);
     void validateDimmerValue();
+    void setAutoDeepSleep(int value);
+    void validateAutoDeepSleepValue();
     void setBright(uint8_t value);
     void validateBrightValue();
     void setAutomaticTimeUpdateViaNTP(bool value);

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -63,6 +63,7 @@ void ConfigMenu::displayUIMenu() {
         std::vector<Option> localOptions = {
             {"Brightness",  [this]() { setBrightnessMenu(); }               },
             {"Dim Time",    [this]() { setDimmerTimeMenu(); }               },
+            {"Deep Sleep Time", [this]() { setAutoDeepSleepMenu(); }        },
             {"Orientation", [this]() { lambdaHelper(gsetRotation, true)(); }},
             {"UI Color",    [this]() { setUIColor(); }                      },
             {"UI Theme",    [this]() { setTheme(); }                        },

--- a/src/core/powerSave.cpp
+++ b/src/core/powerSave.cpp
@@ -1,5 +1,6 @@
 #include "powerSave.h"
 #include "display.h"
+#include "mykeyboard.h"
 #include "settings.h"
 
 /* Check if it's time to put the device to sleep */
@@ -14,9 +15,15 @@ void fadeOutScreen(int startValue) {
 }
 
 void checkPowerSaveTime() {
+    unsigned long elapsed = millis() - previousMillis;
+
+    if (bruceConfig.autoDeepSleepSet != 0 && elapsed >= (unsigned long)bruceConfig.autoDeepSleepSet * 1000) {
+        if (!isScreenOff) fadeOutScreen(bruceConfig.bright);
+        goToDeepSleep();
+    }
+
     if (bruceConfig.dimmerSet == 0) return;
 
-    unsigned long elapsed = millis() - previousMillis;
     int startDimmerBright = bruceConfig.bright / 3;
     int dimmerSetMs = bruceConfig.dimmerSet * 1000;
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -197,6 +197,29 @@ void setDimmerTimeMenu() {
 }
 
 /*********************************************************************
+**  Function: setAutoDeepSleepMenu
+**  Handles Menu to set auto deep sleep time
+**********************************************************************/
+void setAutoDeepSleepMenu() {
+    int idx = 0;
+    if (bruceConfig.autoDeepSleepSet == 60) idx = 0;
+    else if (bruceConfig.autoDeepSleepSet == 300) idx = 1;
+    else if (bruceConfig.autoDeepSleepSet == 900) idx = 2;
+    else if (bruceConfig.autoDeepSleepSet == 1800) idx = 3;
+    else if (bruceConfig.autoDeepSleepSet == 3600) idx = 4;
+    else if (bruceConfig.autoDeepSleepSet == 0) idx = 5;
+    options = {
+        {"1min",     [=]() { bruceConfig.setAutoDeepSleep(60); },   bruceConfig.autoDeepSleepSet == 60  },
+        {"5min",     [=]() { bruceConfig.setAutoDeepSleep(300); },  bruceConfig.autoDeepSleepSet == 300 },
+        {"15min",    [=]() { bruceConfig.setAutoDeepSleep(900); },  bruceConfig.autoDeepSleepSet == 900 },
+        {"30min",    [=]() { bruceConfig.setAutoDeepSleep(1800); }, bruceConfig.autoDeepSleepSet == 1800},
+        {"1hour",    [=]() { bruceConfig.setAutoDeepSleep(3600); }, bruceConfig.autoDeepSleepSet == 3600},
+        {"Disabled", [=]() { bruceConfig.setAutoDeepSleep(0); },    bruceConfig.autoDeepSleepSet == 0   },
+    };
+    loopOptions(options, idx);
+}
+
+/*********************************************************************
 **  Function: setUIColor
 **  Set and store main UI color
 **********************************************************************/

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -61,6 +61,7 @@ void addMifareKeyMenu();
 void setSleepMode();
 
 void setDimmerTimeMenu();
+void setAutoDeepSleepMenu();
 
 void setClock();
 


### PR DESCRIPTION
#### Proposed Changes ####
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Adds automatic time out deep sleeping, works similarly to "Dim Time"
Its listed as "Deep Sleep Time" in the "Display & UI" settings menu
It is disabled by default
#### Types of Changes ####
New Feature
<!-- What types of changes does your code introduce to Bruce? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
tested on t-embed cc1101 plus
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added auto deep sleep (Deep Sleep Time)
```

#### Further Comments ####

