### PR TITLE
feat(ssh): add saved connection profiles

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -48,6 +48,16 @@ JsonDocument BruceConfig::toJson() const {
     JsonArray _evilWifiNames = setting["evilWifiNames"].to<JsonArray>();
     for (auto key : evilWifiNames) _evilWifiNames.add(key);
 
+    JsonArray _sshProfiles = setting["sshProfiles"].to<JsonArray>();
+    for (const auto &p : sshProfiles) {
+        JsonObject o = _sshProfiles.add<JsonObject>();
+        o["name"] = p.name;
+        o["host"] = p.host;
+        o["port"] = p.port;
+        o["user"] = p.user;
+        o["pwd"] = p.pwd;
+    }
+
     JsonObject _evilWifiEndpoints = setting["evilWifiEndpoints"].to<JsonObject>();
     _evilWifiEndpoints["getCredsEndpoint"] = evilPortalEndpoints.getCredsEndpoint;
     _evilWifiEndpoints["setSsidEndpoint"] = evilPortalEndpoints.setSsidEndpoint;
@@ -316,6 +326,20 @@ void BruceConfig::fromFile(bool checkFS) {
     } else {
         count++;
         log_e("Fail");
+    }
+
+    if (!setting["sshProfiles"].isNull()) {
+        sshProfiles.clear();
+        JsonArray _sshProfiles = setting["sshProfiles"].as<JsonArray>();
+        for (JsonObject o : _sshProfiles) {
+            SSHProfile p;
+            p.name = o["name"].as<String>();
+            p.host = o["host"].as<String>();
+            p.port = o["port"].as<String>();
+            p.user = o["user"].as<String>();
+            p.pwd = o["pwd"].as<String>();
+            sshProfiles.push_back(p);
+        }
     }
 
     if (!setting["evilWifiEndpoints"].isNull()) {
@@ -673,6 +697,28 @@ void BruceConfig::addEvilWifiName(String value) {
 void BruceConfig::removeEvilWifiName(String value) {
     evilWifiNames.erase(value);
     saveFile();
+}
+
+void BruceConfig::addSSHProfile(const SSHProfile &profile) {
+    for (auto &p : sshProfiles) {
+        if (p.name == profile.name) {
+            p = profile;
+            saveFile();
+            return;
+        }
+    }
+    sshProfiles.push_back(profile);
+    saveFile();
+}
+
+void BruceConfig::removeSSHProfile(const String &name) {
+    for (auto it = sshProfiles.begin(); it != sshProfiles.end(); ++it) {
+        if (it->name == name) {
+            sshProfiles.erase(it);
+            saveFile();
+            return;
+        }
+    }
 }
 
 void BruceConfig::setEvilEndpointCreds(String value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -32,6 +32,13 @@ public:
         bool allowSetSsid;
         bool allowGetCreds;
     };
+    struct SSHProfile {
+        String name;
+        String host;
+        String port;
+        String user;
+        String pwd;
+    };
 
     const char *filepath = "/bruce.conf";
 
@@ -64,6 +71,7 @@ public:
     WiFiCredential wifiAp = {"BruceNet", "brucenet"};
     std::map<String, String> wifi = {};
     std::set<String> evilWifiNames = {};
+    std::vector<SSHProfile> sshProfiles = {};
     String wifiMAC = ""; //@IncursioHack
     bool TerminalLog = true;
 
@@ -166,6 +174,8 @@ public:
     String getWifiPassword(const String &ssid) const;
     void addEvilWifiName(String value);
     void removeEvilWifiName(String value);
+    void addSSHProfile(const SSHProfile &profile);
+    void removeSSHProfile(const String &name);
     void setEvilEndpointCreds(String value);
     void setEvilEndpointSsid(String value);
     void setEvilAllowEndpointDisplay(bool value);

--- a/src/core/menu_items/WifiMenu.cpp
+++ b/src/core/menu_items/WifiMenu.cpp
@@ -71,7 +71,7 @@ void WifiMenu::optionsMenu() {
     options.push_back({"Client TCP", clientTCP});
     options.push_back({"SOCKS4 Proxy", []() { socks4Proxy(1080); }});
     options.push_back({"TelNET", telnet_setup});
-    options.push_back({"SSH", lambdaHelper(ssh_setup, String(""))});
+    options.push_back({"SSH", ssh_connection_menu});
     options.push_back({"Sniffer", sniffer_setup});
     options.push_back({"Channel Analyzer", channel_analyzer_setup});
     options.push_back({"Jam Detect", jam_detect_setup});

--- a/src/modules/wifi/clients.cpp
+++ b/src/modules/wifi/clients.cpp
@@ -1178,31 +1178,7 @@ char *stringTochar(const String &s) {
     return arr;
 }
 
-void ssh_setup(const String &host) {
-    if (!wifiConnected) wifiConnectMenu();
-    if (!initClientMutex()) {
-        displayError("SSH mutex creation failed.", true);
-        returnToMenu = true;
-        return;
-    }
-
-    resetClientScreen("SSH");
-    if (host != "") {
-        ssh_host = host;
-    } else {
-        String my_net =
-            WiFi.gatewayIP().toString().substring(0, WiFi.gatewayIP().toString().lastIndexOf(".") + 1);
-        ssh_host = keyboard(my_net, 100, "SSH HOST (IP or Hostname)");
-        if (ssh_host == "\x1B") return;
-    }
-
-    ssh_port = num_keyboard("22", 5, "SSH PORT");
-    if (ssh_port == "\x1B") return;
-    ssh_user = keyboard("", 76, "SSH USER");
-    if (ssh_user == "\x1B") return;
-    ssh_password = keyboard("", 76, "SSH PASSWORD", true);
-    if (ssh_password == "\x1B") return;
-
+static void ssh_start_session() {
     IPAddress resolvedIp;
     if (WiFi.hostByName(ssh_host.c_str(), resolvedIp)) {
         ssh_host = resolvedIp.toString();
@@ -1230,6 +1206,110 @@ void ssh_setup(const String &host) {
 
     startSessionLog(ClientProtocol::SSH);
     runSessionUiLoop("SSH");
+}
+
+void ssh_setup(const String &host) {
+    if (!wifiConnected) wifiConnectMenu();
+    if (!initClientMutex()) {
+        displayError("SSH mutex creation failed.", true);
+        returnToMenu = true;
+        return;
+    }
+
+    resetClientScreen("SSH");
+    if (host != "") {
+        ssh_host = host;
+    } else {
+        String my_net =
+            WiFi.gatewayIP().toString().substring(0, WiFi.gatewayIP().toString().lastIndexOf(".") + 1);
+        ssh_host = keyboard(my_net, 100, "SSH HOST (IP or Hostname)");
+        if (ssh_host == "\x1B") return;
+    }
+
+    ssh_port = num_keyboard("22", 5, "SSH PORT");
+    if (ssh_port == "\x1B") return;
+    ssh_user = keyboard("", 76, "SSH USER");
+    if (ssh_user == "\x1B") return;
+    ssh_password = keyboard("", 76, "SSH PASSWORD", true);
+    if (ssh_password == "\x1B") return;
+
+    ssh_start_session();
+}
+
+void ssh_setup_profile(const String &host, const String &port, const String &user, const String &pwd) {
+    ssh_host = host;
+    ssh_port = port;
+    ssh_user = user;
+    ssh_password = pwd;
+
+    if (!wifiConnected) wifiConnectMenu();
+    if (!initClientMutex()) {
+        displayError("SSH mutex creation failed.", true);
+        returnToMenu = true;
+        return;
+    }
+
+    resetClientScreen("SSH");
+
+    ssh_start_session();
+}
+
+static void ssh_add_profile_menu() {
+    BruceConfig::SSHProfile p;
+    p.name = keyboard("", 30, "Profile Name");
+    if (p.name == "\x1B" || p.name.isEmpty()) return;
+    String my_net =
+        WiFi.gatewayIP().toString().substring(0, WiFi.gatewayIP().toString().lastIndexOf(".") + 1);
+    p.host = keyboard(my_net, 100, "SSH HOST (IP or Hostname)");
+    if (p.host == "\x1B") return;
+    p.port = num_keyboard("22", 5, "SSH PORT");
+    if (p.port == "\x1B") return;
+    p.user = keyboard("", 76, "SSH USER");
+    if (p.user == "\x1B") return;
+    p.pwd = keyboard("", 76, "SSH PASSWORD", true);
+    if (p.pwd == "\x1B") return;
+    bruceConfig.addSSHProfile(p);
+}
+
+static void ssh_profile_actions_menu(BruceConfig::SSHProfile prof) {
+    bool goBack = false;
+    while (!goBack) {
+        options = {
+            {"Connect", [&]() { ssh_setup_profile(prof.host, prof.port, prof.user, prof.pwd); }},
+            {"Delete",  [&]() { bruceConfig.removeSSHProfile(prof.name); goBack = true; }},
+            {"Back",    [&]() { goBack = true; }},
+        };
+        int idx = loopOptions(options, MENU_TYPE_SUBMENU, prof.name.c_str());
+        if (idx == -1 || returnToMenu) goBack = true;
+    }
+}
+
+static void ssh_saved_profiles_menu() {
+    bool goBack = false;
+    while (!goBack) {
+        options = {};
+        for (const auto &p : bruceConfig.sshProfiles) {
+            BruceConfig::SSHProfile prof = p;
+            options.push_back({prof.name, [prof]() { ssh_profile_actions_menu(prof); }});
+        }
+        options.push_back({"Add Profile", ssh_add_profile_menu});
+        options.push_back({"Back", [&goBack]() { goBack = true; }});
+        int idx = loopOptions(options, MENU_TYPE_SUBMENU, "Saved Profiles");
+        if (idx == -1 || returnToMenu) goBack = true;
+    }
+}
+
+void ssh_connection_menu() {
+    bool goBack = false;
+    while (!goBack) {
+        options = {
+            {"New Connection", []() { ssh_setup(""); }},
+            {"Saved Profiles", ssh_saved_profiles_menu             },
+            {"Back",           [&goBack]() { goBack = true; }},
+        };
+        int idx = loopOptions(options, MENU_TYPE_SUBMENU, "SSH");
+        if (idx == -1 || returnToMenu) goBack = true;
+    }
 }
 
 void ssh_loop(void *pvParameters) { sshWorkerTask(pvParameters); }

--- a/src/modules/wifi/clients.h
+++ b/src/modules/wifi/clients.h
@@ -7,6 +7,10 @@ void telnet_setup();
 
 void ssh_setup(const String &host = "");
 
+void ssh_setup_profile(const String &host, const String &port, const String &user, const String &pwd);
+
+void ssh_connection_menu();
+
 void ssh_loop(void *pvParameters);
 
 char *stringTochar(const String &s);


### PR DESCRIPTION
#### Proposed Changes ####

Adds persistent SSH connection profiles so users no longer have to retype the connection details every time. Profiles (name, host, port, user, password) are stored in `bruceConfig` and persisted to `/bruce.conf`.

The SSH entry now opens a small menu:
- **New Connection:** keeps the existing manual flow typing host, port, user and password.
- **Saved Profiles:** lists the stored profiles plus **Add Profile**. Selecting a profile opens **Connect / Delete**.

On the config side, a new `sshProfiles` array is added. `addSSHProfile` upserts by name to avoid duplicates and
`removeSSHProfile` deletes by name. The manual and profile connect paths share a common
`ssh_start_session()` helper to avoid duplicated logic.

#### Types of Changes ####

New Feature.

#### Verification ####

Tested on a LilyGo T-Embed CC1101 Plus. Add a profile and confirm it survives a reboot, connect from a saved profile, and delete a profile. Back navigation at each menu level returns to the previous menu correctly. The configuration saved correctly to `/bruce.conf`.

#### Testing ####

This was verified manually on hardware. Compiles across all board environments.

#### Linked Issues ####

Related to #1739 and #2590.

#### User-Facing Change ####
```release-note
Add saved SSH connection profiles (name, host, port, user, password) with a menu to connect to, add, and delete them.
```

#### Further Comments ####
The password is saved as plain text in the device config. This is less secure, but many of these devices have no real keyboard, so you have to enter each character with the buttons or the wheel, which is slow and easy to get wrong. Saving the password is much more comfortable. If you prefer not to save it, the profile can be changed to store only the connection details and ask for the password when connecting.

 I am also working on SSH key generation on the device, as asked in #2590. It will be a separate PR that extends these profiles to support key-based login.

