### PR TITLE
Add LILYGO T-Display-C5 board definition

### DIFF
--- a/boards/lilygo-t-display-c5/interface.cpp
+++ b/boards/lilygo-t-display-c5/interface.cpp
@@ -1,0 +1,138 @@
+#include "core/powerSave.h"
+#include "core/utils.h"
+#include <interface.h>
+
+/***************************************************************************************
+** LILYGO T-Display-C5 — Bruce board interface
+** ST7789 170x320 (no touch), two physical buttons (IO0 + BOOT).
+***************************************************************************************/
+
+/***************************************************************************************
+** Function name: _setup_gpio()
+***************************************************************************************/
+void _setup_gpio() {
+    pinMode(TFT_CS, OUTPUT);
+    digitalWrite(TFT_CS, HIGH);
+    pinMode(TFT_MOSI, OUTPUT);
+    digitalWrite(TFT_MOSI, HIGH);
+    pinMode(TFT_SCLK, OUTPUT);
+
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, HIGH);
+    pinMode(TFT_RST, OUTPUT);
+    pinMode(TFT_DC, OUTPUT);
+    digitalWrite(TFT_DC, HIGH);
+
+#ifdef HAS_2_BUTTONS
+    pinMode(BTN_A, INPUT_PULLUP);
+    pinMode(BTN_B, INPUT_PULLUP);
+#endif
+
+    // All external SPI radios share CS=4 / control=5 on this board.
+    pinMode(NRF24_SS_PIN, OUTPUT);
+    pinMode(CC1101_SS_PIN, OUTPUT);
+    pinMode(W5500_SS_PIN, OUTPUT);
+    digitalWrite(NRF24_SS_PIN, HIGH);
+    digitalWrite(CC1101_SS_PIN, HIGH);
+    digitalWrite(W5500_SS_PIN, HIGH);
+
+    if (SDCARD_CS >= 0) { // no microSD on the T-Display-C5 (SDCARD_CS = -1)
+        pinMode(SDCARD_CS, OUTPUT);
+        digitalWrite(SDCARD_CS, HIGH);
+    }
+
+    pinMode(TFT_CS, OUTPUT);
+    digitalWrite(TFT_CS, HIGH);
+}
+
+/***************************************************************************************
+** Function name: _post_setup_gpio()
+***************************************************************************************/
+void _post_setup_gpio() {
+    // No touch controller on this board — nothing to calibrate.
+}
+
+/***************************************************************************************
+** Function name: getBattery()
+** NOTE: battery gauge lives in the AXP2602 PMU over I2C (SDA=2, SCL=3, INT=10).
+**       Returning 0 for now — implement AXP2602 readout here if you want % / charge.
+***************************************************************************************/
+int getBattery() { return 0; }
+
+/***************************************************************************************
+** Function name: isCharging()
+***************************************************************************************/
+bool isCharging() { return false; }
+
+/*********************************************************************
+** Function: setBrightness
+** Backlight is a plain GPIO (BL=25) on PWM. The display does NOT
+** depend on the AXP2602 — its begin() only wakes the battery fuel
+** gauge, it gates no display rail — so no PMU init is needed to get
+** a picture. AXP2602 is only required for the battery readouts below.
+**********************************************************************/
+void _setBrightness(uint8_t brightval) {
+    // NOTE: analogWrite()/LEDC auto-attach on GPIO25 can fail silently on the
+    // ESP32-C5 with this core and leave the backlight pin undriven (black
+    // screen). Drive it as a plain digital on/off instead so the panel is
+    // always lit. PWM dimming can be restored later with an explicit
+    // ledcAttach(TFT_BL, 5000, 8) once confirmed working.
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, brightval > 0 ? HIGH : LOW);
+}
+
+/*********************************************************************
+** Function: InputHandler   (two-button scheme)
+**   BTN_A short = Next      BTN_A long = Prev
+**   BTN_B short = Select    BTN_B long = Back/Esc
+** Sets PrevPress / NextPress / SelPress / EscPress / AnyKeyPress.
+**********************************************************************/
+void InputHandler(void) {
+    static bool aWasDown = false, bWasDown = false;
+    static unsigned long aDownAt = 0, bDownAt = 0;
+    static unsigned long lastAction = 0;
+    const unsigned long LONG_MS = 400;    // hold beyond this = long press
+    const unsigned long LOCKOUT_MS = 150; // debounce between registered actions
+
+    bool aDown = (digitalRead(BTN_A) == LOW); // BTN_ACT == LOW
+    bool bDown = (digitalRead(BTN_B) == LOW);
+
+    AnyKeyPress = (aDown || bDown);
+
+    // Wake from power-save on any press; swallow that press.
+    if (AnyKeyPress && wakeUpScreen()) {
+        aWasDown = aDown;
+        bWasDown = bDown;
+        return;
+    }
+
+    if (millis() - lastAction >= LOCKOUT_MS) {
+        // Button A: release decides short (Next) vs long (Prev)
+        if (aDown && !aWasDown) aDownAt = millis();
+        if (!aDown && aWasDown) {
+            if (millis() - aDownAt >= LONG_MS) PrevPress = true;
+            else NextPress = true;
+            lastAction = millis();
+        }
+        // Button B: release decides short (Select) vs long (Esc)
+        if (bDown && !bWasDown) bDownAt = millis();
+        if (!bDown && bWasDown) {
+            if (millis() - bDownAt >= LONG_MS) EscPress = true;
+            else SelPress = true;
+            lastAction = millis();
+        }
+    }
+
+    aWasDown = aDown;
+    bWasDown = bDown;
+}
+
+/*********************************************************************
+** Function: powerOff
+**********************************************************************/
+void powerOff() {}
+
+/*********************************************************************
+** Function: checkReboot
+**********************************************************************/
+void checkReboot() {}

--- a/boards/lilygo-t-display-c5/lilygo-t-display-c5.ini
+++ b/boards/lilygo-t-display-c5/lilygo-t-display-c5.ini
@@ -1,0 +1,31 @@
+; ---------------------------------------------------------------------
+; LILYGO T-Display-C5  (ESP32-C5, ST7789 170x320, no touch, AXP2602 PMU)
+; Bruce board environment — add this to platformio.ini (or include it)
+; ---------------------------------------------------------------------
+
+[env:lilygo-t-display-c5]
+board = esp32-c5-devkitc-1
+board_build.partitions = custom_8Mb.csv
+build_src_filter = ${env.build_src_filter} +<../boards/lilygo-t-display-c5>
+build_flags =
+	${env.build_flags}
+	-Iboards/lilygo-t-display-c5
+	-DDEVICE_NAME='"T-Display-C5"'
+	-DLILYGO_T_DISPLAY_C5=1
+	-DBOARD_HAS_PSRAM=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DARDUINO_USB_MODE=1
+	-DCORE_DEBUG_LEVEL=1
+
+	; use any GPIO for IR/RF except TFT + reserved pins
+	-DALLOW_ALL_GPIO_FOR_IR_RF=1
+
+	; text sizes
+	-DFP=1
+	-DFM=2
+	-DFG=3
+	; single physical select button label
+	-DBTN_ALIAS='"OK"'
+
+	; FM Radio (optional, needs Adafruit Si4713 on I2C)
+	;-DFM_SI4713=1

--- a/boards/lilygo-t-display-c5/pins_arduino.h
+++ b/boards/lilygo-t-display-c5/pins_arduino.h
@@ -1,0 +1,170 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+/* =====================================================================
+ * LILYGO T-Display-C5  (ESP32-C5, 1.9" ST7789 170x320, AXP2602 PMU)
+ * Bruce board definition — forked from ESP32-C5-tft
+ *
+ * Physical map (from the LILYGO pinmap):
+ *   Display : CS=26  SCK=7  MOSI=9  DC=8  RST=23  BL=25   (write-only, no MISO)
+ *   Buttons : BOOT=IO28   IO0=IO0
+ *   I2C/QWIIC + PMU : SDA=2  SCL=3   (AXP2602 INT on GPIO10)
+ *   UART    : TX=11  RX=12
+ * ===================================================================== */
+
+/* ---- Arduino-core RGB LED (devkit default; T-Display-C5 has none — harmless) ---- */
+#define PIN_RGB_LED 27
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
+#define BUILTIN_LED  LED_BUILTIN
+#define RGB_BUILTIN  LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
+static const uint8_t TX = 11;
+static const uint8_t RX = 12;
+
+/* I2C — QWIIC connector + AXP2602 PMU */
+static const uint8_t SDA = 2;
+static const uint8_t SCL = 3;
+
+/* Shared SPI bus (display + radios). Display is write-only, so MISO (6)
+ * is only read by the radio modules. */
+static const uint8_t SCK  = 7;
+static const uint8_t MOSI = 9;
+static const uint8_t MISO = 6;
+static const uint8_t SS   = 4;   // radio / peripheral CS default
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+
+// LP I2C / LP UART pins are fixed on ESP32-C5
+static const uint8_t LP_SDA = 4;
+static const uint8_t LP_SCL = 5;
+#define WIRE1_PIN_DEFINED
+#define SDA1 LP_SDA
+#define SCL1 LP_SCL
+static const uint8_t LP_RX = 12;
+static const uint8_t LP_TX = 11;
+
+/* RGB LED — Bruce's led_control.cpp compiles unconditionally and needs
+ * these symbols defined even if the board has no addressable LED. The
+ * RGB_LED pin (27) is only driven if a WS2812 is actually present, so
+ * leaving this defined is harmless on a board without one. */
+#define HAS_RGB_LED 1
+#define LED_ORDER GRB
+#define LED_TYPE WS2812
+#define LED_COUNT 1
+#define LED_COLOR_STEP 15
+#define RGB_LED 27
+
+/* Communication buses */
+#define SERIAL_TX 11
+#define SERIAL_RX 12
+#define GROVE_SDA 2
+#define GROVE_SCL 3
+#define SPI_SCK_PIN  7
+#define SPI_MOSI_PIN 9
+#define SPI_MISO_PIN 6
+#define SPI_SS_PIN   4
+
+/* =========================  TFT (ST7789 170x320)  ==================== */
+#define HAS_SCREEN 1
+#define ROTATION 1              // landscape 320x170; use 0 for portrait
+#define MINBRIGHT (uint8_t)1
+#define USER_SETUP_LOADED 1
+
+#define ST7789_DRIVER 1
+#define TFT_WIDTH  170
+#define TFT_HEIGHT 320
+#define TFT_RGB_ORDER TFT_BGR   // panel is BGR: without this red<->blue swap
+                                // (red shows blue, purple shows pink; green OK)
+#define TFT_INVERSION_ON        // confirmed: factory lcd_init() calls invert_color(true)
+// Confirmed from the factory sketch: the 170-wide panel needs a 35px gap on
+// its short axis (esp_lcd set_gap(0,35)). Recent TFT_eSPI auto-applies this
+// for a 170x320 ST7789; if the image is shifted, that's the value to nudge.
+#define CGRAM_OFFSET
+
+#define TFT_BACKLIGHT_ON 1
+#define TFT_BL   25
+#define TFT_RST  23
+#define TFT_DC   8
+#define TFT_CS   26
+#define TFT_MOSI 9
+#define TFT_SCLK 7
+#define TFT_MISO 6              // display is write-only, but the C5 SPI bus
+                                // init wants a real MISO GPIO assigned (matches
+                                // the working nm-cyd-c5); shares pin 6 with radios
+#define SMOOTH_FONT 1
+// 20MHz to match the known-good C5+ST7789 SPI board (nm-cyd-c5). TFT_eSPI's
+// C5 SPI path is unreliable at 40MHz (backlight on but no image); the factory
+// sketch only reached 40MHz via the native esp_lcd driver, not TFT_eSPI.
+#define SPI_FREQUENCY 20000000
+#define SPI_READ_FREQUENCY 20000000
+
+/* =====================  Buttons — two-button nav  ==================
+ * Only two readable buttons exist; the side "Reset" just reboots the
+ * chip and cannot be read as a GPIO. Navigation is done by the custom
+ * InputHandler in this board's interface.cpp:
+ *     BTN_A short = Next    BTN_A long = Prev
+ *     BTN_B short = Select  BTN_B long = Back / Esc                    */
+#define HAS_2_BUTTONS
+#define BTN_A 0                 // IO0 button
+#define BTN_B 28                // BOOT button
+#define BTN_ACT LOW
+#define DEEPSLEEP_WAKEUP_PIN 0  // IO0 is an RTC/wake-capable pin
+
+/* =========================  InfraRed (optional)  ==================== */
+/* IR is optional and this board exposes almost no free GPIO. GPIO27 is
+ * taken by RGB_LED above, so IR shares GPIO1 (also the freed nav pin).
+ * Rewire these to dedicated pins if you actually fit an IR TX/RX. */
+#define TXLED 1                 // IR TX (placeholder — no dedicated free pin)
+#define RXLED 1                 // IR RX
+#define LED_ON  HIGH
+#define LED_OFF LOW
+
+/* =========================  SD Card  ================================ */
+/* T-Display-C5 has no microSD slot */
+#define SDCARD_CS   -1
+#define SDCARD_SCK  -1
+#define SDCARD_MISO -1
+#define SDCARD_MOSI -1
+
+/* =========================  External radios  ========================
+ * All share the display SPI bus (SCK 7 / MOSI 9 / MISO 6).
+ * CC1101, NRF24 and W5500 reuse the SAME CS (4) and control pin (5),
+ * so only ONE can be installed at a time unless you add a CS switch.
+ * These pins also collide with GPS (below) — pick radio OR gps. */
+// CC1101 (SubGHz)
+#define CC1101_GDO0_PIN 5
+#define CC1101_SS_PIN   4
+#define CC1101_MOSI_PIN SPI_MOSI_PIN
+#define CC1101_SCK_PIN  SPI_SCK_PIN
+#define CC1101_MISO_PIN SPI_MISO_PIN
+// NRF24 (2.4GHz)
+#define NRF24_CE_PIN    5
+#define NRF24_SS_PIN    4
+#define NRF24_MOSI_PIN  SPI_MOSI_PIN
+#define NRF24_SCK_PIN   SPI_SCK_PIN
+#define NRF24_MISO_PIN  SPI_MISO_PIN
+// W5500 (Ethernet)
+#define W5500_INT_PIN   5
+#define W5500_SS_PIN    4
+#define W5500_MOSI_PIN  SPI_MOSI_PIN
+#define W5500_SCK_PIN   SPI_SCK_PIN
+#define W5500_MISO_PIN  SPI_MISO_PIN
+
+/* =========================  Other peripherals  ===================== */
+// GPS — shares GPIO 4/5 with the radios; use one or the other
+#define GPS_SERIAL_TX 5
+#define GPS_SERIAL_RX 4
+// Bad-USB via CH9329 (ESP32-C5 has no USB-OTG) — on the I2C/serial pins
+#define BAD_RX 2
+#define BAD_TX 3
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
#### Proposed Changes ####

Adds a board definition for the LILYGO T-Display-C5 — an ESP32-C5 board with a 1.9" ST7789 170x320 SPI display and an AXP2602 battery management unit. This lets Bruce build and run on the T-Display-C5 out of the box (`pio run -e lilygo-t-display-c5`). Includes `pins_arduino.h`, `interface.cpp` (custom two-button input handler + backlight/GPIO setup), and the PlatformIO env.

#### Types of Changes ####

New Feature (new board support). No changes to shared/core code, so no impact on existing boards.

#### Verification ####

Build: `pio run -e lilygo-t-display-c5` compiles cleanly.
Flash: uploads over USB-Serial/JTAG; boots to the main menu.
Confirmed on hardware: display, backlight, two-button navigation, and theme colors all render correctly.

#### Testing ####

Manually tested on physical hardware (ESP32-C5 rev v1.2):
- Display working over SPI at 20MHz (ST7789 170x320)
- Backlight on/off
- Two-button navigation (IO0 = Next/Prev, BOOT = Select/Back)
- Colors correct with TFT_BGR order
- Clean boot to main menu, no crashes

#### Linked Issues ####

None.

#### User-Facing Change ####
```release-note
Add board support for the LILYGO T-Display-C5 (ESP32-C5, 1.9" ST7789 170x320, AXP2602 BMU).
```

#### Further Comments ####

A few board-specific notes and known limitations for reviewers:

- `TFT_MISO` must be assigned a real GPIO (not `-1`), or the ESP32-C5 SPI bus fails to initialize and the panel stays blank even though the backlight is on.
- SPI clock is capped at 20MHz; 40MHz produced a blank panel via TFT_eSPI on the C5.
- Backlight is on/off only (`digitalWrite`). `analogWrite`/LEDC auto-attach on the C5 left the BL pin undriven, so PWM dimming is disabled for now.
- The on-screen keyboard has no native two-button path yet (Bruce only implements 1- and 3-button keyboards); menu navigation is unaffected.
- External radios (CC1101/NRF24/W5500) share the display SPI bus (one at a time). Probing an absent radio on boot causes minor, harmless display flicker.