### PR TITLE
fix(clients): wait for connection before accepting commands

### DIFF
--- a/src/modules/wifi/clients.cpp
+++ b/src/modules/wifi/clients.cpp
@@ -1057,6 +1057,21 @@ TELNET_EXIT:
 void runSessionUiLoop(const String &title) {
     resetCommandBufferToPrompt();
     resetClientScreen(title.c_str());
+
+    displayTextLine("Connecting...");
+    while (isSessionConnecting() && !isSessionClosed() && !returnToMenu) {
+        if (check(EscPress)) {
+            finishSessionUi(title);
+            return;
+        }
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+    if (returnToMenu || isSessionClosed()) {
+        finishSessionUi(title);
+        return;
+    }
+
+    resetClientScreen(title.c_str());
     renderPrompt();
 
     while (!returnToMenu && !isSessionClosed()) {


### PR DESCRIPTION
#### Proposed Changes ####

Show a "Connecting..." message and block command input until the SSH or Telnet worker reports the session as ready or closed. Before this change the terminal opened right away as if connected, so a failed connection or a wrong login was only shown after the user had already typed one or more commands, and what they typed was lost.

The wait runs before the input loop in runSessionUiLoop, which is shared by SSH and Telnet, so both get the same  behavior. You can still cancel with the back button while it is connecting.

#### Types of Changes ####

Enhancement.

#### Verification ####

Tested on a LilyGo T-Embed CC1101 Plus against both a Linux host and a Windows 11 host with OpenSSH.
- Wrong host or wrong password: the error is shown right away and no command prompt is offered.
- Correct credentials: a short "Connecting..." message is shown, then the terminal opens ready for input.

#### Testing ####

This was verified manually on hardware. Compiles across all board envs.

#### Linked Issues ####

Closes #2739

#### User-Facing Change ####
```release-note
SSH and Telnet now show a "Connecting..." message and wait for the connection before accepting commands, so a failed connection or login is reported right away instead of after typing
```

#### Further Comments ####

The "Connecting..." message uses displayTextLine so it follows the active theme, like the other status messages in the UI.