### PR TITLE
Main menu: add a grid layout next to the icon carousel

### DIFF
--- a/include/MenuItemInterface.h
+++ b/include/MenuItemInterface.h
@@ -4,6 +4,10 @@
 #include "core/display.h"
 #include <globals.h>
 
+// Pixel span a menu icon covers when drawn at scale 1. Lower it to render the icons
+// bigger inside the same box, raise it if the widest ones start touching their label.
+#define ICON_SCALE_REFERENCE 80.0f
+
 class MenuItemInterface {
 public:
     virtual ~MenuItemInterface() = default;
@@ -40,6 +44,40 @@ public:
             if (bruceConfig.theme.label) drawTitle(scale); // Makes sure to draw over the image
         }
         drawStatusBar();
+    }
+
+    // Renders drawIcon() inside an arbitrary box instead of the full screen icon area,
+    // used by the grid main menu. The icons paint straight to `tft` using the member
+    // coordinates and read their colors from bruceConfig, so both are swapped for the
+    // call and put back afterwards.
+    void drawIconInBox(int centerX, int centerY, int box, uint16_t fgColor, uint16_t bgColor) {
+        int oldCenterX = iconCenterX, oldCenterY = iconCenterY;
+        int oldAreaX = iconAreaX, oldAreaY = iconAreaY;
+        int oldAreaW = iconAreaW, oldAreaH = iconAreaH;
+        uint16_t oldPriColor = bruceConfig.priColor;
+        uint16_t oldBgColor = bruceConfig.bgColor;
+
+        iconCenterX = centerX;
+        iconCenterY = centerY;
+        iconAreaW = box;
+        iconAreaH = box;
+        iconAreaX = centerX - box / 2;
+        iconAreaY = centerY - box / 2;
+        bruceConfig.priColor = fgColor;
+        bruceConfig.bgColor = bgColor;
+
+        // The widest icon spans about ICON_SCALE_REFERENCE px at scale 1, so dividing by it
+        // keeps every icon inside `box` and stops it bleeding into the neighbouring cells.
+        drawIcon((float)box / ICON_SCALE_REFERENCE);
+
+        bruceConfig.priColor = oldPriColor;
+        bruceConfig.bgColor = oldBgColor;
+        iconCenterX = oldCenterX;
+        iconCenterY = oldCenterY;
+        iconAreaX = oldAreaX;
+        iconAreaY = oldAreaY;
+        iconAreaW = oldAreaW;
+        iconAreaH = oldAreaH;
     }
 
     void drawArrows(float scale = 1) {

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -68,6 +68,7 @@ JsonDocument BruceConfig::toJson() const {
     setting["wdgwarsApiKey"] = wdgwarsApiKey;
     setting["devMode"] = devMode;
     setting["colorInverted"] = colorInverted;
+    setting["mainMenuStyle"] = mainMenuStyle;
 
     setting["badUSBBLEKeyboardLayout"] = badUSBBLEKeyboardLayout;
     setting["badUSBBLEKeyDelay"] = badUSBBLEKeyDelay;
@@ -386,6 +387,12 @@ void BruceConfig::fromFile(bool checkFS) {
         count++;
         log_e("Fail");
     }
+    if (!setting["mainMenuStyle"].isNull()) {
+        mainMenuStyle = setting["mainMenuStyle"].as<int>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
 
     if (!setting["badUSBBLEKeyboardLayout"].isNull()) {
         badUSBBLEKeyboardLayout = setting["badUSBBLEKeyboardLayout"].as<int>();
@@ -483,6 +490,7 @@ void BruceConfig::validateConfig() {
     validateMifareKeysItems();
     validateDevModeValue();
     validateColorInverted();
+    validateMainMenuStyle();
     validateBadUSBBLEKeyboardLayout();
     validateBadUSBBLEKeyDelay();
     validateEvilEndpointCreds();
@@ -781,6 +789,17 @@ void BruceConfig::setColorInverted(int value) {
 
 void BruceConfig::validateColorInverted() {
     if (colorInverted > 1) colorInverted = 1;
+}
+
+void BruceConfig::setMainMenuStyle(int value) {
+    mainMenuStyle = value;
+    validateMainMenuStyle();
+    saveFile();
+}
+
+void BruceConfig::validateMainMenuStyle() {
+    if (mainMenuStyle < MAIN_MENU_CAROUSEL || mainMenuStyle > MAIN_MENU_GRID)
+        mainMenuStyle = MAIN_MENU_CAROUSEL;
 }
 
 void BruceConfig::setBadUSBBLEKeyboardLayout(int value) {

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -11,6 +11,10 @@
 
 enum EvilPortalPasswordMode { FULL_PASSWORD = 0, FIRST_LAST_CHAR = 1, HIDE_PASSWORD = 2, SAVE_LENGTH = 3 };
 
+// How the main menu presents the modules:
+// CAROUSEL shows one big icon at a time, GRID exposes every module as a selectable cell
+enum MainMenuStyle { MAIN_MENU_CAROUSEL = 0, MAIN_MENU_GRID = 1 };
+
 class BruceConfig : public BruceTheme {
 public:
     struct WiFiCredential {
@@ -87,6 +91,7 @@ public:
     String wdgwarsApiKey = "your 64-char hex key from wdgwars.pl/profile";
     int devMode = 0;
     int colorInverted = 1;
+    int mainMenuStyle = MAIN_MENU_CAROUSEL;
     int badUSBBLEKeyboardLayout = 0;
     uint16_t badUSBBLEKeyDelay = 10;
     bool badUSBBLEShowOutput = true;
@@ -192,6 +197,8 @@ public:
     void validateDevModeValue();
     void setColorInverted(int value);
     void validateColorInverted();
+    void setMainMenuStyle(int value);
+    void validateMainMenuStyle();
     void setBadUSBBLEKeyboardLayout(int value);
     void validateBadUSBBLEKeyboardLayout();
     void setBadUSBBLEKeyDelay(uint16_t value);

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -10,6 +10,8 @@
 
 #define MAX_MENU_SIZE (int)(tftHeight / 25)
 
+uint8_t mainMenuGridColumns = 0;
+
 // Send the ST7789 into or out of sleep mode
 void panelSleep(bool on) {
 #if defined(ST7789_2_DRIVER) || defined(ST7789_DRIVER)
@@ -628,6 +630,33 @@ int loopOptions(
         if (menuType != MENU_TYPE_MAIN && check(EscPress)) {
             index = -1;
             break;
+        }
+
+        // Grid main menu: Up/Down jump a whole row, Prev/Next keep stepping one cell at a time.
+        // Consumed here so the linear handlers below don't also act on the same press.
+        if (menuType == MENU_TYPE_MAIN && mainMenuGridColumns > 1 &&
+            mainMenuGridColumns < static_cast<int>(options.size())) {
+            int rowStep = 0;
+            if (check(UpPress)) rowStep = -1;
+            else if (check(DownPress)) rowStep = 1;
+
+            if (rowStep != 0) {
+                int size = static_cast<int>(options.size());
+                int cols = mainMenuGridColumns;
+                int rows = (size + cols - 1) / cols;
+                int col = index % cols;
+                int row = index / cols + rowStep;
+
+                if (row < 0) row = rows - 1;
+                else if (row >= rows) row = 0;
+
+                int idx = row * cols + col;
+                if (idx >= size) idx = size - 1; // the last row can be shorter than the others
+                if (options[idx].enabled) index = idx;
+
+                devModeCounter = 0;
+                redraw = true;
+            }
         }
 
 #ifdef HAS_ENCODER

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -15,6 +15,10 @@
 #define MENU_TYPE_SUBMENU 1
 #define MENU_TYPE_REGULAR 2
 
+// Columns of the main menu grid layout, set by MainMenu::begin().
+// 0 means the carousel layout is active and navigation stays linear.
+extern uint8_t mainMenuGridColumns;
+
 void panelSleep(bool on);
 void turnOffDisplay();
 bool wakeUpScreen();

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -39,6 +39,32 @@ void MainMenu::begin(void) {
     returnToMenu = false;
     options = {};
 
+    bool gridStyle = bruceConfig.mainMenuStyle == MAIN_MENU_GRID;
+
+    // Option::hover is a plain function pointer, so both renderers stay capture-less
+    // and the grid one resolves its own position from the item pointer it receives.
+    bool (*renderItem)(void *menuItem, bool shouldRender) = [](void *menuItem, bool shouldRender) {
+        if (!shouldRender) return false;
+        drawMainBorder(false);
+
+        MenuItemInterface *obj = static_cast<MenuItemInterface *>(menuItem);
+        float scale = float((float)tftWidth / (float)240);
+        if (bruceConfigPins.rotation & 0b01) scale = float((float)tftHeight / (float)135);
+        obj->draw(scale);
+#if defined(HAS_TOUCH)
+        TouchFooter();
+#endif
+        return true;
+    };
+
+    if (gridStyle) {
+        renderItem = [](void *menuItem, bool shouldRender) {
+            if (!shouldRender) return false;
+            mainMenu.drawGrid(mainMenu.gridIndexOf(static_cast<MenuItemInterface *>(menuItem)));
+            return true;
+        };
+    }
+
     std::vector<String> l = bruceConfig.disabledMenus;
     for (int i = 0; i < _totalItems; i++) {
         String itemName = _menuItems[i]->getName();
@@ -47,27 +73,187 @@ void MainMenu::begin(void) {
                 {// selected lambda
                  itemName,
                  [this, i]() { _menuItems[i]->optionsMenu(); },
-                 false,                                  // selected = false
-                 [](void *menuItem, bool shouldRender) { // render lambda
-                     if (!shouldRender) return false;
-                     drawMainBorder(false);
-
-                     MenuItemInterface *obj = static_cast<MenuItemInterface *>(menuItem);
-                     float scale = float((float)tftWidth / (float)240);
-                     if (bruceConfigPins.rotation & 0b01) scale = float((float)tftHeight / (float)135);
-                     obj->draw(scale);
-#if defined(HAS_TOUCH)
-                     TouchFooter();
-#endif
-                     return true;
-                 },
+                 false, // selected = false
+                 renderItem,
                  _menuItems[i]
                 }
             );
         }
     }
+
+    // The grid needs a fresh full repaint every time we come back to the main menu,
+    // since loopOptions clears the screen before the first render.
+    if (gridStyle) {
+        buildGridLayout(options.size());
+        _gridScroll = 0;
+        _gridLastIndex = -1;
+        _gridRedrawAll = true;
+        mainMenuGridColumns = _grid.cols;
+    } else {
+        mainMenuGridColumns = 0;
+    }
+
     _currentIndex = loopOptions(options, MENU_TYPE_MAIN, "Main Menu", _currentIndex);
 };
+
+/*********************************************************************
+**  Function: gridIndexOf
+**  Position of a menu item inside the currently built options list.
+**  The hover callback is a plain function pointer and cannot capture the
+**  index, so it is resolved back from the item pointer it receives.
+**********************************************************************/
+int MainMenu::gridIndexOf(MenuItemInterface *item) {
+    for (size_t i = 0; i < options.size(); i++) {
+        if (options[i].hoverPointer == item) return (int)i;
+    }
+    return 0;
+}
+
+/*********************************************************************
+**  Function: buildGridLayout
+**  Fits as many module cells as possible in the area below the status bar,
+**  scrolling by rows when they don't all fit at a readable size.
+**********************************************************************/
+void MainMenu::buildGridLayout(int itemCount) {
+    // Below this a cell can't hold a legible icon plus its label
+    const int MIN_CELL_W = 54;
+    const int MIN_CELL_H = 40;
+    const int MAX_CELL_H = 72;
+    const int SCROLLBAR_AREA = 5;
+
+    if (itemCount < 1) itemCount = 1;
+
+    int areaX = BORDER_OFFSET_FROM_SCREEN_EDGE + 2;
+    int areaY = 28; // first line free under the status bar separator
+    int areaW = tftWidth - 2 * areaX - SCROLLBAR_AREA;
+    int areaH = tftHeight - areaY - areaX;
+
+    _grid.cols = max(1, areaW / MIN_CELL_W);
+    if (_grid.cols > itemCount) _grid.cols = itemCount;
+    _grid.cellW = areaW / _grid.cols;
+    _grid.rows = (itemCount + _grid.cols - 1) / _grid.cols;
+
+    _grid.visibleRows = max(1, areaH / MIN_CELL_H);
+    if (_grid.visibleRows > _grid.rows) _grid.visibleRows = _grid.rows;
+    _grid.cellH = min(MAX_CELL_H, areaH / _grid.visibleRows);
+
+    _grid.labelSize = _grid.cellW >= 8 * LW * FM ? FM : FP;
+    // Everything the cell has left once the label and a thin margin are taken out
+    _grid.iconBox = _grid.cellH - LH * _grid.labelSize - 6;
+    if (_grid.iconBox > _grid.cellW - 4) _grid.iconBox = _grid.cellW - 4; // narrow cells cap it
+    if (_grid.iconBox < 12) _grid.iconBox = 12;
+
+    // Center whatever is left over so the grid doesn't hug the border
+    _grid.x = areaX + (areaW - _grid.cols * _grid.cellW) / 2;
+    _grid.y = areaY + (areaH - _grid.visibleRows * _grid.cellH) / 2;
+
+    _gridItemCount = itemCount;
+    _gridRotation = bruceConfigPins.rotation;
+}
+
+/*********************************************************************
+**  Function: drawGrid
+**  Draws the module grid highlighting `index`. Only the two cells that
+**  changed are repainted unless the whole view has to come back.
+**********************************************************************/
+void MainMenu::drawGrid(int index) {
+    int itemCount = options.size();
+    if (itemCount < 1) return;
+    if (index < 0 || index >= itemCount) index = 0;
+
+    if (itemCount != _gridItemCount || _gridRotation != bruceConfigPins.rotation) {
+        buildGridLayout(itemCount);
+        _gridScroll = 0;
+        _gridLastIndex = -1;
+        _gridRedrawAll = true;
+    }
+
+    // Keep the selected cell inside the visible window
+    int scroll = _gridScroll;
+    int row = index / _grid.cols;
+    if (row < scroll) scroll = row;
+    else if (row >= scroll + _grid.visibleRows) scroll = row - _grid.visibleRows + 1;
+
+    bool redrawAll = _gridRedrawAll || scroll != _gridScroll;
+    _gridScroll = scroll;
+
+    if (redrawAll) {
+        drawMainBorder(false);
+        tft.fillRect(
+            _grid.x,
+            _grid.y,
+            _grid.cols * _grid.cellW,
+            _grid.visibleRows * _grid.cellH,
+            bruceConfig.bgColor
+        );
+        int first = _gridScroll * _grid.cols;
+        int last = min(itemCount, first + _grid.visibleRows * _grid.cols);
+        for (int i = first; i < last; i++) drawGridCell(i, i == index);
+        drawGridScrollBar();
+#if defined(HAS_TOUCH)
+        TouchFooter();
+#endif
+    } else {
+        if (_gridLastIndex >= 0 && _gridLastIndex != index && _gridLastIndex < itemCount)
+            drawGridCell(_gridLastIndex, false);
+        drawGridCell(index, true);
+    }
+
+    _gridLastIndex = index;
+    _gridRedrawAll = false;
+}
+
+/*********************************************************************
+**  Function: drawGridCell
+**  Paints a single module cell, inverted when it is the selected one
+**********************************************************************/
+void MainMenu::drawGridCell(int index, bool selected) {
+    int row = index / _grid.cols - _gridScroll;
+    int col = index % _grid.cols;
+    if (row < 0 || row >= _grid.visibleRows) return;
+
+    int x = _grid.x + col * _grid.cellW;
+    int y = _grid.y + row * _grid.cellH;
+
+    uint16_t bgColor = selected ? bruceConfig.priColor : bruceConfig.bgColor;
+    uint16_t fgColor = selected ? bruceConfig.bgColor : bruceConfig.priColor;
+
+    tft.fillRect(x, y, _grid.cellW, _grid.cellH, bruceConfig.bgColor);
+    if (selected) tft.fillRoundRect(x + 1, y + 1, _grid.cellW - 2, _grid.cellH - 2, 3, bgColor);
+
+    MenuItemInterface *item = static_cast<MenuItemInterface *>(options[index].hoverPointer);
+    if (item)
+        item->drawIconInBox(
+            x + _grid.cellW / 2, y + 3 + _grid.iconBox / 2, _grid.iconBox, fgColor, bgColor
+        );
+
+    int maxChars = (_grid.cellW - 4) / (LW * _grid.labelSize);
+    tft.setTextSize(_grid.labelSize);
+    tft.setTextColor(fgColor, bgColor);
+    tft.drawCentreString(
+        options[index].label.substring(0, maxChars),
+        x + _grid.cellW / 2,
+        y + _grid.cellH - LH * _grid.labelSize - 3,
+        1
+    );
+}
+
+/*********************************************************************
+**  Function: drawGridScrollBar
+**  Thin indicator on the right telling there are more rows off screen
+**********************************************************************/
+void MainMenu::drawGridScrollBar() {
+    int barX = tftWidth - BORDER_OFFSET_FROM_SCREEN_EDGE - 4;
+    int trackY = _grid.y;
+    int trackH = _grid.visibleRows * _grid.cellH;
+
+    tft.fillRect(barX, trackY, 3, trackH, bruceConfig.bgColor);
+    if (_grid.rows <= _grid.visibleRows) return;
+
+    int thumbH = max(6, trackH * _grid.visibleRows / _grid.rows);
+    int thumbY = trackY + (trackH - thumbH) * _gridScroll / (_grid.rows - _grid.visibleRows);
+    tft.fillRect(barX, thumbY, 3, thumbH, bruceConfig.priColor);
+}
 
 /*********************************************************************
 **  Function: hideAppsMenu

--- a/src/core/main_menu.h
+++ b/src/core/main_menu.h
@@ -47,10 +47,37 @@ public:
     std::vector<MenuItemInterface *> getItems(void) { return _menuItems; }
     void hideAppsMenu();
 
+    // Grid layout rendering (bruceConfig.mainMenuStyle == MAIN_MENU_GRID)
+    void drawGrid(int index);
+    int gridIndexOf(MenuItemInterface *item);
+
 private:
+    struct GridLayout {
+        int x = 0;
+        int y = 0;
+        int cellW = 0;
+        int cellH = 0;
+        int cols = 1;
+        int rows = 1;
+        int visibleRows = 1;
+        int iconBox = 0;
+        int labelSize = 1;
+    };
+
+    void buildGridLayout(int itemCount);
+    void drawGridCell(int index, bool selected);
+    void drawGridScrollBar();
+
     int _currentIndex = 0;
     int _totalItems = 0;
     std::vector<MenuItemInterface *> _menuItems;
+
+    GridLayout _grid;
+    int _gridItemCount = 0;
+    int _gridScroll = 0;
+    int _gridLastIndex = -1;
+    uint8_t _gridRotation = ROTATION;
+    bool _gridRedrawAll = true;
 };
 extern MainMenu mainMenu;
 

--- a/src/core/menu_items/ConfigMenu.cpp
+++ b/src/core/menu_items/ConfigMenu.cpp
@@ -66,6 +66,7 @@ void ConfigMenu::displayUIMenu() {
             {"Brightness",  [this]() { setBrightnessMenu(); }               },
             {"Dim Time",    [this]() { setDimmerTimeMenu(); }               },
             {"Orientation", [this]() { lambdaHelper(gsetRotation, true)(); }},
+            {"Menu Layout", [this]() { setMainMenuStyleMenu(); }            },
             {"UI Color",    [this]() { setUIColor(); }                      },
             {"UI Theme",    [this]() { setTheme(); }                        },
             {"Back",        []() {}                                         },

--- a/src/core/menu_items/FileMenu.cpp
+++ b/src/core/menu_items/FileMenu.cpp
@@ -44,7 +44,7 @@ void FileMenu::drawIcon(float scale) {
     int foldSize = iconH / 4;
     int iconX = iconCenterX - iconW / 2;
     int iconY = iconCenterY - iconH / 2;
-    int iconDelta = 10;
+    int iconDelta = max(2, (int)(scale * 10)); // scales with the icon so it still fits in a grid cell
 
     // Files
     tft.drawRect(iconX + iconDelta, iconY - iconDelta, iconW, iconH, bruceConfig.priColor);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -261,6 +261,24 @@ void setUIColor() {
     }
 }
 
+/*********************************************************************
+**  Function: setMainMenuStyleMenu
+**  Choose how the main menu presents the modules
+**********************************************************************/
+void setMainMenuStyleMenu() {
+    options = {
+        {"Carousel",
+         []() { bruceConfig.setMainMenuStyle(MAIN_MENU_CAROUSEL); },
+         bruceConfig.mainMenuStyle == MAIN_MENU_CAROUSEL},
+        {"Grid",
+         []() { bruceConfig.setMainMenuStyle(MAIN_MENU_GRID); },
+         bruceConfig.mainMenuStyle == MAIN_MENU_GRID     },
+    };
+    addOptionToMainMenu();
+
+    loopOptions(options, bruceConfig.mainMenuStyle);
+}
+
 uint16_t alterOneColorChannel565(uint16_t color, int newR, int newG, int newB) {
     uint8_t r = (color >> 11) & 0x1F;
     uint8_t g = (color >> 5) & 0x3F;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -18,6 +18,8 @@ void setBrightnessMenu();
 
 void setUIColor();
 
+void setMainMenuStyleMenu();
+
 bool setCustomUIColorMenu();
 
 void setCustomUIColorChoiceMenu(int colorType);


### PR DESCRIPTION
#### Proposed Changes ####

The main menu only offers the icon carousel, where reaching a module means stepping sideways through every other one. This adds a second layout that lays all modules out as selectable cells, so any of them is one or two presses away.

The choice lives in **Config > Display & UI > Menu Layout** and is stored in `bruce.conf` as `mainMenuStyle`. **Carousel stays the default**, so existing setups are untouched and nothing changes unless the user opts in.

The grid sizes itself from the screen rather than assuming a resolution: columns come from the available width (minimum 54px cell, enough for a readable label), visible rows from the height (minimum 40px so the vector icons stay legible). When the rows don't all fit it scrolls by row, with a thin indicator on the right.

| Board | Result |
|---|---|
| Cardputer 240x135 | 4 columns, 2 visible rows of 4 (15 modules over 4 rows, scrolls) |
| CYD 320x240 | 5 x 3, all 15 modules visible at once |
| Portrait 135x240 | 2 x 5 of 8 rows |

Navigation: **Up/Down jump a whole row** preserving the column, **Prev/Next keep stepping one cell at a time**. Boards without separate Up/Down keys fall back to the existing linear stepping, and touch boards already map those directions through `touchHeatMap`, so they work without changes.

Rendering reuses each module's existing `drawIcon()` through a new `drawIconInBox()` helper on `MenuItemInterface`, which remaps the icon coordinates and theme colors onto an arbitrary box and restores them afterwards. No icon had to be rewritten. Only the two cells that changed are repainted on navigation; a full repaint happens on entry or when the view scrolls.

One drive-by fix: Files' icon had a hardcoded 10px offset that did not follow `scale` and overflowed its box when drawn small. It now scales, with identical output at scale 1.

#### Types of Changes ####

New Feature. Opt-in and additive, no breaking change.

#### Verification ####

1. Flash and go to `Config > Display & UI > Menu Layout`, pick **Grid**.
2. Back out to the main menu: every module is now a cell, selected one highlighted with the primary color.
3. Up/Down move a whole row, Prev/Next move one cell, Enter opens the module.
4. On a Cardputer, scrolling past the second row brings the remaining modules in and the right-hand indicator moves.
5. Switch back to **Carousel** and confirm the original behavior is unchanged.
6. Worth checking with a theme that ships icon images, and with modules hidden via `Hide Apps` (the grid rebuilds its layout from the enabled count).

#### Testing ####

Not covered by automated tests; the repo has no rendering test harness. Verified by building `m5stack-cardputer` and by compiling `CYD-2432S028` to exercise the `HAS_TOUCH` paths and a different resolution.

Being upfront about coverage limits: this was validated on a Cardputer. The layout math for other resolutions is derived, not observed on hardware, so a second pair of eyes on a 320x240 and a portrait board would be welcome. Themes that replace icons with images still render the vector icons in grid mode.

#### Linked Issues ####

None.

#### User-Facing Change ####

```release-note
Main menu can now be shown as a grid of all modules instead of the sliding icon carousel. Pick it under Config > Display & UI > Menu Layout; the carousel remains the default.
```

#### Further Comments ####

The icon size is driven by a single constant, `ICON_SCALE_REFERENCE` in `include/MenuItemInterface.h`. Lowering it renders every icon larger inside the same cell; the practical ceiling is when the tallest icon starts touching its label. It is currently at 80.
