### PR TITLE
Dev

### DIFF
--- a/src/core/wifi/wifi_common.cpp
+++ b/src/core/wifi/wifi_common.cpp
@@ -228,6 +228,8 @@ bool wifiConnectMenu(wifi_mode_t mode) {
                             case WIFI_AUTH_WPA2_PSK: encryptionTypeStr = "WPA2/PSK"; break;
                             case WIFI_AUTH_WPA_WPA2_PSK: encryptionTypeStr = "WPA/WPA2/PSK"; break;
                             case WIFI_AUTH_WPA2_ENTERPRISE: encryptionTypeStr = "WPA2/Enterprise"; break;
+                            case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3_PSK"; break;
+                            case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2_WPA3_PSK"; break;
                             default: encryptionTypeStr = "Unknown"; break;
                         }
 

--- a/src/core/wifi/wifi_common.cpp
+++ b/src/core/wifi/wifi_common.cpp
@@ -228,8 +228,8 @@ bool wifiConnectMenu(wifi_mode_t mode) {
                             case WIFI_AUTH_WPA2_PSK: encryptionTypeStr = "WPA2/PSK"; break;
                             case WIFI_AUTH_WPA_WPA2_PSK: encryptionTypeStr = "WPA/WPA2/PSK"; break;
                             case WIFI_AUTH_WPA2_ENTERPRISE: encryptionTypeStr = "WPA2/Enterprise"; break;
-                            case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3_PSK"; break;
-                            case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2_WPA3_PSK"; break;
+                            case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3/PSK"; break;
+                            case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2/WPA3/PSK"; break;
                             default: encryptionTypeStr = "Unknown"; break;
                         }
 

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -295,6 +295,8 @@ void wifi_atk_menu() {
                 case WIFI_AUTH_WPA2_PSK: encryptionTypeStr = "WPA2/PSK"; break;
                 case WIFI_AUTH_WPA_WPA2_PSK: encryptionTypeStr = "WPA/WPA2/PSK"; break;
                 case WIFI_AUTH_WPA2_ENTERPRISE: encryptionTypeStr = "WPA2/Enterprise"; break;
+                case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3_PSK"; break;
+                case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2_WPA3_PSK"; break;
                 default: encryptionTypeStr = "Unknown"; break;
             }
 
@@ -420,6 +422,8 @@ void capture_handshake(const String &tssid, const String &mac, uint8_t channel) 
                 case WIFI_AUTH_WPA2_PSK: encryptionTypeStr = "WPA2/PSK"; break;
                 case WIFI_AUTH_WPA_WPA2_PSK: encryptionTypeStr = "WPA/WPA2/PSK"; break;
                 case WIFI_AUTH_WPA2_ENTERPRISE: encryptionTypeStr = "WPA2/Enterprise"; break;
+                case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3_PSK"; break;
+                case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2_WPA3_PSK"; break;
                 default: encryptionTypeStr = "Unknown"; break;
             }
             break;

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -295,8 +295,8 @@ void wifi_atk_menu() {
                 case WIFI_AUTH_WPA2_PSK: encryptionTypeStr = "WPA2/PSK"; break;
                 case WIFI_AUTH_WPA_WPA2_PSK: encryptionTypeStr = "WPA/WPA2/PSK"; break;
                 case WIFI_AUTH_WPA2_ENTERPRISE: encryptionTypeStr = "WPA2/Enterprise"; break;
-                case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3_PSK"; break;
-                case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2_WPA3_PSK"; break;
+                case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3/PSK"; break;
+                case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2/WPA3/PSK"; break;
                 default: encryptionTypeStr = "Unknown"; break;
             }
 
@@ -422,8 +422,8 @@ void capture_handshake(const String &tssid, const String &mac, uint8_t channel) 
                 case WIFI_AUTH_WPA2_PSK: encryptionTypeStr = "WPA2/PSK"; break;
                 case WIFI_AUTH_WPA_WPA2_PSK: encryptionTypeStr = "WPA/WPA2/PSK"; break;
                 case WIFI_AUTH_WPA2_ENTERPRISE: encryptionTypeStr = "WPA2/Enterprise"; break;
-                case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3_PSK"; break;
-                case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2_WPA3_PSK"; break;
+                case WIFI_AUTH_WPA3_PSK: encryptionTypeStr = "WPA3/PSK"; break;
+                case WIFI_AUTH_WPA2_WPA3_PSK: encryptionTypeStr = "WPA2/WPA3/PSK"; break;
                 default: encryptionTypeStr = "Unknown"; break;
             }
             break;


### PR DESCRIPTION
#### Proposed Changes ####

Added detection for WPA3-PSK and WPA2/WPA3 transition mode encryption in the Wi-Fi scanner.
Thanks to this enhancement, modern secured Wi-Fi networks using WPA3 will now display as "WPA3/PSK" or "WPA2/WPA3/PSK" instead of "Unknown".

From a security/testing perspective, this allows users to identify WPA3 networks immediately, saving time by knowing in advance that standard 4-way handshake capture or deauth attacks will likely fail against these targets.

#### Types of Changes ####

- [x] Enhancement / Bug fix (added missing WPA3 encryption auth modes in Wi-Fi scan)

#### Verification ####

- Compile and flashe the firmware onto the device
- Scan for Wi-Fi networks with a known WPA3 access point nearby
- Verifie that the encryption type is correctly displayed as WPA3 instead of "Unknown"

#### Testing ####

- Code successfully compiled without errors

#### Further Comments ####

here is the official espressif documentation I used:

https://espressif-docs.readthedocs-hosted.com/projects/esp-idf/en/stable/api-reference/network/esp_wifi.html#_CPPv423WIFI_AUTH_WPA2_WPA3_PSK
