### PR TITLE
Jam Detect: share the Channel Analyzer spectrum view

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -1737,6 +1737,31 @@ uint16_t getColorVariation(uint16_t color, int delta, int direction) {
     return compl_color;
 }
 
+uint16_t blendColors(uint16_t a, uint16_t b, uint8_t t) {
+    int ar = (a >> 11) & 0x1f, ag = (a >> 5) & 0x3f, ab = a & 0x1f;
+    int br = (b >> 11) & 0x1f, bg = (b >> 5) & 0x3f, bb = b & 0x1f;
+    int r = ar + (br - ar) * t / 255;
+    int g = ag + (bg - ag) * t / 255;
+    int bl = ab + (bb - ab) * t / 255;
+    return (uint16_t)((r << 11) | (g << 5) | bl);
+}
+
+void buildHeatPalette(uint16_t *lut, uint8_t n) {
+    if (!lut || n < 2) return;
+    uint16_t bg = bruceConfig.bgColor;
+    uint16_t pri = bruceConfig.priColor;
+    uint16_t hot = blendColors(pri, TFT_WHITE, 150);
+
+    lut[0] = bg;
+    for (uint8_t i = 1; i < n; i++) {
+        int t = i * 255 / (n - 1);
+        // ramp to the primary for the lower two thirds, then burn toward the
+        // highlight so strong signals stay readable against a busy plot
+        lut[i] = (t < 170) ? blendColors(bg, pri, 55 + t * 200 / 255)
+                           : blendColors(pri, hot, (t - 170) * 255 / 85);
+    }
+}
+
 // Draw BITMAP files
 // These read 16- and 32-bit types from the SD card file.
 // BMP data is stored little-endian, Arduino is little-endian too.

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -107,6 +107,12 @@ bool showJpeg(const uint8_t *data_array, size_t data_size, int x, int y, bool ce
 uint16_t getComplementaryColor(uint16_t color);
 uint16_t getComplementaryColor2(uint16_t color);
 uint16_t getColorVariation(uint16_t color, int delta = 10, int direction = 0);
+// Linear RGB565 mix: t = 0 returns a, t = 255 returns b. Use it to derive dim
+// or highlighted shades from the theme instead of hardcoding TFT_* constants.
+uint16_t blendColors(uint16_t a, uint16_t b, uint8_t t);
+// Fills lut[0..n-1] with a theme ramp going from the background up to a
+// brightened primary, for waterfalls and other intensity plots.
+void buildHeatPalette(uint16_t *lut, uint8_t n);
 
 void resetTftDisplay(
     int x = 0, int y = 0, uint16_t fc = bruceConfig.priColor, int size = FM,

--- a/src/core/spectrum_plot.cpp
+++ b/src/core/spectrum_plot.cpp
@@ -1,0 +1,207 @@
+#include "spectrum_plot.h"
+
+#include "core/display.h"
+#include <globals.h>
+
+// Waterfall intensity ramp, quantised so identical columns collapse into runs.
+static const int SP_HEAT_N = 16;
+static uint16_t sp_heat[SP_HEAT_N];
+
+static uint32_t sp_rnd_state = 0x2a3b4c5d;
+
+static inline uint32_t sp_rnd() {
+    sp_rnd_state ^= sp_rnd_state << 13;
+    sp_rnd_state ^= sp_rnd_state >> 17;
+    sp_rnd_state ^= sp_rnd_state << 5;
+    return sp_rnd_state;
+}
+
+uint16_t SpectrumPlot::alertColor() {
+    uint16_t pri = bruceConfig.priColor;
+    int r = (pri >> 11) & 0x1f, g = (pri >> 5) & 0x3f, b = pri & 0x1f;
+    // A red alert would vanish on a red theme, so fall back to amber there.
+    bool reddish = (r > 18 && (g >> 1) < 12 && b < 12);
+    return reddish ? TFT_ORANGE : TFT_RED;
+}
+
+void SpectrumPlot::buildGeometry() {
+    _plotL = 8;
+    _plotW = tftWidth - 16;
+    if (_plotW < 32) {
+        _plotL = 2;
+        _plotW = tftWidth - 4;
+    }
+
+    int top = BORDER_PAD_Y + 8 * FM + 2; // just below the title
+    _footY = tftHeight - 8 * FP - 8;
+    _lblY = _footY - 8 * FP - 2;
+
+    int avail = _lblY - top - 2;
+    if (avail < 20) { // no room for the ruler
+        _lblY = -1;
+        avail = _footY - top - 2;
+    }
+    if (avail < 14) { // no room for the status line either
+        _footY = -1;
+        avail = tftHeight - 6 - top;
+    }
+    if (avail < 8) avail = 8;
+
+    _wfRows = 0;
+    if (avail >= 36) {
+        _wfRows = avail / 3;
+        if (_wfRows > 24) _wfRows = 24;
+    }
+    _specTop = top;
+    _specH = avail - _wfRows - (_wfRows ? 2 : 0);
+    _specBot = _specTop + _specH - 1;
+    _wfTop = _specBot + 3;
+}
+
+void SpectrumPlot::buildPalette() {
+    uint16_t pri = bruceConfig.priColor;
+    _bg = bruceConfig.bgColor;
+    _trace = pri;
+    _body = blendColors(_bg, pri, 95);
+    _bodyHl = blendColors(_bg, pri, 165);
+    _peak = blendColors(pri, TFT_WHITE, 150);
+    _grid = blendColors(_bg, pri, 55);
+    _label = blendColors(_bg, pri, 170);
+    buildHeatPalette(sp_heat, SP_HEAT_N);
+}
+
+bool SpectrumPlot::begin(const String &title) {
+    buildGeometry();
+    buildPalette();
+
+    if (_plotW < 8) return false;
+
+    if (_wfRows) {
+        _wf = (uint8_t *)calloc((size_t)_wfRows * _plotW, 1);
+        if (!_wf) _wfRows = 0; // degrade to a plot without history rather than fail
+    }
+    _wfHead = 0;
+    _ok = true;
+
+    drawMainBorderWithTitle(title); // clears the screen itself
+
+    drawWaterfall();
+    return true;
+}
+
+void SpectrumPlot::end() {
+    free(_wf);
+    _wf = nullptr;
+    _wfRows = 0;
+    _ok = false;
+}
+
+void SpectrumPlot::trace(const uint8_t *env, const uint8_t *envPeak, int hlL, int hlR, bool alert) {
+    if (!_ok || !env) return;
+
+    uint16_t trace = alert ? alertColor() : _trace;
+    uint16_t bodyHl = alert ? blendColors(_bg, trace, 165) : _bodyHl;
+
+    int gy[3];
+    gy[0] = _specBot - _specH / 4;
+    gy[1] = _specBot - _specH / 2;
+    gy[2] = _specBot - (_specH * 3) / 4;
+
+    // Every pixel of the band is written exactly once per frame, which keeps the
+    // animation flicker free without needing a full-screen sprite.
+    for (int i = 0; i < _plotW; i++) {
+        int x = _plotL + i;
+
+        int hLive = (int)env[i] * (_specH - 1) / 100;
+        int grass = (int)(sp_rnd() % 3); // animated noise floor
+        if (hLive < grass) hLive = grass;
+        int hPeak = envPeak ? (int)envPeak[i] * (_specH - 1) / 100 : 0;
+        if (hPeak < hLive) hPeak = hLive;
+
+        int yLive = _specBot - hLive;
+        int yPeak = _specBot - hPeak;
+
+        if (yPeak > _specTop) tft.drawFastVLine(x, _specTop, yPeak - _specTop, _bg);
+        if (hPeak > hLive) {
+            tft.drawPixel(x, yPeak, _peak);
+            if (yLive > yPeak + 1) tft.drawFastVLine(x, yPeak + 1, yLive - yPeak - 1, _bg);
+        }
+        tft.drawPixel(x, yLive, trace);
+        if (hLive > 0)
+            tft.drawFastVLine(x, yLive + 1, hLive, (i >= hlL && i <= hlR) ? bodyHl : _body);
+
+        // dashed reference grid, visible only through the empty sky
+        if ((i & 3) == 0) {
+            for (int k = 0; k < 3; k++)
+                if (gy[k] > _specTop && gy[k] < yLive - 1) tft.drawPixel(x, gy[k], _grid);
+        }
+    }
+}
+
+// Newest row sits right under the trace baseline and older ones fall away.
+void SpectrumPlot::drawWaterfall() {
+    if (!_wfRows || !_wf) return;
+
+    for (int r = 0; r < _wfRows; r++) {
+        int idx = (_wfHead - r + 2 * _wfRows) % _wfRows;
+        const uint8_t *row = _wf + (size_t)idx * _plotW;
+        int y = _wfTop + r;
+
+        // flush equal-coloured columns as single spans, the rows are wide
+        int runStart = 0;
+        uint16_t runCol = sp_heat[row[0] * (SP_HEAT_N - 1) / 100];
+        for (int i = 1; i <= _plotW; i++) {
+            bool last = (i == _plotW);
+            uint16_t c = last ? runCol : sp_heat[row[i] * (SP_HEAT_N - 1) / 100];
+            if (last || c != runCol) {
+                tft.drawFastHLine(_plotL + runStart, y, i - runStart, runCol);
+                runStart = i;
+                runCol = c;
+            }
+        }
+    }
+}
+
+void SpectrumPlot::pushRow(const uint8_t *env) {
+    if (!_ok || !_wfRows || !_wf || !env) return;
+    _wfHead = (_wfHead + 1) % _wfRows;
+    memcpy(_wf + (size_t)_wfHead * _plotW, env, _plotW);
+    drawWaterfall();
+}
+
+void SpectrumPlot::ruler(const int *cols, const String *labels, int count, int highlight) {
+    if (!_ok || _lblY < 0 || !cols || !labels) return;
+
+    int h = 8 * FP;
+    tft.fillRect(_plotL, _lblY - 1, _plotW, h + 2, _bg);
+    tft.setTextSize(FP);
+
+    for (int i = 0; i < count; i++) {
+        int w = labels[i].length() * FP * LW;
+        int tx = _plotL + cols[i] - w / 2;
+        // keep edge labels inside the plot
+        if (tx < _plotL) tx = _plotL;
+        if (tx + w > _plotL + _plotW) tx = _plotL + _plotW - w;
+
+        if (i == highlight) {
+            tft.fillRect(tx - 2, _lblY - 1, w + 4, h + 2, bruceConfig.priColor);
+            tft.setTextColor(_bg, bruceConfig.priColor);
+        } else {
+            tft.setTextColor(_label, _bg);
+        }
+        tft.drawString(labels[i], tx, _lblY, 1);
+    }
+}
+
+void SpectrumPlot::status(const String &text, bool alert) {
+    if (!_ok || _footY < 0) return;
+
+    tft.fillRect(_plotL, _footY, _plotW, 8 * FP, _bg);
+    tft.setTextSize(FP);
+    tft.setTextColor(alert ? alertColor() : _label, _bg);
+
+    String s = text;
+    int maxChars = _plotW / (FP * LW);
+    if ((int)s.length() > maxChars) s = s.substring(0, maxChars);
+    tft.drawString(s, _plotL, _footY, 1);
+}

--- a/src/core/spectrum_plot.h
+++ b/src/core/spectrum_plot.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Shared spectrum-analyzer plot.
+//
+// Owns the layout, palette and painting for every "signal strength across a
+// frequency band" screen in Bruce, so Channel Analyzer, Jam Detect and the NRF
+// sweeper share one look instead of each inventing its own bars and colours.
+//
+// The band itself is caller supplied: modules fill an envelope of width()
+// values in 0-100 and the plot turns it into a filled trace with a peak-hold
+// line, an animated noise floor, a dashed reference grid and a scrolling
+// waterfall. Every colour is derived from the active theme.
+//
+// Typical use:
+//     SpectrumPlot plot;
+//     if (!plot.begin("My Scanner")) return;      // frees itself on failure
+//     ...
+//     plot.trace(env, envPeak, hlLeft, hlRight);  // once per animation frame
+//     plot.pushRow(env);                          // once per completed sweep
+//     plot.ruler(cols, labels, n, current);
+//     plot.status("...");
+//     plot.end();
+class SpectrumPlot {
+public:
+    bool begin(const String &title);
+    void end();
+    bool ready() const { return _ok; }
+
+    // Number of columns the caller must fill, and where they land on screen.
+    int width() const { return _plotW; }
+    int left() const { return _plotL; }
+
+    // Paints one frame of the live band. `env` and `envPeak` hold width()
+    // values in 0-100; envPeak may be null. Columns in [hlL, hlR] are filled
+    // with the highlight shade to mark the slice being measured — pass
+    // hlL > hlR for none. `alert` recolours the trace to flag a bad reading.
+    void trace(const uint8_t *env, const uint8_t *envPeak, int hlL, int hlR, bool alert = false);
+
+    // Appends `env` to the waterfall history and repaints it. No-op when the
+    // screen is too short for a waterfall.
+    void pushRow(const uint8_t *env);
+
+    // Labelled ticks under the plot. `cols` are column indices in 0..width()-1;
+    // `highlight` indexes the entry to draw inverted, or -1 for none.
+    void ruler(const int *cols, const String *labels, int count, int highlight = -1);
+
+    // Single line of text at the bottom, truncated to fit.
+    void status(const String &text, bool alert = false);
+
+    // Colour for out-of-range readings, kept visible even on a reddish theme.
+    static uint16_t alertColor();
+
+private:
+    void buildGeometry();
+    void buildPalette();
+    void drawWaterfall();
+
+    bool _ok = false;
+
+    int _plotL = 0, _plotW = 0;
+    int _specTop = 0, _specBot = 0, _specH = 0;
+    int _wfTop = 0, _wfRows = 0;
+    int _lblY = -1;  // -1 when the screen is too short for the ruler
+    int _footY = -1; // -1 when the screen is too short for the status line
+
+    uint16_t _bg = 0, _body = 0, _bodyHl = 0, _trace = 0, _peak = 0, _grid = 0, _label = 0;
+
+    uint8_t *_wf = nullptr; // _wfRows x _plotW ring of rendered envelopes
+    int _wfHead = 0;
+};

--- a/src/modules/wifi/jam_detect.cpp
+++ b/src/modules/wifi/jam_detect.cpp
@@ -10,6 +10,7 @@
 #include "core/display.h"
 #include "core/mykeyboard.h"
 #include "core/wifi/wifi_common.h"
+#include "wifi_spectrum.h"
 #include <Arduino.h>
 #include <globals.h>
 
@@ -72,75 +73,39 @@ static void jd_stop_wifi() {
     vTaskDelay(1 / portTICK_RATE_MS);
 }
 
-static void
-jd_draw(const uint16_t *dps, const uint16_t *peak, uint32_t thr, uint8_t curCh, int attackCh) {
-    drawMainBorderWithTitle("Jam Detect");
-    tft.setTextSize(FP);
-
-    const int x0 = 8;
-    int y = 26;
-
-    // status banner
-    bool attack = (attackCh >= 0);
-    uint16_t sc = attack ? TFT_RED : TFT_GREEN;
-    tft.fillRect(x0, y, tftWidth - 2 * x0, 18, sc);
-    tft.setTextColor(TFT_BLACK, sc);
-    String banner = attack ? ("ATTACK ch" + String(attackCh) + "  " + String(dps[attackCh]) + "/s")
-                           : "scanning... no jamming";
-    tft.drawCentreString(banner, tftWidth / 2, y + 3, 1);
-    y += 24;
-
-    // per-channel deauth bars
-    const int labelW = 28;
-    const int valW = 26;
-    const int barX = x0 + labelW;
-    const int bottom = tftHeight - 14;
-    const int rowH = (bottom - y) / JD_NCH;
-    const int barW = tftWidth - barX - valW - 6;
+// Rates are unbounded, so normalise against twice the alert threshold: a channel
+// sitting exactly on the threshold fills half the lobe and anything past double
+// it saturates. Keeps the shared spectrum view fed with plain 0-100 levels.
+static void jd_normalize(const uint16_t *src, uint8_t *dst, uint32_t thr) {
     uint32_t scale = thr * 2;
     if (scale < 4) scale = 4;
-
     for (int i = 0; i < JD_NCH; i++) {
         uint8_t ch = JD_CHANNELS[i];
-        int ry = y + i * rowH;
-        bool isCur = (ch == curCh);
-        bool over = (dps[ch] >= thr);
-
-        tft.setTextColor(
-            isCur ? bruceConfig.bgColor : bruceConfig.priColor,
-            isCur ? bruceConfig.priColor : bruceConfig.bgColor
-        );
-        tft.drawString("Ch" + String(ch), x0, ry, 1);
-
-        int bh = rowH - 3;
-        if (bh < 4) bh = 4;
-        tft.drawRect(barX, ry, barW, bh, bruceConfig.priColor);
-        tft.fillRect(barX + 1, ry + 1, barW - 2, bh - 2, bruceConfig.bgColor);
-        uint32_t fillW = (uint32_t)(barW - 2) * dps[ch] / scale;
-        if (fillW > (uint32_t)(barW - 2)) fillW = barW - 2;
-        if (fillW > 0) tft.fillRect(barX + 1, ry + 1, (int)fillW, bh - 2, over ? TFT_RED : bruceConfig.priColor);
-        // peak-hold marker
-        uint32_t pkX = (uint32_t)(barX + 1) + (uint32_t)(barW - 2) * peak[ch] / scale;
-        if (peak[ch] > 0 && pkX > (uint32_t)(barX + 1)) tft.drawFastVLine((int)pkX, ry + 1, bh - 2, TFT_YELLOW);
-
-        tft.setTextColor(over ? TFT_RED : bruceConfig.priColor, bruceConfig.bgColor);
-        tft.drawString(String(dps[ch]), barX + barW + 4, ry, 1);
+        uint32_t v = (uint32_t)src[ch] * 100UL / scale;
+        dst[ch] = (uint8_t)(v > 100 ? 100 : v);
     }
-
-    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
-    tft.drawString("scan ch" + String(curCh) + " thr" + String(thr) + "/s  UP/DN  ESC", x0, tftHeight - 12, 1);
 }
 
 void jam_detect_setup() {
     returnToMenu = false;
 
-    uint16_t dps[12] = {0};  // last measured deauth/s per channel (latched)
-    uint16_t peak[12] = {0}; // peak-hold
+    uint16_t dps[WifiSpectrumView::CH_MAX] = {0};  // last measured deauth/s per channel (latched)
+    uint16_t peak[WifiSpectrumView::CH_MAX] = {0}; // peak-hold
+    uint8_t lvl[WifiSpectrumView::CH_MAX] = {0};   // dps[] scaled to the 0-100 the view wants
+    uint8_t lvlPeak[WifiSpectrumView::CH_MAX] = {0};
     uint32_t threshold = 10; // deauth/s to flag (adjustable)
     int idx = 0;
+    int attackCh = -1;
+
+    WifiSpectrumView view;
+    if (!view.begin("Jam Detect")) {
+        displayError("Out of memory", true);
+        return;
+    }
 
     jd_start_wifi();
-    tft.fillScreen(bruceConfig.bgColor);
+    view.commit(lvl, JD_CHANNELS[0]);
+    view.status("CH" + String(JD_CHANNELS[0]) + " scanning  thr" + String(threshold) + "/s");
 
     for (;;) {
         if (returnToMenu) break;
@@ -161,6 +126,7 @@ void jam_detect_setup() {
         // and redraw RIGHT AWAY instead of waiting for the dwell to finish.
         bool tripped = false;
         uint32_t t0 = millis();
+        uint32_t lastFrame = 0;
         while (millis() - t0 < JD_DWELL) {
             if (check(EscPress)) {
                 returnToMenu = true;
@@ -175,6 +141,12 @@ void jam_detect_setup() {
                 tripped = true;
                 break; // detected — stop dwelling, draw immediately, then hop on
             }
+            // Keep the trace breathing between hops; the dwell is short, so this
+            // usually lands once per channel.
+            if (millis() - lastFrame >= 60) {
+                lastFrame = millis();
+                view.animate(lvl, lvlPeak, ch, attackCh >= 0);
+            }
             vTaskDelay(5 / portTICK_PERIOD_MS);
         }
         if (returnToMenu) break;
@@ -188,7 +160,7 @@ void jam_detect_setup() {
         // across the sweep so an attack stays flagged after we hop away).
         // `tripped` guarantees the channel we just left is considered even if a
         // later channel happens to read higher this redraw.
-        int attackCh = -1;
+        attackCh = -1;
         uint16_t worst = 0;
         for (int i = 0; i < JD_NCH; i++) {
             uint8_t c = JD_CHANNELS[i];
@@ -199,10 +171,26 @@ void jam_detect_setup() {
         }
         if (tripped && attackCh < 0) attackCh = ch; // ensure the live trip is shown
 
-        jd_draw(dps, peak, threshold, ch, attackCh);
+        jd_normalize(dps, lvl, threshold);
+        jd_normalize(peak, lvlPeak, threshold);
+
+        view.animate(lvl, lvlPeak, ch, attackCh >= 0);
+        view.commit(lvl, ch);
+        if (attackCh >= 0) {
+            view.status(
+                "! ATTACK CH" + String(attackCh) + " " + String(dps[attackCh]) + "/s  thr" +
+                    String(threshold),
+                true
+            );
+        } else {
+            view.status("CH" + String(ch) + " clear  thr" + String(threshold) + "/s  UP/DN");
+        }
+
         idx = (idx + 1) % JD_NCH;
+        if (idx == 0) drawStatusBar(); // keep battery/clock fresh once per sweep
     }
 
+    view.end();
     jd_stop_wifi();
 }
 

--- a/src/modules/wifi/wifi_spectrum.cpp
+++ b/src/modules/wifi/wifi_spectrum.cpp
@@ -1,0 +1,119 @@
+#if !defined(LITE_VERSION)
+#include "wifi_spectrum.h"
+
+#include "core/display.h"
+#include <globals.h>
+#include <math.h>
+
+// Frequency axis in 0.1MHz units: ch1 = 2412.0MHz, 5MHz spacing, plus a small
+// margin on each side so the outer lobes are not cut too abruptly.
+static const int WS_FCH1 = 24120;
+static const int WS_FSTEP = 50;
+static const int WS_FMARGIN = 70;
+static const int WS_FMIN = WS_FCH1 - WS_FMARGIN;
+static const int WS_FSPAN = (WifiSpectrumView::CHANNELS - 1) * WS_FSTEP + 2 * WS_FMARGIN;
+static const int WS_FLOBE = 220; // lobe reach: +/-22MHz
+
+// Lobe shape sampled over 0..22MHz from the carrier, built once per process.
+static const int WS_SHAPE_N = 48;
+static uint8_t ws_shape[WS_SHAPE_N];
+static bool ws_shape_ready = false;
+
+static void ws_build_shape() {
+    if (ws_shape_ready) return;
+    for (int i = 0; i < WS_SHAPE_N; i++) {
+        float d = 22.0f * i / (WS_SHAPE_N - 1); // MHz from the carrier
+        float a;
+        if (d <= 11.0f) a = 0.5f * (1.0f + cosf(PI * d / 11.0f)); // main lobe
+        else a = 0.05f * (1.0f - cosf(2.0f * PI * (d - 11.0f) / 11.0f)); // side lobe
+        ws_shape[i] = (uint8_t)(a * 255.0f + 0.5f);
+    }
+    ws_shape_ready = true;
+}
+
+static inline int ws_freq(uint8_t ch) { return WS_FCH1 + (ch - 1) * WS_FSTEP; }
+
+// Column index for a frequency, in plot coordinates.
+static inline int ws_col(int fq, int plotW) {
+    return (int)((int32_t)(fq - WS_FMIN) * (plotW - 1) / WS_FSPAN);
+}
+
+bool WifiSpectrumView::begin(const String &title) {
+    ws_build_shape();
+    if (!_plot.begin(title)) return false;
+
+    _env = (uint8_t *)malloc(_plot.width());
+    _envPeak = (uint8_t *)malloc(_plot.width());
+    if (!_env || !_envPeak) {
+        end();
+        return false;
+    }
+    memset(_disp, 0, sizeof(_disp));
+    memset(_env, 0, _plot.width());
+    return true;
+}
+
+void WifiSpectrumView::end() {
+    free(_env);
+    free(_envPeak);
+    _env = _envPeak = nullptr;
+    _plot.end();
+}
+
+// Envelope of the per-channel values across the plot, taking the strongest
+// contributor at each column so overlapping lobes read as one skyline.
+void WifiSpectrumView::envelope(const uint8_t *v, uint8_t *env) const {
+    int plotW = _plot.width();
+    for (int i = 0; i < plotW; i++) {
+        int fq = WS_FMIN + (int)((int32_t)i * WS_FSPAN / (plotW - 1));
+        uint8_t best = 0;
+        for (int ch = 1; ch <= CHANNELS; ch++) {
+            if (!v[ch]) continue;
+            int d = fq - ws_freq(ch);
+            if (d < 0) d = -d;
+            if (d >= WS_FLOBE) continue;
+            uint8_t a = (uint8_t)((uint16_t)v[ch] * ws_shape[d * (WS_SHAPE_N - 1) / WS_FLOBE] / 255);
+            if (a > best) best = a;
+        }
+        env[i] = best;
+    }
+}
+
+void WifiSpectrumView::animate(const uint8_t *level, const uint8_t *peak, uint8_t curCh, bool alert) {
+    if (!ready()) return;
+
+    for (int ch = 1; ch <= CHANNELS; ch++) {
+        int d = (int)level[ch] - (int)_disp[ch];
+        if (d) _disp[ch] = (uint8_t)((int)_disp[ch] + (d > 0 ? max(1, d / 3) : min(-1, d / 3)));
+    }
+    envelope(_disp, _env);
+    envelope(peak, _envPeak);
+
+    // highlight the 22MHz slice the radio is parked on
+    int plotW = _plot.width();
+    _plot.trace(_env, _envPeak, ws_col(ws_freq(curCh) - 110, plotW), ws_col(ws_freq(curCh) + 110, plotW), alert);
+}
+
+void WifiSpectrumView::commit(const uint8_t *level, uint8_t curCh) {
+    if (!ready()) return;
+
+    envelope(level, _env);
+    _plot.pushRow(_env);
+
+    int plotW = _plot.width();
+    int cols[CHANNELS];
+    String labels[CHANNELS];
+    int n = 0, highlight = -1;
+    // drop even channels when the ruler would collide, but never the current one
+    bool sparse = (plotW * WS_FSTEP) / WS_FSPAN < (2 * FP * LW + 4);
+    for (int ch = 1; ch <= CHANNELS; ch++) {
+        if (sparse && !(ch & 1) && ch != curCh) continue;
+        if (ch == curCh) highlight = n;
+        cols[n] = ws_col(ws_freq(ch), plotW);
+        labels[n] = String(ch);
+        n++;
+    }
+    _plot.ruler(cols, labels, n, highlight);
+}
+
+#endif

--- a/src/modules/wifi/wifi_spectrum.h
+++ b/src/modules/wifi/wifi_spectrum.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#if !defined(LITE_VERSION)
+
+#include "core/spectrum_plot.h"
+#include <Arduino.h>
+
+// 2.4GHz WiFi channel view, built on SpectrumPlot.
+//
+// Turns per-channel levels into overlapping spectral lobes on a real frequency
+// axis, so the 22MHz overlap between neighbours is visible and a sweep reads as
+// one continuous trace instead of eleven isolated bars.
+//
+// Callers own the radio and feed normalised 0-100 levels indexed by channel
+// number; everything on screen belongs to the view.
+class WifiSpectrumView {
+public:
+    static const int CHANNELS = 11;
+    static const int CH_MAX = 12; // arrays are indexed by channel number
+
+    // Allocates the column buffers and paints the frame. Returns false when
+    // there is not enough memory, in which case nothing was drawn.
+    bool begin(const String &title);
+    void end();
+    bool ready() const { return _env != nullptr; }
+
+    // One animation frame. The drawn levels ease toward `level` so the sweep
+    // glides instead of snapping when a measurement lands. `alert` recolours
+    // the trace to flag an abnormal reading.
+    void animate(const uint8_t *level, const uint8_t *peak, uint8_t curCh, bool alert = false);
+
+    // Call once per completed measurement: pushes a waterfall row and repaints
+    // the channel ruler with `curCh` highlighted.
+    void commit(const uint8_t *level, uint8_t curCh);
+
+    void status(const String &text, bool alert = false) { _plot.status(text, alert); }
+
+private:
+    void envelope(const uint8_t *v, uint8_t *env) const;
+
+    SpectrumPlot _plot;
+    uint8_t *_env = nullptr;
+    uint8_t *_envPeak = nullptr;
+    uint8_t _disp[CH_MAX] = {0};
+};
+
+#endif


### PR DESCRIPTION
#### Proposed Changes ####

Jam Detect and Channel Analyzer sweep the same eleven channels and carried two
separate implementations of the same stacked-bar drawing, differing mainly in
which fixed TFT_ constants each had picked. Jam Detect also flagged attacks
with a TFT_RED/TFT_GREEN banner that ignored the theme entirely.

The ~55 line jd_draw is replaced by a 12 line jd_normalize that scales
deauth/s against twice the alert threshold - a channel sitting exactly on the
threshold fills half its lobe, anything past double saturates - and hands the
result to WifiSpectrumView. Both modules now look identical.

The alert recolours the trace and the status line instead of painting a
banner, using a colour chosen to stay visible even when the theme itself is
reddish.

Detection is untouched: the deauth/disassoc frame test, the channel hop, the
rate extrapolation and the immediate in-dwell trip all behave as before.

#### Types of Changes ####

New Feature / UI rework. No breaking change. Detection behaviour is unchanged.

#### Verification ####

Flash and open WiFi -> Jam Detect. With no attack running, expect a quiet
trace and a "clear" status line. Then run a deauth flood from a second device
on a known channel and expect:

  - that channel's lobe to rise and the trace to switch to the alert colour
  - the status line to read "! ATTACK CHn <rate>/s" in the alert colour
  - the alert to latch while the sweep moves on, as it did before
  - Up/Down to still move the threshold in steps of 5, between 5 and 250

Setting the threshold below the ambient deauth rate should trip immediately,
which is the quickest way to check the alert path without generating traffic.

#### Testing ####

No unit test harness exists for this layer. jam_detect.cpp compiles clean for
m5stack-cardputer, verified in the combined tree; this branch was not built in
isolation. Not yet verified on hardware by me - the alert path in particular
should be confirmed against a real deauth source.

#### Linked Issues ####

None. Depends on #2755 (ui/spectrum-view).

#### User-Facing Change ####
```release-note
Jam Detect now shares the Channel Analyzer spectrum display. Attacks are flagged by recolouring the trace and status line instead of a coloured banner, and the alert colour follows the active theme.
```

#### Further Comments ####

The rate is unbounded while the shared view wants 0-100, so the normalisation
picks twice the threshold as full scale. That choice is what makes the plot
readable at any threshold setting, but it does mean the lobe height is
relative to the threshold rather than absolute - the exact rate stays in the
status line.

---

> **Stacked PR.** This branch is built on #2754 and #2755. GitHub can only base a cross-fork PR on an upstream branch, so until they are merged the diff above also contains their commits. Review only the commit titled *Jam Detect: share the Channel Analyzer spectrum view*; the diff shrinks on its own once the base lands.