### PR TITLE
RF Spectrum: derive the plot area from the panel, not from a 120px screen

### DIFF
--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -1737,6 +1737,31 @@ uint16_t getColorVariation(uint16_t color, int delta, int direction) {
     return compl_color;
 }
 
+uint16_t blendColors(uint16_t a, uint16_t b, uint8_t t) {
+    int ar = (a >> 11) & 0x1f, ag = (a >> 5) & 0x3f, ab = a & 0x1f;
+    int br = (b >> 11) & 0x1f, bg = (b >> 5) & 0x3f, bb = b & 0x1f;
+    int r = ar + (br - ar) * t / 255;
+    int g = ag + (bg - ag) * t / 255;
+    int bl = ab + (bb - ab) * t / 255;
+    return (uint16_t)((r << 11) | (g << 5) | bl);
+}
+
+void buildHeatPalette(uint16_t *lut, uint8_t n) {
+    if (!lut || n < 2) return;
+    uint16_t bg = bruceConfig.bgColor;
+    uint16_t pri = bruceConfig.priColor;
+    uint16_t hot = blendColors(pri, TFT_WHITE, 150);
+
+    lut[0] = bg;
+    for (uint8_t i = 1; i < n; i++) {
+        int t = i * 255 / (n - 1);
+        // ramp to the primary for the lower two thirds, then burn toward the
+        // highlight so strong signals stay readable against a busy plot
+        lut[i] = (t < 170) ? blendColors(bg, pri, 55 + t * 200 / 255)
+                           : blendColors(pri, hot, (t - 170) * 255 / 85);
+    }
+}
+
 // Draw BITMAP files
 // These read 16- and 32-bit types from the SD card file.
 // BMP data is stored little-endian, Arduino is little-endian too.

--- a/src/core/display.h
+++ b/src/core/display.h
@@ -107,6 +107,12 @@ bool showJpeg(const uint8_t *data_array, size_t data_size, int x, int y, bool ce
 uint16_t getComplementaryColor(uint16_t color);
 uint16_t getComplementaryColor2(uint16_t color);
 uint16_t getColorVariation(uint16_t color, int delta = 10, int direction = 0);
+// Linear RGB565 mix: t = 0 returns a, t = 255 returns b. Use it to derive dim
+// or highlighted shades from the theme instead of hardcoding TFT_* constants.
+uint16_t blendColors(uint16_t a, uint16_t b, uint8_t t);
+// Fills lut[0..n-1] with a theme ramp going from the background up to a
+// brightened primary, for waterfalls and other intensity plots.
+void buildHeatPalette(uint16_t *lut, uint8_t n);
 
 void resetTftDisplay(
     int x = 0, int y = 0, uint16_t fc = bruceConfig.priColor, int size = FM,

--- a/src/modules/rf/rf_spectrum.cpp
+++ b/src/modules/rf/rf_spectrum.cpp
@@ -1,8 +1,33 @@
 #include "rf_spectrum.h"
+#include "core/display.h"
 #include "protocols/rf_config.h"
 #include "protocols/rf_decoder.h"
 #include "rf_utils.h"
 #include "structs.h"
+
+// Plot band, derived from the panel so the graph never collides with the title
+// bar or the status line on any of the supported screens.
+static inline int rf_plot_top() { return BORDER_PAD_Y + 8 * FM + 2; }
+static inline int rf_plot_bot() { return tftHeight - 8 * FP - 8; }
+// Side margins keep the graph clear of the rounded theme border at x = 5.
+static inline int rf_plot_left() { return 8; }
+static inline int rf_plot_width() { return tftWidth - 16; }
+static inline uint16_t rf_grid_color() {
+    return blendColors(bruceConfig.bgColor, bruceConfig.priColor, 55);
+}
+static inline uint16_t rf_label_color() {
+    return blendColors(bruceConfig.bgColor, bruceConfig.priColor, 170);
+}
+
+// Frame plus a single status line at the bottom. Drawn once, and again only
+// when the tuning changes, so the live graph never flickers.
+static void draw_rf_header(const String &title, const String &info) {
+    drawMainBorderWithTitle(title);
+    tft.setTextSize(FP);
+    tft.fillRect(rf_plot_left(), rf_plot_bot() + 2, rf_plot_width(), 8 * FP, bruceConfig.bgColor);
+    tft.setTextColor(rf_label_color(), bruceConfig.bgColor);
+    tft.drawString(info, rf_plot_left(), rf_plot_bot() + 2, 1);
+}
 
 static bool spectrum_rmt_rx_done_callback(
     rmt_channel_t *channel, const rmt_rx_done_event_data_t *edata, void *user_data
@@ -15,19 +40,31 @@ static bool spectrum_rmt_rx_done_callback(
 }
 
 void draw_tf_spectrum_grid() {
-    tft.setTextSize(1);
-    tft.setCursor(3, 2);
-    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
-    tft.printf(" RF - Spectrum (%.2f Mhz)", bruceConfigPins.rfFreq);
-    tft.fillRect(0, 20, tftWidth, tftHeight - 20, bruceConfig.bgColor);
-    tft.drawFastHLine(0, 20 + tftHeight / 2, tftWidth, TFT_DARKGREY);
-    tft.drawFastVLine((1 * tftWidth) / 4, 20, tftHeight - 20, TFT_DARKGREY);
-    tft.drawFastVLine((2 * tftWidth) / 4, 20, tftHeight - 20, TFT_DARKGREY);
-    tft.drawFastVLine((3 * tftWidth) / 4, 20, tftHeight - 20, TFT_DARKGREY);
+    const int top = rf_plot_top();
+    const int bot = rf_plot_bot();
+    const uint16_t grid = rf_grid_color();
+
+    const int left = rf_plot_left();
+    const int w = rf_plot_width();
+
+    tft.fillRect(left, top, w, bot - top, bruceConfig.bgColor);
+    tft.drawFastHLine(left, (top + bot) / 2, w, grid);
+    for (int i = 1; i < 4; i++) tft.drawFastVLine(left + (i * w) / 4, top, bot - top, grid);
+}
+
+// Centres a pulse-width bar on the mid line of the plot band.
+static void draw_rf_pulse(int x, int magnitude) {
+    const int top = rf_plot_top();
+    const int bot = rf_plot_bot();
+    const int mid = (top + bot) / 2;
+    int h = map(magnitude, 0, SIGNAL_STRENGTH_THRESHOLD, 0, bot - top);
+    int startY = constrain(mid - h / 2, top, bot);
+    int endY = constrain(mid + h / 2, top, bot);
+    tft.drawLine(x, startY, x, endY, bruceConfig.priColor);
 }
 
 void rf_spectrum() {
-    tft.fillScreen(bruceConfig.bgColor);
+    draw_rf_header("RF Spectrum", String(bruceConfigPins.rfFreq, 2) + " MHz");
     draw_tf_spectrum_grid();
     if (bruceConfigPins.rfModule == M5_RF_MODULE) {
         RfRxSession rx;
@@ -41,13 +78,10 @@ void rf_spectrum() {
             if (rx.poll(durations)) {
                 draw_tf_spectrum_grid();
                 for (size_t i = 0; i < durations.size(); i++) {
-                    int pulse = abs(durations[i]);
-                    int lineHeight = map(pulse, 0, SIGNAL_STRENGTH_THRESHOLD, 0, tftHeight / 2);
                     int lineX =
-                        map(i, 0, durations.size() > 1 ? durations.size() - 1 : 1, 0, tftWidth - 1);
-                    int startY = constrain(20 + tftHeight / 2 - lineHeight / 2, 20, 20 + tftHeight);
-                    int endY = constrain(20 + tftHeight / 2 + lineHeight / 2, 20, 20 + tftHeight);
-                    tft.drawLine(lineX, startY, lineX, endY, bruceConfig.priColor);
+                        rf_plot_left() +
+                        map(i, 0, durations.size() > 1 ? durations.size() - 1 : 1, 0, rf_plot_width() - 1);
+                    draw_rf_pulse(lineX, abs(durations[i]));
                 }
                 RF_DBG("m5 spectrum: durations=%u", (unsigned)durations.size());
             }
@@ -56,6 +90,7 @@ void rf_spectrum() {
             if (setMHZMenu()) {
                 rx.end();
                 rx.begin();
+                draw_rf_header("RF Spectrum", String(bruceConfigPins.rfFreq, 2) + " MHz");
                 draw_tf_spectrum_grid();
             }
             vTaskDelay(pdMS_TO_TICKS(10));
@@ -98,16 +133,8 @@ void rf_spectrum() {
             draw_tf_spectrum_grid();
             // Draw waveform based on signal strength
             for (size_t i = 0; i < rx_size; i++) {
-                int lineHeight =
-                    map(rx_items[i].duration0 + rx_items[i].duration1,
-                        0,
-                        SIGNAL_STRENGTH_THRESHOLD,
-                        0,
-                        tftHeight / 2);
-                int lineX = map(i, 0, rx_size - 1, 0, tftWidth - 1); // Map i to within the display width
-                int startY = constrain(20 + tftHeight / 2 - lineHeight / 2, 20, 20 + tftHeight);
-                int endY = constrain(20 + tftHeight / 2 + lineHeight / 2, 20, 20 + tftHeight);
-                tft.drawLine(lineX, startY, lineX, endY, bruceConfig.priColor);
+                int lineX = rf_plot_left() + map(i, 0, rx_size - 1, 0, rf_plot_width() - 1);
+                draw_rf_pulse(lineX, rx_items[i].duration0 + rx_items[i].duration1);
             }
 
             ESP_ERROR_CHECK(rmt_receive(rx_ch, item, sizeof(item), &receive_config));
@@ -125,7 +152,7 @@ void rf_spectrum() {
     deinitRfModule();
 }
 
-#define TIME_DIVIDER (tftWidth / 10)
+#define TIME_DIVIDER (rf_plot_width() / 10)
 //@Pirata
 void rf_SquareWave() {
     if (!initRfModule("rx", bruceConfigPins.rfFreq)) return;
@@ -135,15 +162,18 @@ void rf_SquareWave() {
         deinitRfModule();
         return;
     }
-    int line_w = 0;
-    int line_h = 15;
+    const int top = rf_plot_top();
+    const int bot = rf_plot_bot();
+    const int traceH = 6; // height of one logic level
+    int line_w = rf_plot_left();
+    int line_h = top;
     std::vector<int> durations;
 PRINT:
     tft.drawPixel(0, 0, 0);
-    tft.fillScreen(bruceConfig.bgColor);
-    tft.setTextSize(1);
-    tft.setCursor(3, 2);
-    tft.printf("  RF - SquareWave (%.2f Mhz)", bruceConfigPins.rfFreq);
+    line_w = rf_plot_left();
+    line_h = top;
+    draw_rf_header("RF SquareWave", String(bruceConfigPins.rfFreq, 2) + " MHz");
+    tft.fillRect(rf_plot_left(), top, rf_plot_width(), bot - top, bruceConfig.bgColor);
 
     while (1) {
         if (rx.poll(durations)) {
@@ -155,20 +185,23 @@ PRINT:
 
                 if (high > 20000) high = 20000;
                 if (low > 20000) low = 20000;
-                if (line_w + (high + low) / TIME_DIVIDER > tftWidth) {
-                    line_w = 10;
-                    line_h += 10;
+                if (line_w + (high + low) / TIME_DIVIDER > rf_plot_left() + rf_plot_width()) {
+                    line_w = rf_plot_left();
+                    line_h += traceH + 4;
                 }
-                if (line_h > tftHeight) {
-                    line_h = 15;
-                    tft.fillRect(0, 12, tftWidth, tftHeight, bruceConfig.bgColor);
+                if (line_h + traceH > bot) {
+                    line_h = top;
+                    tft.fillRect(rf_plot_left(), top, rf_plot_width(), bot - top, bruceConfig.bgColor);
                 }
-                tft.drawFastVLine(line_w, line_h, 6, bruceConfig.priColor);
+                tft.drawFastVLine(line_w, line_h, traceH, bruceConfig.priColor);
                 tft.drawFastHLine(line_w, line_h, high / TIME_DIVIDER, bruceConfig.priColor);
 
-                tft.drawFastVLine(line_w + high / TIME_DIVIDER, line_h, 6, bruceConfig.priColor);
+                tft.drawFastVLine(line_w + high / TIME_DIVIDER, line_h, traceH, bruceConfig.priColor);
                 tft.drawFastHLine(
-                    line_w + high / TIME_DIVIDER, line_h + 6, low / TIME_DIVIDER, bruceConfig.priColor
+                    line_w + high / TIME_DIVIDER,
+                    line_h + traceH,
+                    low / TIME_DIVIDER,
+                    bruceConfig.priColor
                 );
                 line_w += (high + low) / TIME_DIVIDER;
             }
@@ -188,53 +221,64 @@ void rf_CC1101_rssi() {
         displayError("only for CC1101 module", true);
         return;
     }
-    int graph_size = tftWidth - 20;
+    // Left gutter wide enough for the "-95" scale labels, band derived from the
+    // panel instead of assuming a 120px tall screen.
+    const int top = rf_plot_top();
+    const int bot = rf_plot_bot();
+    const int axisX = rf_plot_left() + 3 * FP * LW + 2;
+    const int graph_size = rf_plot_left() + rf_plot_width() - axisX - 2;
     std::vector<int> signal(graph_size, -95);
     const size_t freq_count = sizeof(subghz_frequency_list) / sizeof(float);
     std::vector<int> bar_size(freq_count, 0);
-    int max_bar_size = tftHeight - 20 /*bottom margin*/ - 20 /*top margin*/;
+    const int max_bar_size = bot - top;
     bool redraw = true;
     const int min_value = map(-70, -95, -20, 0, max_bar_size);
+    // dBm -> screen row, so the scale follows the plot band on every device
+    auto rssiY = [&](int rssi) { return (int)map(constrain(rssi, -95, -20), -95, -20, bot, top); };
+
     while (1) {
         if (redraw) {
             redraw = false;
             tft.drawPixel(0, 0, 0);
-            tft.fillScreen(bruceConfig.bgColor);
-            tft.setTextSize(1);
-            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
-            tft.setCursor(3, 2);
+            tft.setTextSize(FP);
             // Fixed frequency sees a dot running grafic, showing RSSI over time
             if (bruceConfigPins.rfFxdFreq) {
                 if (!initRfModule("rx", bruceConfigPins.rfFreq))
                     displayError("Error setting frequency", true);
-                tft.printf(" RF - RSSI spectrum (%.2f Mhz)", bruceConfigPins.rfFreq);
-                tft.drawFastVLine(20, 20, tftHeight, bruceConfig.priColor);
-                tft.drawString("-95", 0, (tftHeight - 120) + 95);
-                tft.drawString("-80", 0, (tftHeight - 120) + 80);
-                tft.drawString("-65", 0, (tftHeight - 120) + 65);
-                tft.drawString("-50", 0, (tftHeight - 120) + 50);
-                tft.drawString("-35", 0, (tftHeight - 120) + 35);
-                tft.drawString("-20", 0, (tftHeight - 120) + 20);
+                draw_rf_header("RF RSSI", String(bruceConfigPins.rfFreq, 2) + " MHz");
+                tft.fillRect(rf_plot_left(), top, rf_plot_width(), bot - top, bruceConfig.bgColor);
+                tft.drawFastVLine(axisX, top, bot - top, bruceConfig.priColor);
+                tft.setTextColor(rf_label_color(), bruceConfig.bgColor);
+                for (int dbm = -95; dbm <= -20; dbm += 15) {
+                    int y = rssiY(dbm) - (8 * FP) / 2;
+                    tft.drawString(String(dbm), 8, y, 1);
+                    tft.drawFastHLine(axisX - 2, rssiY(dbm), 3, rf_grid_color());
+                }
                 // resets signal array
                 std::fill(signal.begin(), signal.end(), -95);
             }
             // Range Scan Sees a bargraph simillar to NRF24 grafic, using RSSI across frequencies
             else {
                 if (!initRfModule("rx", bruceConfigPins.rfFreq)) displayError("Error starting module", true);
-                tft.printf(" RF - RSSI spectrum (%s)", subghz_frequency_ranges[bruceConfigPins.rfScanRange]);
-                tft.drawFastHLine(0, tftHeight - 20, tftWidth, bruceConfig.priColor);
-                char buf[7];
+                // the band edges are drawn on the bottom row, so keep it empty here
+                draw_rf_header(
+                    String("RF RSSI ") + subghz_frequency_ranges[bruceConfigPins.rfScanRange], ""
+                );
+                tft.fillRect(rf_plot_left(), top, rf_plot_width(), bot - top, bruceConfig.bgColor);
+                tft.drawFastHLine(rf_plot_left(), bot, rf_plot_width(), bruceConfig.priColor);
+                tft.setTextColor(rf_label_color(), bruceConfig.bgColor);
+                char buf[8];
                 float var = subghz_frequency_list[range_limits[bruceConfigPins.rfScanRange][0]];
                 snprintf(buf, sizeof(buf), "%.3f", var);
-                tft.drawString(buf, 2, tftHeight - 10);
+                tft.drawString(buf, rf_plot_left(), bot + 2, 1);
                 var = subghz_frequency_list[range_limits[bruceConfigPins.rfScanRange][1]];
                 snprintf(buf, sizeof(buf), "%.3f", var);
-                tft.drawRightString(buf, tftWidth - 2, tftHeight - 10);
+                tft.drawRightString(buf, rf_plot_left() + rf_plot_width(), bot + 2, 1);
                 int range = range_limits[bruceConfigPins.rfScanRange][1] -
                             range_limits[bruceConfigPins.rfScanRange][0] + 1;
-                int space = tftWidth / range;
+                int space = rf_plot_width() / range;
                 for (int i = 0; i < range; i++) {
-                    tft.drawFastVLine(space * i, tftHeight - 20, 5, bruceConfig.priColor);
+                    tft.drawFastVLine(rf_plot_left() + space * i, bot - 4, 4, rf_grid_color());
                 }
                 std::fill(bar_size.begin(), bar_size.end(), 0);
             }
@@ -244,24 +288,23 @@ void rf_CC1101_rssi() {
         if (bruceConfigPins.rfFxdFreq) {
             int rssi = ELECHOUSE_cc1101.getRssi();
             tft.drawPixel(0, 0, 0); // To make sure CC1101 shared with TFT works properly
-            const int base_y = tftHeight - 120;
             int prev = signal[0];
             for (int i = 1; i < graph_size; i++) {
                 if (EscPress || SelPress) break;
-                const int x0 = 20 + (i - 1);
-                const int x1 = 20 + i;
+                const int x0 = axisX + (i - 1);
+                const int x1 = axisX + i;
                 const int curr = signal[i];
                 // erase old segment between previous and current points
-                tft.drawLine(x0, base_y - prev, x1, base_y - curr, bruceConfig.bgColor);
+                tft.drawLine(x0, rssiY(prev), x1, rssiY(curr), bruceConfig.bgColor);
                 const int next_val = (i == graph_size - 1) ? rssi : signal[i + 1];
                 // shift buffer left by one
                 signal[i - 1] = curr;
                 if (i == graph_size - 1) signal[i] = rssi;
                 // draw updated segment using new values
-                tft.drawLine(x0, base_y - curr, x1, base_y - next_val, bruceConfig.priColor);
+                tft.drawLine(x0, rssiY(curr), x1, rssiY(next_val), bruceConfig.priColor);
                 prev = curr;
             }
-            tft.drawFastVLine(20, 20, tftHeight, bruceConfig.priColor);
+            tft.drawFastVLine(axisX, top, bot - top, bruceConfig.priColor);
             vTaskDelay(pdMS_TO_TICKS(75));
         }
         // draw a bargraph similar to nrf24 across the range
@@ -269,7 +312,7 @@ void rf_CC1101_rssi() {
             int range = range_limits[bruceConfigPins.rfScanRange][1] -
                         range_limits[bruceConfigPins.rfScanRange][0] + 1;
 
-            int space = tftWidth / range;
+            int space = rf_plot_width() / range;
             int max_idx = 0;
             for (int i = 0; i < range; i++) {
                 if (EscPress || SelPress) break;
@@ -281,17 +324,20 @@ void rf_CC1101_rssi() {
                 if (size > bar_size[i]) bar_size[i] = size;
                 else bar_size[i] = bar_size[i] - (bar_size[i] - size) / 2; // slow down decrease
                 tft.fillRect(
-                    i * space, tftHeight - 20 - bar_size[i], space - 2, bar_size[i], bruceConfig.priColor
+                    rf_plot_left() + i * space, bot - bar_size[i], space - 2, bar_size[i], bruceConfig.priColor
                 );
-                tft.fillRect(i * space, 20, space, max_bar_size - bar_size[i], bruceConfig.bgColor);
+                tft.fillRect(
+                    rf_plot_left() + i * space, top, space, max_bar_size - bar_size[i], bruceConfig.bgColor
+                );
                 if (bar_size[i] > bar_size[max_idx] && bar_size[i] > min_value) max_idx = i;
             }
             if (bar_size[max_idx] > min_value) {
-                char buf[7];
+                char buf[8];
                 float var = subghz_frequency_list[range_limits[bruceConfigPins.rfScanRange][0] + max_idx];
                 snprintf(buf, sizeof(buf), "%.2f", var);
-                tft.drawCentreString("Max=      ", tftWidth / 2, tftHeight - 10);
-                tft.drawCentreString("Max=" + String(buf), tftWidth / 2, tftHeight - 10);
+                tft.setTextColor(rf_label_color(), bruceConfig.bgColor);
+                tft.drawCentreString("Max=       ", tftWidth / 2, bot + 2, 1);
+                tft.drawCentreString("Max=" + String(buf), tftWidth / 2, bot + 2, 1);
             }
         }
         if (check(EscPress)) { break; }


### PR DESCRIPTION
#### Proposed Changes ####

The three views in this file each assumed a fixed layout. The plot started at
y = 20 and ran to tftHeight, spanned x = 0 to tftWidth, and the dBm scale was
positioned with the literal `(tftHeight - 120) + 95`, which only lands
correctly on a screen with 120px of usable height. The grid was TFT_DARKGREY
and the font size a literal 1.

All three now share one plot rectangle from rf_plot_top(), rf_plot_bot(),
rf_plot_left() and rf_plot_width(), derived from the title bar, the status
line and the rounded theme border at x = 5, so the trace no longer paints over
the frame on either side. The dBm arithmetic is replaced by an rssiY() that
maps -95..-20 onto that band, and the left gutter is sized from the label
width instead of a hardcoded 20px.

The header moved to drawMainBorderWithTitle with the tuning on a status line,
drawn once and repainted only when the frequency changes, so the live graph no
longer flickers. Grid and labels use theme-derived shades.

Behaviour of the RMT capture, the M5 receiver and the CC1101 sweep is
unchanged.

#### Types of Changes ####

Bugfix (layout only correct on one screen size; graph overran the frame) plus
UI rework.

#### Verification ####

Flash and open each of the three views - RF -> Spectrum, RF -> SquareWave and
RF -> RSSI, the last in both fixed-frequency and range modes. In every one:

  - the graph must stay inside the rounded border, with clear margins on the
    left and right edges
  - the title bar and the status line must not be overdrawn
  - the dBm labels in the RSSI view must line up with the trace, and -95 must
    sit at the bottom of the plot rather than off the band

The frequency-range view should still show the band edges bottom-left and
bottom-right and the Max= readout centred.

Worth checking on a panel that is not 240x135, since the old scale arithmetic
was only correct at one height and that is what this PR fixes.

#### Testing ####

No unit test harness exists for this layer. Compiled for m5stack-cardputer on
this branch. Not yet verified on hardware by me - the three views need a CC1101
or an M5 RF module to exercise fully.

#### Linked Issues ####

None. Depends on #2754 (ui/color-helpers) for blendColors. Does not need the
SpectrumPlot component, so it can be reviewed and merged independently of the
rest of the series.

#### User-Facing Change ####
```release-note
RF Spectrum, SquareWave and RSSI views now size their plot area from the display instead of assuming a 120px tall screen, no longer draw over the window border, and follow the active theme.
```

#### Further Comments ####

The RSSI range view still draws its own bargraph rather than going through the
shared SpectrumPlot component, which it is a natural fit for - same shape of
data as the NRF sweeper. That conversion was left out to keep this PR to
layout and theming; it would be a good follow-up.

---

> **Stacked PR.** This branch is built on #2754. GitHub can only base a cross-fork PR on an upstream branch, so until it is merged the diff above also contains its commit. Review only the commit titled *RF Spectrum: derive the plot area from the panel, not from a 120px screen*; the diff shrinks on its own once the base lands.