### PR TITLE
Add led serial command for RGB LED control

### DIFF
--- a/src/core/serial_commands/cli.cpp
+++ b/src/core/serial_commands/cli.cpp
@@ -5,6 +5,7 @@
 #include "gpio_commands.h"
 #include "interpreter_commands.h"
 #include "ir_commands.h"
+#include "led_commands.h"
 #include "power_commands.h"
 #include "rf_commands.h"
 #include "rfid_commands.h"
@@ -53,6 +54,9 @@ void SerialCli::setup() {
 #endif
 #ifdef HAS_SCREEN
     createScreenCommands(&_cli);
+#endif
+#ifdef HAS_RGB_LED
+    createLedCommands(&_cli);
 #endif
 #if defined(HAS_NS4168_SPKR) || defined(BUZZ_PIN)
     createSoundCommands(&_cli);

--- a/src/core/serial_commands/led_commands.cpp
+++ b/src/core/serial_commands/led_commands.cpp
@@ -1,0 +1,155 @@
+#include "led_commands.h"
+#include <globals.h>
+
+#ifdef HAS_RGB_LED
+#include "core/led_control.h"
+
+// The effect task reads the color/effect straight from bruceConfig (led_control.cpp),
+// so these commands go through the config setters and then re-apply, exactly like the
+// LED settings menu does. That also makes the change survive a reboot.
+static void applyLedColor(uint32_t color) {
+    bruceConfig.setLedColor(color);
+    ledSetup();
+    serialDevice->printf("LED color set to %06X\n", (unsigned int)(color & 0xFFFFFF));
+}
+
+static bool parseByteArg(Command &cmd, const char *name, int &out) {
+    Argument arg = cmd.getArgument(name);
+    String strValue = arg.getValue();
+    strValue.trim();
+
+    out = atoi(strValue.c_str());
+    if (out < 0 || out > 255) {
+        serialDevice->println("Invalid value: " + strValue + " (expected 0-255)");
+        return false;
+    }
+    return true;
+}
+
+// Keeps the other two channels untouched, so "led r 255" then "led g 255" gives yellow.
+static uint32_t setLedChannel(cmd *c, uint8_t shift) {
+    Command cmd(c);
+
+    int value = 0;
+    if (!parseByteArg(cmd, "value", value)) return false;
+
+    uint32_t color = bruceConfig.ledColor & ~((uint32_t)0xFF << shift);
+    applyLedColor(color | ((uint32_t)value << shift));
+    return true;
+}
+
+// e.g. "led r 255", "led g 128", "led b 0"
+static uint32_t ledRedCallback(cmd *c) { return setLedChannel(c, 16); }
+static uint32_t ledGreenCallback(cmd *c) { return setLedChannel(c, 8); }
+static uint32_t ledBlueCallback(cmd *c) { return setLedChannel(c, 0); }
+
+// e.g. "led rgb 255 0 255"
+static uint32_t ledRgbCallback(cmd *c) {
+    Command cmd(c);
+
+    int r = 0, g = 0, b = 0;
+    if (!parseByteArg(cmd, "red", r)) return false;
+    if (!parseByteArg(cmd, "green", g)) return false;
+    if (!parseByteArg(cmd, "blue", b)) return false;
+
+    applyLedColor(((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b);
+    return true;
+}
+
+// e.g. "led hex ff00ff"
+static uint32_t ledHexCallback(cmd *c) {
+    Command cmd(c);
+
+    Argument arg = cmd.getArgument("value");
+    String strValue = arg.getValue();
+    strValue.trim();
+    if (strValue.startsWith("#")) strValue = strValue.substring(1);
+
+    char *end = nullptr;
+    uint32_t value = strtoul(strValue.c_str(), &end, 16);
+
+    if (strValue.length() == 0 || *end != '\0' || value > 0xFFFFFF) {
+        serialDevice->println("Invalid color: " + strValue);
+        return false;
+    }
+
+    applyLedColor(value);
+    return true;
+}
+
+// e.g. "led br 50" (0-100, same scale as the settings menu)
+static uint32_t ledBrightnessCallback(cmd *c) {
+    Command cmd(c);
+
+    Argument arg = cmd.getArgument("value");
+    String strValue = arg.getValue();
+    strValue.trim();
+
+    int value = atoi(strValue.c_str());
+    if (value < 0 || value > 100) {
+        serialDevice->println("Invalid value: " + strValue + " (expected 0-100)");
+        return false;
+    }
+
+    bruceConfig.setLedBright(value);
+    setLedBrightness(value);
+    serialDevice->println("LED brightness set to " + String(value) + "%");
+    return true;
+}
+
+// e.g. "led effect 3"
+static uint32_t ledEffectCallback(cmd *c) {
+    Command cmd(c);
+
+    Argument arg = cmd.getArgument("value");
+    String strValue = arg.getValue();
+    strValue.trim();
+
+    int value = atoi(strValue.c_str());
+    if (value < LED_EFFECT_SOLID || value > LED_EFFECT_FIRE) {
+        serialDevice->println("Invalid effect: " + strValue + " (expected 0-9)");
+        return false;
+    }
+
+    bruceConfig.setLedEffect(value);
+    ledSetup();
+    serialDevice->println("LED effect set to " + String(value));
+    return true;
+}
+
+// Same as picking "OFF" in the LED color menu.
+static uint32_t ledOffCallback(cmd *c) {
+    applyLedColor(0);
+    return true;
+}
+
+void createLedCommands(SimpleCLI *cli) {
+    Command ledCmd = cli->addCompositeCmd("led");
+
+    Command redCmd = ledCmd.addCommand("r/ed", ledRedCallback);
+    redCmd.addPosArg("value");
+    Command greenCmd = ledCmd.addCommand("g/reen", ledGreenCallback);
+    greenCmd.addPosArg("value");
+    Command blueCmd = ledCmd.addCommand("b/lue", ledBlueCallback);
+    blueCmd.addPosArg("value");
+
+    Command rgbCmd = ledCmd.addCommand("rgb", ledRgbCallback);
+    rgbCmd.addPosArg("red");
+    rgbCmd.addPosArg("green");
+    rgbCmd.addPosArg("blue");
+
+    Command hexCmd = ledCmd.addCommand("hex", ledHexCallback);
+    hexCmd.addPosArg("value");
+
+    Command brightCmd = ledCmd.addCommand("br/ight/ness", ledBrightnessCallback);
+    brightCmd.addPosArg("value");
+
+    Command effectCmd = ledCmd.addCommand("effect", ledEffectCallback);
+    effectCmd.addPosArg("value");
+
+    ledCmd.addCommand("off", ledOffCallback);
+}
+
+#else
+void createLedCommands(SimpleCLI *cli) {}
+#endif

--- a/src/core/serial_commands/led_commands.h
+++ b/src/core/serial_commands/led_commands.h
@@ -1,0 +1,8 @@
+#ifndef __SERIAL_LED_CMD_H__
+#define __SERIAL_LED_CMD_H__
+
+#include <SimpleCLI.h>
+
+void createLedCommands(SimpleCLI *cli);
+
+#endif

--- a/src/core/serial_commands/util_commands.cpp
+++ b/src/core/serial_commands/util_commands.cpp
@@ -183,8 +183,20 @@ uint32_t helpCallback(cmd *c) {
     serialDevice->println("  say <text>   - Text-To-Speech (speaker required).");
 
     serialDevice->println("\nUI Commands:");
-    serialDevice->println("  led <r/g/b> <0-255>    - Change the UI main color.");
-    serialDevice->println("  clock                 - Show the clock UI.");
+    serialDevice->println("  screen color rgb <r> <g> <b>  - Change the UI main color.");
+    serialDevice->println("  screen color hex <RRGGBB>     - Change the UI main color.");
+    serialDevice->println("  screen brightness <0-255>     - Change the screen backlight.");
+    serialDevice->println("  clock                         - Show the clock UI.");
+
+#ifdef HAS_RGB_LED
+    serialDevice->println("\nRGB LED Commands:");
+    serialDevice->println("  led <r/g/b> <0-255>      - Change a single channel of the RGB LED.");
+    serialDevice->println("  led rgb <r> <g> <b>      - Change the RGB LED color.");
+    serialDevice->println("  led hex <RRGGBB>         - Change the RGB LED color.");
+    serialDevice->println("  led brightness <0-100>   - Change the RGB LED brightness.");
+    serialDevice->println("  led effect <0-9>         - Change the RGB LED effect (0 = solid color).");
+    serialDevice->println("  led off                  - Turn the RGB LED off.");
+#endif
 
     serialDevice->println("\nPower Management:");
     serialDevice->println("  power <off/reboot/sleep>  - General power management.");


### PR DESCRIPTION
## Problem

The `led` command is listed in the CLI `help` output but was never registered with the CLI, so typing it in the serial terminal returns `ERROR: Command not found`. The help entry also describes it as changing the UI main color, which is what the existing `screen color rgb` / `screen color hex` commands already do.

## Change

Register a real `led` composite command that drives the physical RGB LED:

```
led r|g|b <0-255>       change a single channel, keeping the other two
led rgb <r> <g> <b>     set the full color
led hex <RRGGBB>        set the full color
led brightness <0-100>  aliases: br, bright
led effect <0-9>        0 selects the solid color
led off
```

The callbacks write through `bruceConfig` and call `ledSetup()` instead of touching `leds[]` directly. When an effect is active, its task reads the color, effect, speed and direction straight from `bruceConfig` (`led_control.cpp`), so a direct write would be overwritten on the next frame. As a side effect the change persists across reboots, matching the behaviour of the LED settings menu.

The whole translation unit is guarded by `HAS_RGB_LED`: `led_control.h` only declares its API under that define, and PlatformIO compiles every source file regardless of the target board.

The help text is fixed as well. The UI section now documents the real `screen` commands, and a new "RGB LED Commands" section is printed only on boards that actually have an RGB LED.

## Testing

Built successfully for `m5stack-cardputer` and `Lilygo-t-embed-cc1101` (has `HAS_RGB_LED`) and `Marauder-Mini` (does not), covering both sides of the guard. Tested only on Lilygo-t-embed-cc1101

🤖 Generated with [Claude Code](https://claude.com/claude-code) and double checked by me ;-)
