### PR TITLE
Change selected text color to secondary color in BLE spam config

### DIFF
--- a/src/modules/ble/ble_spam.cpp
+++ b/src/modules/ble/ble_spam.cpp
@@ -1711,7 +1711,7 @@ static void bleSpamRenderConfigRows(
         bool editing = (editState.editing && editState.edit_row == i);
 
         tft.fillRect(10, rowY, tftWidth - 20, rowH, bruceConfig.bgColor);
-        uint16_t fg = selected ? TFT_YELLOW : bruceConfig.priColor;
+        uint16_t fg = selected ? bruceConfig.secColor : bruceConfig.priColor;
         tft.setTextColor(fg, bruceConfig.bgColor);
         tft.drawString(rows[i].label, 12, rowY + 2, 1);
 
@@ -1748,7 +1748,7 @@ bleSpamConfigScreen(const BleSpamSelection &selection, BleSpamConfig &config, bo
             bleSpamRenderConfigRows(config, cursor, editState, rowStart, rowH);
 
             tft.fillRect(10, startRowY, tftWidth - 20, rowH, bruceConfig.bgColor);
-            uint16_t startColor = (cursor == 4) ? TFT_YELLOW : bruceConfig.priColor;
+            uint16_t startColor = (cursor == 4) ? bruceConfig.secColor : bruceConfig.priColor;
             tft.setTextColor(startColor, bruceConfig.bgColor);
             tft.drawCentreString("[ Start ]", tftWidth / 2, startRowY + 2, 1);
 


### PR DESCRIPTION
Improve UI readability in BLE spam config

#### Proposed Changes ####

Previously when going to the config in BLE spam, the selection was marked yellow, which blended in when using yellow as primary color. My change highlights it in the secondary color, so its actually possible to see the selection.

#### Types of Changes ####

Bugfix

#### Verification ####

Inspected the code.

#### Testing ####

Not tested

#### Linked Issues ####

None

#### User-Facing Change ####

Fixed BLE Spam config menu selection highlights blending into yellow primary themes.

#### Further Comments ####

None