### PR TITLE
Add DuckyScript DEFINE constant support to BadUSB parser

### DIFF
--- a/sd_files/BadUSB and BlueDucky/Ducky-br.html
+++ b/sd_files/BadUSB and BlueDucky/Ducky-br.html
@@ -480,6 +480,7 @@ color: #ffffff; /* Cor do texto dentro do input */
 			<div class="misc-commands-section">
 				<b>Comandos diversos:</b><br />
 				<font size="2" style="color:#bbbdba"><i><mark>REPEAT</mark> é usado para repetir o comando anterior. Ele espera o número de repetições adicionais como parâmetro.<br />
+				<mark>DEFINE</mark> declara uma constante (ex.: <mark>DEFINE #NOME valor</mark>) que é substituída onde quer que apareça antes da execução do payload.<br />
 				<mark>ALTCHAR</mark> é para exibir teclas <mark>ALT+Numpad</mark> individuais (no Windows), ou teclas <mark>ALT</mark><mark>(ALT+SHIFT)</mark> (no macOS).<br />
 				Clique
 				</i></font><font size="2" style="color:#bbbdba"><a href="https://www.alt-codes.net" target="new">AQUI</a></font><font size="2" style="color:#bbbdba"><i> para uma lista completa de códigos disponíveis para caracteres ALT.</i></font>

--- a/sd_files/BadUSB and BlueDucky/Ducky-en.html
+++ b/sd_files/BadUSB and BlueDucky/Ducky-en.html
@@ -480,6 +480,7 @@ color: #ffffff; /* Cor do texto dentro do input */
 			<div class="misc-commands-section">
 				<b>Misc. Commands:</b><br />
 				<font size="2" style="color:#bbbdba"><i><mark>REPEAT</mark> is used to repeat the previous command. It expects the number of additional repeats as parameter.<br />
+				<mark>DEFINE</mark> declares a constant (e.g. <mark>DEFINE #NAME value</mark>) that is substituted wherever it appears before the payload runs.<br />
 				<mark>ALTCHAR</mark> is to display single <mark>ALT+Numpad</mark> Keys (on Windows), or <mark>ALT</mark><mark>(ALT+SHIFT)</mark> Keys (on macOS).<br />
 				Click
 				</i></font><font size="2" style="color:#bbbdba"><a href="https://www.alt-codes.net" target="new">HERE</a></font><font size="2" style="color:#bbbdba"><i> for a complete list of available codes for ALT characters.</i></font>

--- a/sd_files/BadUSB and BlueDucky/DuckyScript_DEFINE_demo.txt
+++ b/sd_files/BadUSB and BlueDucky/DuckyScript_DEFINE_demo.txt
@@ -1,0 +1,13 @@
+REM DuckyScript 3.0 DEFINE demo
+REM Constants are declared with DEFINE and substituted before the payload runs.
+REM Undefined names and whole tokens are left untouched (#NAME never matches #NAMES).
+DEFINE #EDITOR notepad.exe
+DEFINE #NAME Bruce
+DEFINE #PAUSE 500
+
+GUI r
+DELAY #PAUSE
+STRINGLN #EDITOR
+DELAY 1000
+STRINGLN Hello, my name is #NAME
+STRINGLN DEFINE keeps payloads readable and easy to retarget

--- a/src/modules/badusb_ble/ducky_typer.cpp
+++ b/src/modules/badusb_ble/ducky_typer.cpp
@@ -8,6 +8,7 @@
 #include "esp_mac.h"
 #include "modules/ble/ble_common.h"
 #include <NimBLEDevice.h>
+#include <map>
 #if defined(USB_as_HID)
 #include "tusb.h"
 #endif
@@ -576,6 +577,49 @@ DuckyCombination *findDuckyCombination(const char *cmd) {
 }
 
 // ============================================================================
+// DUCKYSCRIPT 3.0 DEFINE - Constant substitution
+// ============================================================================
+
+// '#' is a token char because DEFINE names are conventionally '#'-prefixed.
+static bool isDuckyDefineTokenChar(char c) { return isAlphaNumeric(c) || c == '_' || c == '#'; }
+
+static bool parseDuckyDefine(const String &line, std::map<String, String> &defines) {
+    if (!line.startsWith("DEFINE ")) return false;
+
+    int nameStart = 7; // strlen("DEFINE ")
+    while (nameStart < (int)line.length() && line.charAt(nameStart) == ' ') nameStart++;
+
+    int nameEnd = line.indexOf(' ', nameStart);
+    String name = (nameEnd < 0) ? line.substring(nameStart) : line.substring(nameStart, nameEnd);
+    if (name.length() == 0) return true;
+
+    defines[name] = (nameEnd < 0) ? String("") : line.substring(nameEnd + 1);
+    return true;
+}
+
+// Replaces whole-token matches only, so a name never matches inside a larger token.
+static void applyDuckyDefines(String &line, const std::map<String, String> &defines) {
+    for (const auto &entry : defines) {
+        const String &name = entry.first;
+        const String &value = entry.second;
+        int from = 0;
+        while (true) {
+            int pos = line.indexOf(name, from);
+            if (pos < 0) break;
+            int after = pos + name.length();
+            bool leftOk = (pos == 0) || !isDuckyDefineTokenChar(line.charAt(pos - 1));
+            bool rightOk = (after >= (int)line.length()) || !isDuckyDefineTokenChar(line.charAt(after));
+            if (leftOk && rightOk) {
+                line = line.substring(0, pos) + value + line.substring(after);
+                from = pos + value.length();
+            } else {
+                from = pos + 1;
+            }
+        }
+    }
+}
+
+// ============================================================================
 // START KEYBOARD - Creates fresh BLE instance with new stack
 // ============================================================================
 
@@ -814,6 +858,7 @@ void key_input(FS fs, const String &bad_script, HIDInterface *_hid) {
     char Cmd[25];
     String Argument = "";
     String RepeatTmp = "";
+    std::map<String, String> duckyDefines;
 
     static int nextStringDelay = -1;
     static int defaultStringDelay = bruceConfig.badUSBBLEKeyDelay;
@@ -855,6 +900,10 @@ void key_input(FS fs, const String &bad_script, HIDInterface *_hid) {
         if (lineContent.endsWith("\r")) lineContent.remove(lineContent.length() - 1);
 
         if (lineContent.length() == 0) continue;
+
+        // DEFINE stores a constant; every other line has its constants expanded first.
+        if (parseDuckyDefine(lineContent, duckyDefines)) continue;
+        if (!duckyDefines.empty()) applyDuckyDefines(lineContent, duckyDefines);
 
         int spaceIndex = lineContent.indexOf(' ');
 


### PR DESCRIPTION
#### Proposed Changes ####

Adds support for the DuckyScript 3.0 DEFINE command to the BadUSB / BadBLE parser (ducky_typer.cpp).

DEFINE <NAME> <VALUE> declares a constant. Every subsequent line has each defined name replaced with its value before the line is parsed and dispatched, matching Hak5 DuckyScript 3.0. Names are conventionally #-prefixed but any name works.

- DEFINE lines are directives: they store the constant and type nothing.
- Substitution uses whole-token / word-boundary matching, so a name never partially replaces a larger token (#PORT is not matched inside #PORTAL). It works inside STRING / STRINGLN arguments as well as command arguments (e.g. DELAY #PAUSE).
- Undefined names are left untouched — no error spam that blocks the run.
- Constants live in a small std::map<String, String> local to key_input, freed when the script ends. Payloads that do not use DEFINE are completely unaffected.

Scope is intentionally limited to DEFINE only. VAR, IF/ELSE, WHILE, FUNCTION, expressions and ATTACKMODE are out of scope: Bruce already ships a full JavaScript interpreter for advanced logic, so re-implementing a scripting runtime inside the Ducky parser would add significant memory cost and complexity for little benefit. DEFINE is the one DuckyScript 3.0 feature broadly useful for plain HID payloads without needing a language runtime.

Context: discussion #1796 (DuckyScript version support).

#### Types of Changes ####

New Feature (additive, non-breaking).

#### Verification ####

- Builds/compiles cleanly for lilygo-t-embed-cc1101 with no new warnings (board-agnostic parser logic, safe across all envs).
- Example payload added at sd_files/BadUSB and BlueDucky/DuckyScript_DEFINE_demo.txt.
- Substitution rules verified:
  - DEFINE #DUCKY_LOVE Mischief + STRING I <3 #DUCKY_LOVE  -> types "I <3 Mischief"
  - DEFINE #PORT 8080 + STRING #PORT and #PORTAL           -> "8080 and #PORTAL"
  - DEFINE #N 3 + REPEAT #N                                -> repeats 3 times
  - Undefined #FOO                                          -> left as "#FOO"

#### Testing ####

The substitution logic was exercised against the exact algorithm with checks covering basic substitution, whole-token boundaries, values with spaces, multiple occurrences per line, undefined names, empty values and the "value contains its own name" case (verifying the scan cannot loop). The repo has no on-device unit-test harness for the Ducky parser, so validation was off-device plus the example payload.

#### Linked Issues ####

Discussion #1796 (DuckyScript version support).

#### User-Facing Change ####
```release-note
Add DuckyScript 3.0 DEFINE constant support to the BadUSB/BadBLE parser. Use `DEFINE #NAME value` to declare a constant that is substituted throughout the payload before it runs.
```

#### Further Comments ####
The in-app DuckyScript reference (Ducky-en.html / Ducky-br.html) was updated to document DEFINE alongside the other misc commands.
