### PR TITLE
Fix WiFi auto-connect skipping open networks

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -666,6 +666,8 @@ String BruceConfig::getWifiPassword(const String &ssid) const {
     return "";
 }
 
+bool BruceConfig::hasWifiCredential(const String &ssid) const { return wifi.find(ssid) != wifi.end(); }
+
 void BruceConfig::addEvilWifiName(String value) {
     evilWifiNames.insert(value);
     saveFile();

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -164,6 +164,7 @@ public:
     void addQrCodeEntry(const String &menuName, const String &content);
     void removeQrCodeEntry(const String &menuName);
     String getWifiPassword(const String &ssid) const;
+    bool hasWifiCredential(const String &ssid) const;
     void addEvilWifiName(String value);
     void removeEvilWifiName(String value);
     void setEvilEndpointCreds(String value);

--- a/src/core/wifi/wifi_common.cpp
+++ b/src/core/wifi/wifi_common.cpp
@@ -312,7 +312,10 @@ void wifiConnectTask(void *pvParameters) {
     for (int i = 0; i < nets; i++) {
         ssid = WiFi.SSID(i);
         pwd = bruceConfig.getWifiPassword(ssid);
-        if (pwd == "") continue;
+        // An empty password only means "unknown network" for secured APs: known open
+        // networks are stored with an empty password and must be joined without one.
+        bool knownOpenNet = WiFi.encryptionType(i) == WIFI_AUTH_OPEN && bruceConfig.hasWifiCredential(ssid);
+        if (pwd == "" && !knownOpenNet) continue;
 
         WiFi.begin(ssid, pwd);
         for (int i = 0; i < 50; i++) {

--- a/src/core/wifi/wifi_common.h
+++ b/src/core/wifi/wifi_common.h
@@ -50,7 +50,7 @@ esp_err_t wifiRawTx(wifi_interface_t ifx, const void *frame, int len, uint8_t re
 /**
  * @brief tries to connect to min(found_networks, maxSearch) networks
  * using stored passwords
- * @TODO fix: rn it skips open networks due to password == "" check
+ * @note known open networks are stored with an empty password and joined without one
  */
 void wifiConnectTask(void *pvParameters);
 


### PR DESCRIPTION
#### Proposed Changes ####

The background auto-connect task `wifiConnectTask` skipped every OPEN
(passwordless) network because it bailed out on `pwd == ""`. Known open
networks are stored with an empty password, so they could never be joined
automatically.

`wifiConnectTask` now treats an empty stored password as "unknown network"
only for secured APs. When a scanned network's auth mode is `WIFI_AUTH_OPEN`
and it is present in the stored credentials, it is connected without a
password. Behaviour for secured (WPA/WPA2/WPA3) networks is unchanged.

A small `BruceConfig::hasWifiCredential()` helper distinguishes a known open
network (stored, empty password) from an unknown network (not stored), without
changing the credential storage format.

#### Types of Changes ####

Bugfix

#### Verification ####

1. Save an open network's SSID to the stored WiFi credentials (empty password).
2. Enable WiFi auto-connect and let `wifiConnectTask` run near that network.
3. The device now connects to the open network instead of skipping it; secured
   networks keep connecting exactly as before.

Builds clean for `lilygo-t-embed-cc1101`; the change is board-agnostic.

#### Testing ####

Not covered by automated tests (no harness for this path); verified by building
the firmware and by inspecting the connect path.

#### Linked Issues ####

Resolves the TODO in `src/core/wifi/wifi_common.h`:
"rn it skips open networks due to password == \"\" check".

#### User-Facing Change ####
```release-note
Fix WiFi auto-connect skipping open (passwordless) networks.
```

#### Further Comments ####
Minimal, non-breaking change; no unrelated refactors. The helper is const and
adds no per-connection allocation, so the ESP32 memory impact is negligible.
