### PR TITLE
Support multi-chunk encrypted uploads in web interface

### DIFF
--- a/src/core/passwords.cpp
+++ b/src/core/passwords.cpp
@@ -172,6 +172,44 @@ String encryptString(String &plaintext, const String &password_str) {
     return out;
 }
 
+String encryptFileHeader() {
+    // Same header encryptString() writes, up to (and including) the "Data: " prefix.
+    // The hex payload that follows may be appended incrementally across chunks.
+    String out = "Filetype: Bruce Encrypted File\nVersion: 1\n";
+    out += "Algo: XOR\n";
+    out += "KeyDerivationAlgo: MD5\n";
+    out += "KeyDerivationPasses: 10\n";
+    out += "Data: ";
+    return out;
+}
+
+String encryptChunkToHex(const uint8_t *data, size_t len, const String &password_str, size_t streamOffset) {
+    // Derive the same 16-byte key xorEncryptDecryptMD5() uses (MD5 of the password, 10
+    // passes), so a chunk-encrypted file decrypts identically to a single-shot one.
+    MD5Builder md5;
+    String hash = password_str;
+    for (int i = 0; i < 10; i++) {
+        md5.begin();
+        md5.add(hash);
+        md5.calculate();
+    }
+    uint8_t md5Hash[16];
+    md5.getBytes(md5Hash);
+
+    // Fixed-width "XX " per byte: the reader parses the Data line in 3-char groups, so
+    // every byte must be two uppercase hex digits followed by a separator.
+    static const char hexDigits[] = "0123456789ABCDEF";
+    String out;
+    out.reserve(len * 3);
+    for (size_t i = 0; i < len; i++) {
+        uint8_t b = data[i] ^ md5Hash[(streamOffset + i) % 16];
+        out += hexDigits[(b >> 4) & 0x0F];
+        out += hexDigits[b & 0x0F];
+        out += ' ';
+    }
+    return out;
+}
+
 /* OLD:
 String decryptString(String& cypertext, const String& password_str)
 

--- a/src/core/passwords.h
+++ b/src/core/passwords.h
@@ -6,6 +6,13 @@
 
 String encryptString(String &plaintext, const String &password_str);
 
+// Streaming helpers for chunked encryption (e.g. web uploads). The XOR keystream is
+// position-based, so a file can be encrypted chunk by chunk as long as each chunk knows
+// its absolute offset in the plaintext. encryptFileHeader() emits the header once,
+// ending with "Data: "; encryptChunkToHex() appends the hex bytes for one chunk.
+String encryptFileHeader();
+String encryptChunkToHex(const uint8_t *data, size_t len, const String &password_str, size_t streamOffset);
+
 String decryptString(String &cypertext, const String &password_str);
 
 String readDecryptedFile(FS &fs, String filepath);

--- a/src/core/wifi/webInterface.cpp
+++ b/src/core/wifi/webInterface.cpp
@@ -238,20 +238,20 @@ void handleUpload(
                 // Serial.println("Failed to open file for writing: " + uploadFolder + "/" + filename);
                 goto RETRY;
             }
+            if (request->hasArg("password") && request->_tempFile) {
+                // Write the encrypted-file header once; the hex payload is streamed per chunk.
+                String header = encryptFileHeader();
+                request->_tempFile.write((const uint8_t *)header.c_str(), header.length());
+            }
         }
 
         if (len) {
             if (request->hasArg("password")) {
-                // encryption requested
-                static int chunck_no = 0;
-                if (chunck_no != 0) {
-                    // TODO: handle multiple chunks
-                    request->send(404, "text/html", "file is too big");
-                    return;
-                } else chunck_no += 1;
+                // Encrypt this chunk incrementally. The XOR keystream is position-based, so
+                // `index` (the chunk's offset in the plaintext) keeps it continuous across
+                // chunks without buffering the whole file in RAM.
                 String enc_password = request->arg("password");
-                String plaintext = String((char *)data).substring(0, len);
-                String cyphertxt = encryptString(plaintext, enc_password);
+                String cyphertxt = encryptChunkToHex(data, len, enc_password, index);
                 if (cyphertxt == "") { return; }
                 if (request->_tempFile)
                     request->_tempFile.write((const uint8_t *)cyphertxt.c_str(), cyphertxt.length());
@@ -260,6 +260,8 @@ void handleUpload(
             }
         }
         if (final) {
+            // Terminate the encrypted Data line before closing, matching encryptString().
+            if (request->hasArg("password") && request->_tempFile) request->_tempFile.write((const uint8_t *)"\n", 1);
             // close the file handle as the upload is now done
             if (request->_tempFile) request->_tempFile.close();
         }


### PR DESCRIPTION
#### Proposed Changes ####

Encrypted file uploads in the web interface only processed the first chunk.
`handleUpload` used a `static int chunck_no` counter and returned `404 "file is
too big"` on any second chunk, so files larger than one AsyncWebServer chunk
(~1.4 KB) could never be uploaded encrypted.

The root cause was that encryption was done with `encryptString()`, which writes
a complete self-contained file (header + a single `Data:` line) and restarts the
position-based XOR keystream at offset 0. Calling it per chunk would emit multiple
headers/`Data:` lines and reset the keystream, which the reader
(`readDecryptedFile`) cannot decrypt — hence the hard single-chunk limit.

This PR encrypts uploads incrementally instead:

- `encryptFileHeader()` writes the encrypted-file header once (on the first
  chunk), ending with the `Data: ` prefix.
- `encryptChunkToHex()` encrypts each chunk on its own and appends its hex bytes
  to that single `Data:` line. It uses the chunk's absolute plaintext offset
  (`index`, provided by AsyncWebServer) so the XOR keystream stays continuous
  across chunks — the resulting file decrypts identically to a single-shot one.
- The trailing newline that terminates the `Data:` line is written on the final
  chunk.

Only the encrypted path changed; the plain (non-encrypted) upload path is
untouched.

#### Types of Changes ####

Bugfix

#### Verification ####

1. Open the web interface and upload a text file larger than one chunk (a few KB
   is enough) with an encryption password set.
2. Before: the upload failed with `404 "file is too big"`. After: the full
   `.enc` file is written.
3. On the device, open the uploaded `.enc` file and enter the same password; it
   decrypts to the original content (`readDecryptedFile`).
4. Small single-chunk files still encrypt and decrypt exactly as before.

Builds clean for `lilygo-t-embed-cc1101`; the change is board-agnostic.

#### Testing ####

Not covered by automated tests (no harness for the web-upload path). Verified by
building the firmware and by tracing the encrypt/decrypt round-trip: the reader
parses the `Data:` line in fixed 3-char groups and XOR-decrypts from offset 0, so
the streamed output (fixed two-digit hex per byte, keystream keyed by absolute
offset) round-trips correctly for both single- and multi-chunk uploads.

#### Linked Issues ####

Resolves the `// TODO: handle multiple chunks` in
`src/core/wifi/webInterface.cpp` (the `handleUpload` encrypted path).

#### User-Facing Change ####

```release-note
Web interface: encrypted file uploads now support files larger than one chunk instead of failing with "file is too big".
```

#### Further Comments ####

Memory-safe by design for the ESP32: the file is never buffered whole in RAM. Each
chunk allocates only a transient hex string (~3x the chunk size) that is written
and freed before the next chunk. There is no longer a hard size limit — uploads
are bounded only by free space on the target filesystem.

As a side effect the encrypted path is more robust than before: bytes are now
emitted as fixed two-digit uppercase hex (the previous `String(byte, HEX)` dropped
the leading zero for values < 0x10, which the fixed-width reader parses
incorrectly), and chunk data is read by exact length rather than through
`String((char*)data)`, which stopped at the first null byte.
