### PR TITLE
fix(rf): route KeeLoq sub files to loopEmulate

### DIFF
--- a/src/modules/rf/rf_send.cpp
+++ b/src/modules/rf/rf_send.cpp
@@ -60,7 +60,7 @@ void sendCustomRF() {
 
         if (!readSubFile(filesystem, filepath, data)) continue;
 
-        if (data.protocol == "RcSwitch") {
+        if (data.protocol == "RcSwitch" || data.protocol.equalsIgnoreCase("keeloq")) {
             loopEmulate(data);
         } else {
             txSubFile(data);


### PR DESCRIPTION
#### Proposed Changes ####

Fixes an issue in Sub-GHz transmission (`src/modules/rf/rf_send.cpp`) where KeeLoq `.sub` files failed to trigger interactive emulation.

Previously, `sendCustomRF()` only routed files to `loopEmulate()` if `data.protocol == "RcSwitch"`. Because KeeLoq files save their protocol as `"KeeLoq"`, they fell through to `txSubFile()`, which bypassed the interactive UI, counter stepping, and dynamic key generation.

This change updates the condition to also match KeeLoq protocols (case-insensitively via `.equalsIgnoreCase("keeloq")`), ensuring KeeLoq files are properly routed to `loopEmulate()` while keeping raw/static files on `txSubFile()`.

#### Types of Changes ####

Bugfix

#### Verification ####

1. Save or load a KeeLoq `.sub` file with `Protocol: KeeLoq` on LittleFS or SD Card.
2. Navigate to RF -> Send -> Custom SubGhz / saved file.
3. Verify that selecting the KeeLoq file enters `loopEmulate()` (displaying interactive frequency, serial, button, counter, and payload info).
4. Verify pressing Send transmits the frame and increments the rolling-code counter correctly.
5. Verify non-emulated / raw `.sub` files still correctly route to `txSubFile()`.

#### Testing ####

No testing needed since this is a straight forward fix.

#### Linked Issues ####

N/A

#### User-Facing Change ####
```release-note
Fix KeeLoq .sub file replay not entering interactive emulation mode in RF Send menu.
```

#### Further Comments ####

None