### PR TITLE
feat(cardputer-adv): add CC1101 nRF24 LoRa 3-in-1 expansion support

### DIFF
--- a/boards/m5stack-cardputer/interface.cpp
+++ b/boards/m5stack-cardputer/interface.cpp
@@ -3,6 +3,10 @@
 #include <Adafruit_TCA8418.h>
 #include <Keyboard.h>
 #include <Wire.h>
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#endif
 #include <interface.h>
 
 // Cardputer and 1.1 keyboard
@@ -94,6 +98,62 @@ void IRAM_ATTR gpio_isr_handler(void *arg) {
     // static long i = 0;
     // Serial.printf("interrupt %ld\n", i++);
 }
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+// Cardputer ADV 3-in-1 expansion:
+// GPIO8 = TCA8418 SDA / NRF24 CE
+// GPIO9 = TCA8418 SCL / NRF24 CS
+//
+// The keyboard and NRF24 cannot own these pins simultaneously.  A mutex
+// serializes the board-specific GPIO8/9 multiplexer.  NRF24 code can hold
+// the mutex during a receive window while the keyboard task uses a non-
+// blocking try-lock and leaves its interrupt pending for the next gap.
+static SemaphoreHandle_t adv3in1MuxMutexHandle() {
+    static SemaphoreHandle_t mutex = xSemaphoreCreateMutex();
+    return mutex;
+}
+
+
+void adv3in1Nrf24CriticalBegin() {
+    SemaphoreHandle_t mutex = adv3in1MuxMutexHandle();
+    if (mutex != nullptr) xSemaphoreTake(mutex, portMAX_DELAY);
+}
+
+void adv3in1Nrf24CriticalEnd() {
+    SemaphoreHandle_t mutex = adv3in1MuxMutexHandle();
+    if (mutex != nullptr) xSemaphoreGive(mutex);
+}
+
+
+static bool adv3in1KeyboardTryBegin() {
+    SemaphoreHandle_t mutex = adv3in1MuxMutexHandle();
+    if (mutex == nullptr) return false;
+    if (xSemaphoreTake(mutex, 0) == pdTRUE) return true;
+    return false;
+}
+
+static void adv3in1KeyboardEnd() {
+    SemaphoreHandle_t mutex = adv3in1MuxMutexHandle();
+    if (mutex != nullptr) xSemaphoreGive(mutex);
+}
+
+static void setAdvSharedPinsToNrfIdle() {
+    // Release the I2C controller before using GPIO8/9 as NRF24 pins.
+    Wire1.end();
+
+    // NRF24 CE inactive.
+    pinMode(TCA8418_SDA_PIN, OUTPUT);
+    digitalWrite(TCA8418_SDA_PIN, LOW);
+
+    // NRF24 CS inactive.
+    pinMode(TCA8418_SCL_PIN, OUTPUT);
+    digitalWrite(TCA8418_SCL_PIN, HIGH);
+}
+
+static void setAdvSharedPinsToI2c() {
+    Wire1.begin(TCA8418_SDA_PIN, TCA8418_SCL_PIN);
+    delay(5);
+}
+#endif
 void _post_setup_gpio() {
     // Initialize TCA8418 I2C keyboard controller
     Serial.println("DEBUG: Cardputer ADV - Initializing TCA8418 keyboard");
@@ -133,6 +193,21 @@ void _post_setup_gpio() {
     bruceConfigPins.gps_bus.tx = (gpio_num_t)13;
     bruceConfigPins.gpsBaudrate = 115200;
 
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    // Cardputer ADV + CC1101/NRF24/LoRa 3-in-1 expansion.
+    bruceConfigPins.CC1101_bus.sck = (gpio_num_t)40;
+    bruceConfigPins.CC1101_bus.miso = (gpio_num_t)39;
+    bruceConfigPins.CC1101_bus.mosi = (gpio_num_t)14;
+    bruceConfigPins.CC1101_bus.cs = (gpio_num_t)15;
+    bruceConfigPins.CC1101_bus.io0 = (gpio_num_t)13;
+
+    bruceConfigPins.NRF24_bus.sck = (gpio_num_t)40;
+    bruceConfigPins.NRF24_bus.miso = (gpio_num_t)39;
+    bruceConfigPins.NRF24_bus.mosi = (gpio_num_t)14;
+    bruceConfigPins.NRF24_bus.cs = (gpio_num_t)9;
+    bruceConfigPins.NRF24_bus.io0 = (gpio_num_t)8;
+#else
+    // Preserve the existing Cardputer ADV runtime defaults.
     bruceConfigPins.CC1101_bus.sck = (gpio_num_t)40;
     bruceConfigPins.CC1101_bus.miso = (gpio_num_t)39;
     bruceConfigPins.CC1101_bus.mosi = (gpio_num_t)14;
@@ -144,19 +219,41 @@ void _post_setup_gpio() {
     bruceConfigPins.NRF24_bus.mosi = (gpio_num_t)14;
     bruceConfigPins.NRF24_bus.cs = (gpio_num_t)6;
     bruceConfigPins.NRF24_bus.io0 = (gpio_num_t)4;
+#endif
 
+#if !defined(CARDPUTER_ADV_3IN1_MUX)
     pinMode(bruceConfigPins.NRF24_bus.cs, OUTPUT);
+    digitalWrite(bruceConfigPins.NRF24_bus.cs, HIGH);
+#endif
+
     pinMode(bruceConfigPins.CC1101_bus.cs, OUTPUT);
     pinMode(bruceConfigPins.LoRa_bus.cs, OUTPUT);
-    digitalWrite(bruceConfigPins.NRF24_bus.cs, HIGH);
     digitalWrite(bruceConfigPins.CC1101_bus.cs, HIGH);
     digitalWrite(bruceConfigPins.LoRa_bus.cs, HIGH);
 
+    // Finish TCA8418 keyboard initialization first.
     tca.matrix(7, 8);
     tca.flush();
+
     pinMode(11, INPUT);
-    attachInterruptArg(digitalPinToInterrupt(11), gpio_isr_handler, nullptr, CHANGE);
+    attachInterruptArg(
+        digitalPinToInterrupt(11),
+        gpio_isr_handler,
+        nullptr,
+        CHANGE
+    );
+
     tca.enableInterrupts();
+
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    // Create the mux mutex during board setup, before the input task starts
+    // competing with NRF24 operations.
+    (void)adv3in1MuxMutexHandle();
+
+    // Keyboard initialization is finished.
+    // GPIO8/9 can now return to NRF24 idle mode.
+    setAdvSharedPinsToNrfIdle();
+#endif
 }
 
 /*********************************************************************
@@ -220,6 +317,16 @@ void InputHandler(void) {
         keyStroke key;
 
         if (kb_interrupt || digitalRead(11) == LOW) {
+            bool keyboardMuxReady = true;
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+            keyboardMuxReady = adv3in1KeyboardTryBegin();
+#endif
+
+            if (keyboardMuxReady) {
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+                setAdvSharedPinsToI2c();
+#endif
+
             if (!kb_interrupt && digitalRead(11) == LOW) {
                 detachInterrupt(digitalPinToInterrupt(11));
                 attachInterruptArg(digitalPinToInterrupt(11), gpio_isr_handler, nullptr, CHANGE);
@@ -351,6 +458,12 @@ void InputHandler(void) {
             tca.writeRegister(TCA8418_REG_INT_STAT, 1);
             int intstat = tca.readRegister(TCA8418_REG_INT_STAT);
             if ((intstat & 0x01) == 0) { kb_interrupt = false; }
+
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+            setAdvSharedPinsToNrfIdle();
+            adv3in1KeyboardEnd();
+#endif
+            }
         }
 
         unsigned long now = millis();
@@ -503,7 +616,17 @@ void _setup_codec_speaker(bool enable) {
     };
     static constexpr const uint8_t disabled_bulk_data[] = {0};
 
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    adv3in1Nrf24CriticalBegin();
+    setAdvSharedPinsToI2c();
+#endif
+
     i2c_bulk_write(&Wire1, ES8311_ADDR, enable ? enabled_bulk_data : disabled_bulk_data);
+
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    setAdvSharedPinsToNrfIdle();
+    adv3in1Nrf24CriticalEnd();
+#endif
 }
 
 /*********************************************************************
@@ -540,5 +663,15 @@ void _setup_codec_mic(bool enable) {
         0
     };
 
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    adv3in1Nrf24CriticalBegin();
+    setAdvSharedPinsToI2c();
+#endif
+
     i2c_bulk_write(&Wire1, ES8311_ADDR, enable ? enabled_bulk_data : disabled_bulk_data);
+
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    setAdvSharedPinsToNrfIdle();
+    adv3in1Nrf24CriticalEnd();
+#endif
 }

--- a/boards/m5stack-cardputer/m5stack-cardputer-adv-3in1.ini
+++ b/boards/m5stack-cardputer/m5stack-cardputer-adv-3in1.ini
@@ -1,0 +1,28 @@
+; M5Stack Cardputer ADV + JosephCGS CC1101/NRF24/LoRa 3-in-1
+;
+; Inherits the standard Cardputer environment and overrides only the
+; radio pins required by the 3-in-1 expansion.
+;
+; GPIO8/9 are shared between the ADV TCA8418 keyboard and NRF24.
+
+[env:m5stack-cardputer-adv-3in1]
+extends = env:m5stack-cardputer
+
+build_unflags =
+    -DCC1101_GDO0_PIN=GROVE_SDA
+    -DCC1101_SS_PIN=SPI_SS_PIN
+    -DNRF24_CE_PIN=GROVE_SDA
+    -DNRF24_SS_PIN=SPI_SS_PIN
+
+build_flags =
+    ${env:m5stack-cardputer.build_flags}
+
+    -DCARDPUTER_ADV_3IN1_MUX=1
+
+    ; CC1101
+    -DCC1101_GDO0_PIN=13
+    -DCC1101_SS_PIN=15
+
+    ; NRF24
+    -DNRF24_CE_PIN=8
+    -DNRF24_SS_PIN=9

--- a/src/core/bus_HAL.cpp
+++ b/src/core/bus_HAL.cpp
@@ -216,6 +216,20 @@ void releaseI2CBus() {
 }
 
 bool checkAndRecoverSysI2CBus() {
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    // Cardputer ADV 3-in-1 expansion:
+    // GPIO8/9 are multiplexed between the TCA8418 I2C keyboard
+    // and NRF24 CE/CS.
+    //
+    // NRF24 CE is intentionally held LOW while idle, so sampling
+    // GPIO8 as an I2C SDA health signal would falsely report a
+    // permanently stuck I2C bus and trigger recovery.
+    //
+    // Keyboard access is explicitly handled by the board-specific
+    // GPIO8/9 multiplexing code in interface.cpp.
+    return false;
+#endif
+
     int8_t sda = (int8_t)bruceConfigPins.sys_i2c.sda;
     int8_t scl = (int8_t)bruceConfigPins.sys_i2c.scl;
     if (sda < 0 || scl < 0) return false; // board has no sys_i2c

--- a/src/modules/NRF24/nrf_common.cpp
+++ b/src/modules/NRF24/nrf_common.cpp
@@ -43,6 +43,22 @@ bool nrf_start(NRF24_MODE mode) {
 
     if (!CHECK_NRF_SPI(mode)) return result;
 
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    // CC1101, NRF24 and LoRa share SCK/MISO/MOSI on the 3-in-1 board.
+    // Keep every inactive device deselected before talking to NRF24.
+    if (bruceConfigPins.CC1101_bus.cs != GPIO_NUM_NC) {
+        pinMode(bruceConfigPins.CC1101_bus.cs, OUTPUT);
+        digitalWrite(bruceConfigPins.CC1101_bus.cs, HIGH);
+    }
+
+#if !defined(LITE_VERSION)
+    if (bruceConfigPins.LoRa_bus.cs != GPIO_NUM_NC) {
+        pinMode(bruceConfigPins.LoRa_bus.cs, OUTPUT);
+        digitalWrite(bruceConfigPins.LoRa_bus.cs, HIGH);
+    }
+#endif
+#endif
+
     // Always re-assert CE LOW and CS HIGH before begin() — these pins
     // may have been left in an indeterminate state by the previous session,
     // especially after stopConstCarrier() which can leave CE HIGH internally.

--- a/src/modules/NRF24/nrf_spectrum.cpp
+++ b/src/modules/NRF24/nrf_spectrum.cpp
@@ -6,26 +6,67 @@
 #define RGB565(r, g, b) ((((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3)))
 uint8_t channel[CHANNELS];
 
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+// Implemented by boards/m5stack-cardputer/interface.cpp.
+// The mutex prevents the TCA8418 keyboard task from taking GPIO8/9 while
+// an NRF24 receive window is in progress.
+extern void adv3in1Nrf24CriticalBegin();
+extern void adv3in1Nrf24CriticalEnd();
+#endif
+
+
 // scanning channels
 #define _BW tftWidth / CHANNELS
 String scanChannels(bool web) {
     String result = "{";
 
     uint8_t rpdValues[CHANNELS] = {0};
+
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    adv3in1Nrf24CriticalBegin();
+#endif
+
+    // CE must be inactive before changing channels.
     digitalWrite(bruceConfigPins.NRF24_bus.io0, LOW);
 
     for (int i = 0; i < CHANNELS; i++) {
         NRFradio.setChannel(i);
         NRFradio.startListening();
+
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+        // The 3-in-1 expansion needs the RPD sample while CE still owns GPIO8.
+        // Keep the hardware-validated tolerant detection strategy scoped to
+        // this board so other NRF24 devices retain the upstream scanner.
+        delayMicroseconds(130);
+        bool foundSignal = NRFradio.testRPD();
+        NRFradio.stopListening();
+        foundSignal = foundSignal || NRFradio.testRPD() || NRFradio.available();
+
+        if (foundSignal) {
+            NRFradio.flush_rx();
+        }
+
+        int rpd = foundSignal ? 1 : 0;
+#else
         delayMicroseconds(128);
         NRFradio.stopListening();
 
         int rpd = NRFradio.testRPD() ? 1 : 0;
+#endif
         channel[i] = (channel[i] * 3 + rpd * 125) / 4;
         rpdValues[i] = channel[i];
     }
 
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    // Leave NRF24 electrically inactive while the TCA8418 borrows GPIO8/9.
+    digitalWrite(bruceConfigPins.NRF24_bus.io0, LOW);
+    digitalWrite(bruceConfigPins.NRF24_bus.cs, HIGH);
+    adv3in1Nrf24CriticalEnd();
+#else
+    // Preserve upstream behaviour for every other NRF24 configuration.
     digitalWrite(bruceConfigPins.NRF24_bus.io0, HIGH);
+#endif
+
 
     for (int i = 0; i < CHANNELS; i++) {
         int level = rpdValues[i];
@@ -61,7 +102,15 @@ void nrf_spectrum() {
     tft.drawCentreString("2.44Ghz", tftWidth / 2, tftHeight - LH, 1);
     tft.drawRightString("2.48Ghz", tftWidth, tftHeight - LH, 1);
 
-    if (nrf_start(NRF_MODE_SPI)) { // This function only works on SPI
+
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    adv3in1Nrf24CriticalBegin();
+#endif
+
+    bool nrfStarted = nrf_start(NRF_MODE_SPI); // This function only works on SPI
+
+    if (nrfStarted) {
+
         NRFradio.setAutoAck(false);
         NRFradio.disableCRC();       // accept any signal we find
         NRFradio.setAddressWidth(2); // a reverse engineering tactic (not typically recommended)
@@ -75,13 +124,29 @@ void nrf_spectrum() {
         };
         for (uint8_t i = 0; i < 6; ++i) { NRFradio.openReadingPipe(i, noiseAddress[i]); }
         NRFradio.setDataRate(RF24_1MBPS);
+    }
 
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+    adv3in1Nrf24CriticalEnd();
+#endif
+
+    if (nrfStarted) {
         while (!check(EscPress)) {
             scanChannels();
+            // The NRF24 mux is released before this yield. Pending TCA8418
+            // events can therefore be serviced without corrupting the RF scan.
             vTaskDelay(pdMS_TO_TICKS(1));
         }
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+        adv3in1Nrf24CriticalBegin();
+#endif
         NRFradio.stopListening();
         NRFradio.powerDown();
+#if defined(CARDPUTER_ADV_3IN1_MUX)
+        digitalWrite(bruceConfigPins.NRF24_bus.io0, LOW);
+        digitalWrite(bruceConfigPins.NRF24_bus.cs, HIGH);
+        adv3in1Nrf24CriticalEnd();
+#endif
         delay(250);
         return;
 


### PR DESCRIPTION
#### Proposed Changes ####

Add support for the JosephCGS CC1101/NRF24/LoRa 3-in-1 expansion board on the M5Stack Cardputer ADV.

This introduces a dedicated PlatformIO environment:

`m5stack-cardputer-adv-3in1`

The standard `m5stack-cardputer` environment remains unchanged.

The expansion shares the Cardputer ADV SPI bus and multiplexes GPIO8/9 between the TCA8418 keyboard controller and NRF24 CE/CS.

The implementation:

- adds the dedicated Cardputer ADV 3-in-1 build environment;
- configures CC1101 GDO0=13 / CS=15;
- configures NRF24 CE=8 / CS=9;
- keeps inactive SPI devices deselected;
- arbitrates GPIO8/9 between the TCA8418 keyboard and NRF24;
- prevents generic I2C recovery from misinterpreting NRF24 CE LOW as a stuck SDA line;
- keeps the NRF24 spectrum handling changes scoped to this hardware configuration.

This PR is rebased onto `dev` (`fe07bd7`). The only conflict was `src/modules/NRF24/nrf_spectrum.cpp`, rewritten by #2758 (`SpectrumPlot`, continuous trace, frequency ruler). The 3-in-1 changes were reapplied on the new structure:

- `scanChannels()` — the mux critical section wraps the sweep; the tolerant RPD detection stays scoped to `#if defined(CARDPUTER_ADV_3IN1_MUX)`, and the `#else` path is the current upstream scanner (`NRF_FULL_SCALE`);
- `nrf_spectrum()` — `dev` early-returns when `nrf_start()` fails, so `adv3in1Nrf24CriticalEnd()` runs before that return; otherwise the mutex would leak and leave the TCA8418 keyboard stuck when the radio fails to start.

`nrf_common.cpp`, `bus_HAL.cpp` and the board files rebased cleanly.

#### Types of Changes ####

New Feature / Hardware Support

#### Verification ####

Both environments build successfully:

- `pio run -e m5stack-cardputer`
- `pio run -e m5stack-cardputer-adv-3in1`

The standard Cardputer environment was also verified to retain its original compile-time pin configuration.

Hardware testing on M5Stack Cardputer ADV with the JosephCGS 3-in-1 expansion validated:

- Cardputer ADV boot
- microSD
- TCA8418 keyboard
- CC1101 receive
- LoRa
- NRF24 SPI initialization
- NRF24 spectrum reception
- keyboard operation after leaving NRF24 Spectrum

#### Testing ####

Both environments build successfully against `dev` (`fe07bd7`):

Standard environment:
- RAM: 130596 / 327680 bytes (39.9%)
- Flash: 4146136 / 8388608 bytes (49.4%)

3-in-1 environment:
- RAM: 130604 / 327680 bytes (39.9%)
- Flash: 4146276 / 8388608 bytes (49.4%)

The hardware checklist above was validated on the functional implementation prior to the rebase. The final rebased commit was build-tested on both environments against `dev`; a hardware retest is pending.

#### Linked Issues ####

None.

#### User-Facing Change ####

```release-note
Add optional M5Stack Cardputer ADV support for the JosephCGS CC1101/NRF24/LoRa 3-in-1 expansion board.
```