### PR TITLE
fix(nesso): support Grove I2C devices

### DIFF
--- a/boards/arduino-nesso-n1/interface.cpp
+++ b/boards/arduino-nesso-n1/interface.cpp
@@ -7,6 +7,8 @@
 constexpr uint32_t kBtnBDoublePressWindowMs = 270;
 constexpr uint32_t kBtnBLongPressMs = 500;
 
+bool enableNessoGrovePower();
+
 /***************************************************************************************
 ** Function name: _setup_gpio()
 ** Location: main.cpp
@@ -17,6 +19,7 @@ void _setup_gpio() {
     // ESP32-C6 only has one general-purpose I2C controller (SOC_HP_I2C_NUM == 1), so
     // I2C_NUM_1 doesn't exist in i2c_port_t here and M5.In_I2C is always on Wire/I2C_NUM_0.
     setSysI2CBus(&Wire);
+    enableNessoGrovePower();
     bruceConfig.colorInverted = 0;
     M5.BtnA.setDebounceThresh(8);
     M5.BtnB.setDebounceThresh(8);

--- a/boards/arduino-nesso-n1/nesso_grove_i2c.cpp
+++ b/boards/arduino-nesso-n1/nesso_grove_i2c.cpp
@@ -1,0 +1,142 @@
+#include "core/bus_HAL.h"
+#include <Arduino.h>
+#include <M5Unified.h>
+
+namespace {
+constexpr uint8_t kNessoExpanderAddress = 0x44;
+constexpr uint8_t kGrovePowerBit = 2;
+constexpr uint32_t kDefaultI2CFrequency = 100000;
+
+class NessoGroveM5Wire : public TwoWire {
+public:
+    NessoGroveM5Wire() : TwoWire(255) {}
+
+    bool begin(int sda, int scl, uint32_t frequency = kDefaultI2CFrequency) {
+        _freq = frequency;
+        return M5.Ex_I2C.begin(I2C_NUM_0, sda, scl);
+    }
+
+    bool begin(int sda, int scl) { return begin(sda, scl, _freq); }
+    bool end() override { return M5.Ex_I2C.release(); }
+    bool setClock(uint32_t freq) override {
+        _freq = freq;
+        return true;
+    }
+
+    void beginTransmission(uint8_t address) override {
+        _addr = address;
+        _error = 0;
+        _open = M5.Ex_I2C.start(address, false, _freq);
+        if (!_open) _error = 4;
+    }
+
+    uint8_t endTransmission(bool sendStop) override {
+        if (sendStop) {
+            if (_open && !M5.Ex_I2C.stop()) _error = 4;
+            _open = false;
+        }
+        return _error;
+    }
+
+    uint8_t endTransmission() override { return endTransmission(true); }
+
+    size_t requestFrom(uint8_t address, size_t len, bool sendStop) override {
+        if (len > sizeof(_rxBuf)) len = sizeof(_rxBuf);
+        bool ok = _open ? M5.Ex_I2C.restart(address, true, _freq) : M5.Ex_I2C.start(address, true, _freq);
+        _open = false;
+        _rxLen = _rxPos = 0;
+        if (ok && M5.Ex_I2C.read(_rxBuf, len, true)) _rxLen = len;
+        if (sendStop) M5.Ex_I2C.stop();
+        return _rxLen;
+    }
+
+    size_t requestFrom(uint8_t address, size_t len) override { return requestFrom(address, len, true); }
+
+    size_t write(uint8_t data) override {
+        if (!_open || !M5.Ex_I2C.write(data)) {
+            _error = 4;
+            return 0;
+        }
+        return 1;
+    }
+
+    size_t write(const uint8_t *data, size_t quantity) override {
+        if (!_open || !M5.Ex_I2C.write(data, quantity)) {
+            _error = 4;
+            return 0;
+        }
+        return quantity;
+    }
+
+    int available() override { return (int)(_rxLen - _rxPos); }
+    int read() override { return _rxPos < _rxLen ? _rxBuf[_rxPos++] : -1; }
+    int peek() override { return _rxPos < _rxLen ? _rxBuf[_rxPos] : -1; }
+
+    void onReceive(const std::function<void(int)> &) override {}
+    void onRequest(const std::function<void()> &) override {}
+
+private:
+    uint32_t _freq = kDefaultI2CFrequency;
+    uint8_t _addr = 0;
+    bool _open = false;
+    uint8_t _error = 0;
+    uint8_t _rxBuf[64];
+    size_t _rxLen = 0;
+    size_t _rxPos = 0;
+};
+
+
+bool nessoExpanderSetBit(uint8_t reg, uint8_t bit, bool enabled) {
+    uint8_t value = 0;
+    if (!M5.In_I2C.readRegister(kNessoExpanderAddress, reg, &value, 1, kDefaultI2CFrequency)) return false;
+    uint8_t updated = enabled ? (value | (1 << bit)) : (value & ~(1 << bit));
+    if (updated == value) return true;
+    return M5.In_I2C.writeRegister8(kNessoExpanderAddress, reg, updated, kDefaultI2CFrequency);
+}
+
+bool nessoEnableGrovePower() {
+    static bool enabled = false;
+    if (enabled) return true;
+
+    bool ok = nessoExpanderSetBit(0x03, kGrovePowerBit, true);
+    ok = nessoExpanderSetBit(0x07, kGrovePowerBit, false) && ok;
+    ok = nessoExpanderSetBit(0x05, kGrovePowerBit, true) && ok;
+    if (ok) {
+        enabled = true;
+        delay(20);
+    }
+    return ok;
+}
+
+NessoGroveM5Wire &nessoGroveWire() {
+    static NessoGroveM5Wire wire;
+    return wire;
+}
+} // namespace
+
+bool enableNessoGrovePower() { return nessoEnableGrovePower(); }
+
+TwoWire *acquireBoardI2CBus(int8_t sda, int8_t scl) {
+    if (sda != GROVE_SDA || scl != GROVE_SCL) return nullptr;
+    enableNessoGrovePower();
+
+    lockSysI2CBus();
+    M5.In_I2C.release();
+
+    NessoGroveM5Wire &wire = nessoGroveWire();
+    if (!wire.begin(sda, scl, kDefaultI2CFrequency)) {
+        M5.In_I2C.begin(I2C_NUM_0, SYS_I2C_SDA, SYS_I2C_SCL);
+        unlockSysI2CBus();
+        return nullptr;
+    }
+    return &wire;
+}
+
+bool releaseBoardI2CBus(TwoWire *wire) {
+    if (wire != &nessoGroveWire()) return false;
+
+    nessoGroveWire().end();
+    M5.In_I2C.begin(I2C_NUM_0, SYS_I2C_SDA, SYS_I2C_SCL);
+    unlockSysI2CBus();
+    return true;
+}

--- a/boards/arduino-nesso-n1/platformio.ini
+++ b/boards/arduino-nesso-n1/platformio.ini
@@ -46,6 +46,7 @@ build_flags =
 	-D GROVE_SCL=4
 	-D SYS_I2C_SDA=10
 	-D SYS_I2C_SCL=8
+	-D BRUCE_BOARD_HAS_SOFTWARE_I2C=1
 
 	;Features Enabled
 	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility

--- a/src/core/bus_HAL.cpp
+++ b/src/core/bus_HAL.cpp
@@ -90,16 +90,18 @@ public:
     void beginTransmission(uint8_t address) override {
         lockSysI2CBus();
         _addr = address;
+        _error = 0;
         _open = _i2c.start(address, false, _freq);
+        if (!_open) _error = 4;
     }
 
     uint8_t endTransmission(bool stopBit) override {
         if (stopBit) {
-            _i2c.stop();
+            if (_open && !_i2c.stop()) _error = 4;
             _open = false;
             unlockSysI2CBus();
         }
-        return 0;
+        return _error;
     }
     uint8_t endTransmission() override { return endTransmission(true); }
 
@@ -116,8 +118,20 @@ public:
     }
     size_t requestFrom(uint8_t address, size_t len) override { return requestFrom(address, len, true); }
 
-    size_t write(uint8_t data) override { return _i2c.write(data) ? 1 : 0; }
-    size_t write(const uint8_t *buf, size_t len) override { return _i2c.write(buf, len) ? len : 0; }
+    size_t write(uint8_t data) override {
+        if (!_open || !_i2c.write(data)) {
+            _error = 4;
+            return 0;
+        }
+        return 1;
+    }
+    size_t write(const uint8_t *buf, size_t len) override {
+        if (!_open || !_i2c.write(buf, len)) {
+            _error = 4;
+            return 0;
+        }
+        return len;
+    }
 
     int available() override { return (int)(_rxLen - _rxPos); }
     int read() override { return _rxPos < _rxLen ? _rxbuf[_rxPos++] : -1; }
@@ -131,6 +145,7 @@ private:
     uint32_t _freq = 400000;
     uint8_t _addr = 0;
     bool _open = false;
+    uint8_t _error = 0;
     uint8_t _rxbuf[64];
     size_t _rxLen = 0;
     size_t _rxPos = 0;
@@ -145,6 +160,17 @@ static TwoWire *sysWireAdapter() {
     return adapter;
 }
 #endif
+
+TwoWire *__attribute__((weak)) acquireBoardI2CBus(int8_t sda, int8_t scl) {
+    (void)sda;
+    (void)scl;
+    return nullptr;
+}
+
+bool __attribute__((weak)) releaseBoardI2CBus(TwoWire *wire) {
+    (void)wire;
+    return false;
+}
 
 static TwoWire *userWire = nullptr;
 static bool userBusShared = false;
@@ -185,6 +211,15 @@ TwoWire *acquireI2CBus(int8_t sda, int8_t scl) {
 #endif
     }
 
+    TwoWire *boardWire = acquireBoardI2CBus(sda, scl);
+    if (boardWire != nullptr) {
+        userWire = boardWire;
+        userBusShared = false;
+        activeSda = sda;
+        activeScl = scl;
+        return boardWire;
+    }
+
 #ifdef BRUCE_HAS_DUAL_I2C
     TwoWire *wire = (sysWire == &Wire) ? &Wire1 : &Wire;
 #else
@@ -208,8 +243,10 @@ void releaseI2CBus() {
     BUSHAL_DBG("[busHAL] release(): userBusShared=%d userWire=%p\n", (int)userBusShared, (void *)userWire);
     if (userBusShared) return;
     if (userWire == nullptr) return;
-    BUSHAL_DBG("[busHAL] release(): calling userWire->end()\n");
-    userWire->end();
+    if (!releaseBoardI2CBus(userWire)) {
+        BUSHAL_DBG("[busHAL] release(): calling userWire->end()\n");
+        userWire->end();
+    }
     userWire = nullptr;
     activeSda = -1;
     activeScl = -1;

--- a/src/core/bus_HAL.h
+++ b/src/core/bus_HAL.h
@@ -28,6 +28,12 @@ TwoWire *getSysI2CBus();
 TwoWire *acquireI2CBus(int8_t sda, int8_t scl);
 TwoWire *acquireI2CBus();
 
+// Board-specific escape hatch for devices that need a non-hardware I2C transport (for example,
+// a software bus when the only hardware controller is reserved for sys_i2c). Most boards use the
+// weak defaults in bus_HAL.cpp.
+TwoWire *acquireBoardI2CBus(int8_t sda, int8_t scl);
+bool releaseBoardI2CBus(TwoWire *wire);
+
 // Ends the i2c_bus TwoWire instance started by acquireI2CBus(), unless it turned out to be the
 // same physical bus as sys_i2c (which must stay on).
 void releaseI2CBus();

--- a/src/core/configPins.cpp
+++ b/src/core/configPins.cpp
@@ -212,7 +212,8 @@ void BruceConfigPins::fromJson(JsonObject obj) {
     //     log_e("Fail");
     // }
     if (!root["i2c_bus"].isNull()) {
-#if defined(SOC_HP_I2C_NUM) && SOC_HP_I2C_NUM < 2 && SYS_I2C_SDA >= 0 && SYS_I2C_SCL >= 0
+#if defined(SOC_HP_I2C_NUM) && SOC_HP_I2C_NUM < 2 && SYS_I2C_SDA >= 0 && SYS_I2C_SCL >= 0 && \
+    !defined(BRUCE_BOARD_HAS_SOFTWARE_I2C)
         log_e("I2C Pins cannot be changed on this board, using default values");
         i2c_bus = sys_i2c;
 #else

--- a/src/modules/rfid/RFID2.cpp
+++ b/src/modules/rfid/RFID2.cpp
@@ -7,40 +7,123 @@
  */
 
 #include "RFID2.h"
+#include "core/bus_HAL.h"
 #include "core/display.h"
 #include "core/i2c_finder.h"
 #include "core/sd_functions.h"
-#include <MFRC522DriverI2C.h>
 #include <MFRC522DriverSPI.h>
 #include <MFRC522Hack.h>
 #include <algorithm>
 
 #define RFID2_I2C_ADDRESS 0x28
+#define WS1850S_VERSION 0x15
+
+namespace {
+class BruceMFRC522DriverI2C : public MFRC522Driver {
+public:
+    BruceMFRC522DriverI2C(const byte slaveAdr, TwoWire &wire) : _slaveAdr(slaveAdr), _wire(wire) {}
+
+    bool init() override { return true; }
+
+    void PCD_WriteRegister(const PCD_Register reg, const byte value) override {
+        _wire.beginTransmission(_slaveAdr);
+        _wire.write(i2cRegisterAddress(reg));
+        _wire.write(value);
+        _wire.endTransmission();
+    }
+
+    void PCD_WriteRegister(const PCD_Register reg, const byte count, byte *const values) override {
+        _wire.beginTransmission(_slaveAdr);
+        _wire.write(i2cRegisterAddress(reg));
+        _wire.write(values, count);
+        _wire.endTransmission();
+    }
+
+    byte PCD_ReadRegister(const PCD_Register reg) override {
+        _wire.beginTransmission(_slaveAdr);
+        _wire.write(i2cRegisterAddress(reg));
+        _wire.endTransmission();
+
+        if (_wire.requestFrom(_slaveAdr, (uint8_t)1) != 1) return 0xFF;
+        return (uint8_t)_wire.read();
+    }
+
+    void PCD_ReadRegister(
+        const PCD_Register reg, const byte count, byte *const values, const byte rxAlign = 0
+    ) override {
+        if (count == 0 || values == nullptr) return;
+
+        _wire.beginTransmission(_slaveAdr);
+        _wire.write(i2cRegisterAddress(reg));
+        _wire.endTransmission();
+        _wire.requestFrom(_slaveAdr, count);
+
+        byte index = 0;
+        while (_wire.available() && index < count) {
+            byte value = (byte)_wire.read();
+            if (index == 0 && rxAlign) {
+                byte mask = 0;
+                for (byte i = rxAlign; i <= 7; i++) mask |= (1 << i);
+                values[0] = (values[index] & ~mask) | (value & mask);
+            } else {
+                values[index] = value;
+            }
+            index++;
+        }
+    }
+
+private:
+    static byte i2cRegisterAddress(const PCD_Register reg) { return (byte)reg; }
+
+    const byte _slaveAdr;
+    TwoWire &_wire;
+};
+} // namespace
 
 RFID2::RFID2(bool use_i2c) : _use_i2c(use_i2c) {
-    if (use_i2c)
-        _driver =
-            new MFRC522DriverI2C{RFID2_I2C_ADDRESS, bruceConfigPins.i2c_bus.sda, bruceConfigPins.i2c_bus.scl};
-    else _driver = new MFRC522DriverSPI{ss_pin, SPI_SCK_PIN, SPI_MISO_PIN, SPI_MOSI_PIN};
-    mfrc522.SetDriver(*_driver);
+    if (use_i2c) {
+        _i2cWire = acquireI2CBus();
+        if (_i2cWire != nullptr) _driver = new BruceMFRC522DriverI2C{RFID2_I2C_ADDRESS, *_i2cWire};
+    } else {
+        _driver = new MFRC522DriverSPI{ss_pin, SPI_SCK_PIN, SPI_MISO_PIN, SPI_MOSI_PIN};
+    }
+    if (_driver != nullptr) mfrc522.SetDriver(*_driver);
 }
 
-RFID2::~RFID2() { delete _driver; }
+RFID2::~RFID2() {
+    delete _driver;
+    if (_use_i2c) releaseI2CBus();
+}
 
 bool RFID2::begin() {
-    bool i2c_check = check_i2c_address(RFID2_I2C_ADDRESS);
+    bool i2c_check = false;
+    if (_use_i2c && _i2cWire != nullptr) {
+        _i2cWire->beginTransmission(RFID2_I2C_ADDRESS);
+        i2c_check = _i2cWire->endTransmission() == 0;
+    }
 
-    mfrc522.PCD_Init();
+    if (_driver == nullptr) return false;
 
+    bool init_ok = mfrc522.PCD_Init();
+    if (_use_i2c) mfrc522.PCD_SetAntennaGain(MFRC522::PCD_RxGain::RxGain_max);
+    byte raw_version = _driver->PCD_ReadRegister(MFRC522::PCD_Register::VersionReg);
     MFRC522::PCD_Version version = mfrc522.PCD_GetVersion();
 
-    return i2c_check || version != MFRC522::PCD_Version::Version_Unknown;
+    if (_use_i2c) {
+        return i2c_check && (raw_version == WS1850S_VERSION ||
+                             (init_ok && version != MFRC522::PCD_Version::Version_Unknown));
+    }
+    return init_ok && version != MFRC522::PCD_Version::Version_Unknown;
 }
 
 bool RFID2::PICC_IsNewCardPresent() {
     byte bufferATQA[2];
     byte bufferSize = sizeof(bufferATQA);
     byte result = mfrc522.PICC_RequestA(bufferATQA, &bufferSize);
+    if (result != MFRC522::StatusCode::STATUS_OK && result != MFRC522::StatusCode::STATUS_COLLISION) {
+        bufferSize = sizeof(bufferATQA);
+        result = mfrc522.PICC_WakeupA(bufferATQA, &bufferSize);
+    }
     bool bl_result =
         (result == MFRC522::StatusCode::STATUS_OK || result == MFRC522::StatusCode::STATUS_COLLISION);
     if (bl_result) {
@@ -60,9 +143,17 @@ int RFID2::read(int cardBaudRate) {
 
     if (!PICC_IsNewCardPresent() || !mfrc522.PICC_ReadCardSerial()) return TAG_NOT_PRESENT;
 
-    displayInfo("Reading data blocks...");
-    pageReadStatus = read_data_blocks();
-    pageReadSuccess = pageReadStatus == SUCCESS;
+    byte piccType = mfrc522.PICC_GetType(mfrc522.uid.sak);
+    if (piccType == MFRC522::PICC_Type::PICC_TYPE_ISO_14443_4) {
+        pageReadStatus = NOT_IMPLEMENTED;
+        pageReadSuccess = false;
+        mfrc522.PICC_HaltA();
+        return NOT_IMPLEMENTED;
+    } else {
+        displayInfo("Reading data blocks...");
+        pageReadStatus = read_data_blocks();
+        pageReadSuccess = pageReadStatus == SUCCESS;
+    }
     format_data();
     set_uid();
     return SUCCESS;

--- a/src/modules/rfid/RFID2.h
+++ b/src/modules/rfid/RFID2.h
@@ -10,6 +10,7 @@
 #include <MFRC522Driver.h>
 #include <MFRC522DriverPinSimple.h>
 #include <MFRC522v2.h>
+#include <Wire.h>
 
 class RFID2 : public RFIDInterface {
 public:
@@ -39,7 +40,8 @@ public:
 
 private:
     bool _use_i2c;
-    MFRC522Driver *_driver;
+    TwoWire *_i2cWire = nullptr;
+    MFRC522Driver *_driver = nullptr;
     MFRC522DriverPinSimple ss_pin = MFRC522DriverPinSimple(SPI_SS_PIN);
 
     /////////////////////////////////////////////////////////////////////////////////////

--- a/src/modules/rfid/tag_o_matic.cpp
+++ b/src/modules/rfid/tag_o_matic.cpp
@@ -21,6 +21,22 @@
 #define NDEF_DATA_SIZE 100
 #define SCAN_DUMP_SIZE 5
 
+namespace {
+void displaySmallErrorToast(const String &txt) {
+    constexpr int textSize = FP;
+    int boxWidth = txt.length() * LW * textSize + 18;
+    if (boxWidth > tftWidth - 20) boxWidth = tftWidth - 20;
+    int boxHeight = LH * textSize + 10;
+    int boxX = (tftWidth - boxWidth) / 2;
+    int boxY = tftHeight / 2 - boxHeight / 2;
+
+    tft.fillRoundRect(boxX, boxY, boxWidth, boxHeight, 5, TFT_RED);
+    tft.setTextColor(TFT_WHITE, TFT_RED);
+    tft.setTextSize(textSize);
+    tft.drawCentreString(txt, tftWidth / 2, boxY + 5);
+}
+} // namespace
+
 TagOMatic::TagOMatic() {
     _initial_state = READ_MODE;
     setup();
@@ -274,12 +290,39 @@ void TagOMatic::dump_scan_results() {
     }
 }
 
+void TagOMatic::show_not_implemented_card() {
+    displaySmallErrorToast(_rfid->statusMessage(RFIDInterface::NOT_IMPLEMENTED));
+
+    while (!returnToMenu) {
+        delay(200);
+        if (check(EscPress)) {
+            returnToMenu = true;
+            break;
+        }
+        if (_rfid->read() != RFIDInterface::NOT_IMPLEMENTED) break;
+    }
+
+    delay(700);
+    display_banner();
+    _lastReadTime = millis();
+}
+
 void TagOMatic::read_card() {
     if (millis() - _lastReadTime < 2000) return;
 
-    if (_rfid->read() != RFIDInterface::SUCCESS) {
+    int readStatus = _rfid->read();
+    if (readStatus != RFIDInterface::SUCCESS) {
+        if (readStatus == RFIDInterface::NOT_IMPLEMENTED) {
+            show_not_implemented_card();
+            return;
+        }
         if (bruceConfigPins.rfidModule != M5_RFID2_MODULE) { // Read felica if module is PN532
-            if (_rfid->read(1) != RFIDInterface::SUCCESS) return;
+            readStatus = _rfid->read(1);
+            if (readStatus == RFIDInterface::NOT_IMPLEMENTED) {
+                show_not_implemented_card();
+                return;
+            }
+            if (readStatus != RFIDInterface::SUCCESS) return;
         } else {
             return;
         }

--- a/src/modules/rfid/tag_o_matic.h
+++ b/src/modules/rfid/tag_o_matic.h
@@ -76,6 +76,7 @@ private:
     void dump_check_details();
     void dump_ndef_details();
     void dump_scan_results();
+    void show_not_implemented_card();
 
     /////////////////////////////////////////////////////////////////////////////////////
     // State management


### PR DESCRIPTION
#### Proposed Changes ####

Fix Arduino Nesso N1 Grove I2C and M5Stack RFID2 support without moving the Nesso internal/system I2C bus.

The Nesso N1 has two logical I2C paths:

- system/internal I2C on GPIO10/GPIO8 for onboard devices, M5Unified, and the `0x44` I/O expander
- external Grove I2C on GPIO5/GPIO4 for Grove modules such as M5Stack RFID2 and ENV Pro

This PR:

- keeps the Nesso system bus on GPIO10/GPIO8
- enables the Nesso Grove 5 V rail through the onboard expander at `0x44`, P2/bit 2
- uses read-modify-write operations for the expander registers so unrelated bits are preserved
- adds board-level hooks so Nesso can provide the Grove I2C transport without adding Nesso conditionals throughout generic code
- borrows the ESP32-C6 hardware I2C controller for `M5.Ex_I2C` on GPIO5/GPIO4 while the Grove bus is in use, then restores `M5.In_I2C` on GPIO10/GPIO8 when released
- keeps existing RFID2 behavior unchanged for other boards
- makes RFID2 use the selected Bruce I2C transport instead of reinitializing the wrong global bus
- accepts the M5Stack RFID2 WS1850S version value (`0x15`) during I2C RFID2 initialization
- improves ISO14443-4 handling in the RFID2 read path by showing a small `Not implemented` toast instead of verbose read errors for unsupported targets such as DESFire/ISO-DEP devices

Root cause: on ESP32-C6, Bruce has limited hardware I2C resources. The Nesso system bus must remain available for M5Unified/onboard devices, while external Grove devices are on a separate GPIO5/GPIO4 bus that also requires explicit Grove 5 V enable through the `0x44:P2` expander path. The previous RFID2 path could also reinitialize/use the wrong I2C transport, and the WS1850S firmware version was not recognized by the bundled MFRC522 version check.

The previous scanner result `0x01` was not a real Grove ACK. It came from the M5 system-bus adapter returning success from `endTransmission()` even when the underlying transaction failed, so failed probes could be displayed as found addresses.

#### Types of Changes ####

Bugfix / board support fix.

#### Verification ####

Hardware facts verified on this Nesso N1 before and during this PR:

- Nesso system I2C: SDA GPIO10, SCL GPIO8
- Nesso system I2C scan with MicroPython: `0x38 0x43 0x44 0x49 0x55 0x68`
- Nesso Grove I2C: SDA GPIO5, SCL GPIO4
- Grove 5 V is controlled by expander `0x44`, P2/bit 2
- Required Grove power sequence:
  - register `0x03`, bit 2 = 1
  - register `0x07`, bit 2 = 0
  - register `0x05`, bit 2 = 1
- M5Stack ENV Pro detected on Grove at `0x77`
- M5Stack RFID2 detected on Grove at `0x28`

Build/flash verification performed with the Homebrew-installed PlatformIO (`/opt/homebrew/bin/pio`, PlatformIO Core 6.1.19) and Homebrew `esptool` (`/opt/homebrew/bin/esptool`, esptool 5.3.1):

- baseline `pio run -e arduino-nesso-n1` before patch — passed
- patched `pio run -e arduino-nesso-n1` — passed
- regression `pio run -e m5stack-cplus2` — passed
- flashed patched firmware to the connected Nesso N1 on `/dev/cu.usbmodem11201` with:
  - `esptool --chip esp32c6 --port /dev/cu.usbmodem11201 --baud 460800 write-flash 0x0 .pio/build/arduino-nesso-n1/bootloader.bin 0x8000 .pio/build/arduino-nesso-n1/partitions.bin 0xe000 /Users/anapeksha/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/arduino-nesso-n1/firmware.bin`
- all flashed segments were hash-verified by esptool on the connected ESP32-C6 Nesso N1 (`VID:PID 303A:1001`)
- Bruce I2C Finder detects RFID2 at `0x28` on the Nesso Grove port
- RFID2 no longer reports `RFID module not found!`
- DESFire EV1 / ISO14443-4 metro card is selected by RFID2 and reported as unsupported in this RFID2 path
- BlackBerry NFC / ISO14443-4 target is selected by RFID2 and reported as unsupported in this RFID2 path
- confirmed UI behavior: the small red `Not implemented` toast stays visible while the unsupported ISO14443-4 target remains on the RFID2 module and clears after the target is removed

Serial CLI/log validation could not be captured in this environment. PlatformIO monitor failed with `termios.error: (19, 'Operation not supported by device')`, and direct pyserial reads did not produce usable Bruce CLI output. Flash/upload access to the physical board was confirmed with esptool.

#### Testing ####

Covered by PlatformIO builds:

- `arduino-nesso-n1`
- `m5stack-cplus2`

Covered by physical Nesso N1 testing:

- patched firmware flashed successfully with esptool
- Grove I2C Finder shows RFID2 at `0x28`
- RFID2 initializes successfully
- unsupported ISO14443-4 targets are detected and show the intended `Not implemented` toast behavior

Full DESFire/EMV APDU reading is not implemented by this RFID2 path. The tested DESFire EV1 metro card and BlackBerry NFC target are detected/selected, but this PR intentionally reports them as unsupported rather than pretending to dump unsupported card types.

#### Linked Issues ####

Closes #2837.

#### User-Facing Change ####
```release-note
Fix Arduino Nesso N1 Grove I2C support for external Grove devices such as M5Stack RFID2 while preserving the internal system I2C bus.
```

#### Further Comments ####

M5Stack's WS1850S/MFRC522 RFID2 path is timing-sensitive. A software I2C implementation could ACK the device and read registers, but RF polling was not reliable. This PR uses the board-scoped Nesso bus hook to temporarily route the ESP32-C6 hardware I2C controller to the Grove bus through `M5.Ex_I2C`, then restores the Nesso system bus afterwards.
