### PR TITLE
fix(ble,core,rf,rfid,wifi): resolve BLE device names and fix stability issues

### DIFF
--- a/src/core/connect/esp_connection.cpp
+++ b/src/core/connect/esp_connection.cpp
@@ -8,13 +8,20 @@
 EspConnection *EspConnection::instance = nullptr;
 std::vector<Option> peerOptions;
 
-EspConnection::EspConnection() { setInstance(this); }
+EspConnection::EspConnection() {
+    queueMutex = xSemaphoreCreateMutex();
+    setInstance(this);
+}
 
 EspConnection::~EspConnection() {
     esp_now_unregister_send_cb();
     esp_now_unregister_recv_cb();
 
     esp_now_deinit();
+    if (queueMutex) {
+        vSemaphoreDelete(queueMutex);
+        queueMutex = nullptr;
+    }
 }
 
 bool EspConnection::beginSend() {
@@ -66,7 +73,8 @@ EspConnection::Message EspConnection::createMessage(String text) {
     message.bytesSent = text.length();
     message.done = true;
 
-    strncpy(message.data, text.c_str(), ESP_DATA_SIZE);
+    strncpy(message.data, text.c_str(), sizeof(message.data) - 1);
+    message.data[sizeof(message.data) - 1] = '\0';
 
     return message;
 }
@@ -78,8 +86,14 @@ EspConnection::Message EspConnection::createFileMessage(File file) {
     message.isFile = true;
     message.totalBytes = file.size();
 
-    strncpy(message.filename, file.name(), ESP_FILENAME_SIZE);
-    strncpy(message.filepath, path.substring(0, path.lastIndexOf("/")).c_str(), ESP_FILEPATH_SIZE);
+    strncpy(message.filename, file.name(), sizeof(message.filename) - 1);
+    message.filename[sizeof(message.filename) - 1] = '\0';
+    strncpy(
+        message.filepath,
+        path.substring(0, path.lastIndexOf("/")).c_str(),
+        sizeof(message.filepath) - 1
+    );
+    message.filepath[sizeof(message.filepath) - 1] = '\0';
 
     return message;
 }
@@ -192,18 +206,24 @@ void EspConnection::onDataSent(const uint8_t *mac_addr, esp_now_send_status_t st
 }
 
 void EspConnection::onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
-    Message recvMessage;
+    if (len < (int)sizeof(Message) || !incomingData) return;
 
-    // Use reinterpret_cast and copy assignment
-    const Message *incomingMessage = reinterpret_cast<const Message *>(incomingData);
-    recvMessage = *incomingMessage; // Use copy assignment
+    Message recvMessage;
+    memcpy(&recvMessage, incomingData, sizeof(Message));
 
     printMessage(recvMessage);
 
     if (recvMessage.ping) return sendPong(mac);
     if (recvMessage.pong) return appendPeerToList(mac);
 
-    recvQueue.push_back(recvMessage);
+    if (queueMutex) {
+        if (xSemaphoreTake(queueMutex, 50 / portTICK_PERIOD_MS) == pdTRUE) {
+            recvQueue.push_back(recvMessage);
+            xSemaphoreGive(queueMutex);
+        }
+    } else {
+        recvQueue.push_back(recvMessage);
+    }
 }
 
 void EspConnection::onDataSentStatic(const wifi_tx_info_t *info, esp_now_send_status_t status) {

--- a/src/core/connect/esp_connection.h
+++ b/src/core/connect/esp_connection.h
@@ -54,6 +54,7 @@ protected:
     uint8_t dstAddress[6];
     uint8_t broadcastAddress[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     std::vector<Message> recvQueue;
+    SemaphoreHandle_t queueMutex = nullptr;
 
     bool beginSend();
     bool beginEspnow();

--- a/src/core/sd_functions.cpp
+++ b/src/core/sd_functions.cpp
@@ -235,6 +235,7 @@ bool copyToFs(FS from, FS to, String path, bool draw) {
     if (!path.startsWith("/")) path = "/" + path;
     File dest = to.open(path, FILE_WRITE);
     if (!dest) {
+        source.close();
         Serial.println("Fail creating destination file");
         return false;
     }
@@ -243,6 +244,8 @@ bool copyToFs(FS from, FS to, String path, bool draw) {
     int prog = 0;
 
     if (&to == &LittleFS && (LittleFS.totalBytes() - LittleFS.usedBytes()) < tot) {
+        source.close();
+        dest.close();
         displayError("Not enought space", true);
         return false;
     }

--- a/src/core/tftLogger/tftLogger.cpp
+++ b/src/core/tftLogger/tftLogger.cpp
@@ -290,6 +290,11 @@ void tft_logger::imageToBin(uint8_t fs, String file, int x, int y, bool center, 
             }
         }
     }
+    if (imageSlot == 0xFF) {
+        imageSlot = 0;
+        strncpy(images[0], file.c_str(), sizeof(images[0]) - 1);
+        images[0][sizeof(images[0]) - 1] = 0;
+    }
 
     // Use image path as identifier in log.data
     uint8_t buffer[MAX_LOG_SIZE];

--- a/src/modules/ble/BLE_Suite.cpp
+++ b/src/modules/ble/BLE_Suite.cpp
@@ -116,6 +116,19 @@ void ScannerData::addDevice(
             if (deviceAddresses[i] == address) {
                 isDuplicate = true;
                 if (rssi > deviceRssi[i]) deviceRssi[i] = rssi;
+                if ((deviceNames[i] == address || deviceNames[i] == "Unknown" || deviceNames[i] == "<no name>" ||
+                     deviceNames[i].isEmpty()) &&
+                    !name.isEmpty() && name != address && name != "Unknown" && name != "<no name>") {
+                    deviceNames[i] = name;
+                    dataVersion++;
+                    if (snapshotCache) {
+                        delete snapshotCache;
+                        snapshotCache = nullptr;
+                    }
+                }
+                if (fastPair) deviceFastPair[i] = true;
+                if (hasHFP) deviceHasHFP[i] = true;
+                deviceTypes[i] |= type;
                 break;
             }
         }
@@ -4225,7 +4238,7 @@ String selectTargetFromScan(const char *title) {
             if (!device) continue;
 
             String address = String(device->getAddress().toString().c_str());
-            String name = String(device->getName().c_str());
+            String name = resolveBleDeviceName(device);
             if (name.isEmpty() || name == "(null)" || name == "null" || name == "NULL") {
                 // name = "Unknown";
                 name = address;
@@ -4264,7 +4277,7 @@ String selectTargetFromScan(const char *title) {
             if (!device) continue;
 
             String address = String(device->getAddress().toString().c_str());
-            String name = String(device->getName().c_str());
+            String name = resolveBleDeviceName(device);
             if (name.isEmpty() || name == "(null)" || name == "null" || name == "NULL") {
                 // name = "Unknown";
                 name = address;

--- a/src/modules/ble/BLE_Suite.h
+++ b/src/modules/ble/BLE_Suite.h
@@ -240,6 +240,8 @@ struct FastPairModelInfo {
     const char *deviceType;
 };
 
+extern const FastPairModelInfo fastpair_models[];
+
 // v3.1: Samsung MAC OUI detection
 extern const char *SAMSUNG_MAC_OUIS[];
 extern const int SAMSUNG_MAC_OUIS_COUNT;

--- a/src/modules/ble/ble_common.cpp
+++ b/src/modules/ble/ble_common.cpp
@@ -178,6 +178,60 @@ bool ble_scan_setup() {
     return true;
 }
 
+String resolveBleDeviceName(const NimBLEAdvertisedDevice *dev) {
+    if (!dev) return "";
+
+    String name = dev->getName().c_str();
+    if (!name.isEmpty() && name != "(null)" && name != "null" && name != "NULL" && name != "<no name>") {
+        return name;
+    }
+
+#if !defined(LITE_VERSION)
+    if (dev->haveServiceData()) {
+        std::string serviceData = dev->getServiceData(NimBLEUUID((uint16_t)0xFE2C));
+        if (serviceData.length() >= 3) {
+            uint32_t modelId =
+                ((uint8_t)serviceData[0] << 16) | ((uint8_t)serviceData[1] << 8) | (uint8_t)serviceData[2];
+            for (size_t i = 0; fastpair_models[i].name != nullptr; i++) {
+                if (fastpair_models[i].modelId == modelId) {
+                    return String(fastpair_models[i].name);
+                }
+            }
+            char modelBuf[32];
+            snprintf(modelBuf, sizeof(modelBuf), "FastPair 0x%06X", (unsigned int)modelId);
+            return String(modelBuf);
+        }
+    }
+#endif
+
+    if (dev->haveManufacturerData()) {
+        std::string manuf = dev->getManufacturerData();
+        if (manuf.length() >= 2) {
+            uint16_t company = (uint8_t)manuf[0] | ((uint8_t)manuf[1] << 8);
+            if (company == 0x004C) {
+                if (manuf.length() >= 3) {
+                    uint8_t type = (uint8_t)manuf[2];
+                    if (type == 0x07) return "Apple AirPods/Audio";
+                    if (type == 0x10) return "Apple AirTag/Nearby";
+                    if (type == 0x0F) return "Apple Device";
+                    if (type == 0x05) return "Apple AirDrop";
+                }
+                return "Apple Device";
+            } else if (company == 0x0075) {
+                if (manuf.length() >= 4) {
+                    if ((uint8_t)manuf[2] == 0x42 && (uint8_t)manuf[3] == 0x09) return "Samsung Galaxy Buds";
+                    if ((uint8_t)manuf[2] == 0x01 && (uint8_t)manuf[3] == 0x00) return "Samsung Galaxy Watch";
+                }
+                return "Samsung Galaxy Device";
+            } else if (company == 0x0006) {
+                return "Microsoft Device";
+            }
+        }
+    }
+
+    return "";
+}
+
 void ble_scan() {
     displayTextLine("Scanning..");
 
@@ -212,7 +266,7 @@ void ble_scan() {
             String bt_address;
             String bt_signal;
 
-            bt_name = advertisedDevice->getName().c_str();
+            bt_name = resolveBleDeviceName(advertisedDevice);
             bt_address = advertisedDevice->getAddress().toString().c_str();
             bt_signal = String(advertisedDevice->getRSSI());
 

--- a/src/modules/ble/ble_common.h
+++ b/src/modules/ble/ble_common.h
@@ -44,6 +44,8 @@ bool ble_scan_setup();
 void ble_scan();
 void stopBLEStack();
 
+String resolveBleDeviceName(const NimBLEAdvertisedDevice *dev);
+
 bool bleNotifyRetry(NimBLECharacteristic *chr, const uint8_t *value, size_t length, uint8_t retries = 8);
 bool bleNotifyRetry(NimBLECharacteristic *chr, uint8_t retries = 8);
 

--- a/src/modules/rf/rf_scan.cpp
+++ b/src/modules/rf/rf_scan.cpp
@@ -890,8 +890,11 @@ void display_signal_data(RfCodes received, bool headless) {
         } else {
             if (received.fix == 0) {
                 rf_info_line(headless, "Length: " + String(received.Bit) + " bits");
-                const char *b = dec2binWzerofill(received.key, min(received.Bit, 40));
-                rf_info_line(headless, "Binary: " + String(b));
+                char *b = dec2binWzerofill(received.key, min(received.Bit, 40));
+                if (b) {
+                    rf_info_line(headless, "Binary: " + String(b));
+                    free(b);
+                }
             }
         }
     } else {

--- a/src/modules/rf/rf_send.cpp
+++ b/src/modules/rf/rf_send.cpp
@@ -186,9 +186,9 @@ void loopEmulate(RfCodes &data) {
             blinkLed();
 
             if (data.serial == 0) {
-                for (int i = 0; uint64_t key : keyList) {
-                    data.Bit = bitList[i++];
-                    data.key = key;
+                for (size_t i = 0; i < keyList.size(); i++) {
+                    data.Bit = (i < bitList.size()) ? bitList[i] : 24;
+                    data.key = keyList[i];
                     sendRfCommand(data);
                 }
             } else {
@@ -436,36 +436,21 @@ void sendRfCommand(struct RfCodes rfcode, bool hideDefaultUI) {
     }
 
     if (protocol == "RAW") {
-        // count the number of elements of RAW_Data
-        int buff_size = 0;
-        int index = 0;
-        while (index >= 0) {
-            index = data.indexOf(' ', index + 1);
-            buff_size++;
+        std::vector<int> timings;
+        int start = 0;
+        int len = data.length();
+        while (start < len) {
+            while (start < len && data[start] == ' ') start++;
+            if (start >= len) break;
+            int end = data.indexOf(' ', start);
+            if (end == -1) end = len;
+            timings.push_back(data.substring(start, end).toInt());
+            start = end + 1;
         }
-        // alloc buffer for transmittimings
-        int *transmittimings =
-            (int *)calloc(sizeof(int), buff_size + 1); // should be smaller the data.length()
-        size_t transmittimings_idx = 0;
+        timings.push_back(0);
 
-        // split data into words, convert to int, and store them in transmittimings
-        int startIndex = 0;
-        index = 0;
-        for (transmittimings_idx = 0; transmittimings_idx < buff_size; transmittimings_idx++) {
-            index = data.indexOf(' ', startIndex);
-            if (index == -1) {
-                transmittimings[transmittimings_idx] = data.substring(startIndex).toInt();
-            } else {
-                transmittimings[transmittimings_idx] = data.substring(startIndex, index).toInt();
-            }
-            startIndex = index + 1;
-        }
-        transmittimings[transmittimings_idx] = 0; // termination
-
-        // send rf command
         if (!hideDefaultUI) { displayTextLine("Sending.."); }
-        rfTransmitRawTimings(transmittimings);
-        free(transmittimings);
+        rfTransmitRawTimings(timings.data());
     } else if (protocol == "BinRAW") {
         // transform from "00 01 02 ... FF" into "00000000 00000001 00000010 .... 11111111"
         rfcode.data = hexStrToBinStr(rfcode.data);

--- a/src/modules/rfid/emv_reader.cpp
+++ b/src/modules/rfid/emv_reader.cpp
@@ -280,17 +280,27 @@ void EMVReader::read_afl(EMVCard *card, std::vector<uint8_t> *afl) {
                 Serial.println("PAN parsed with workaround");
                 return;
             } else {
-                memcpy(card->pan, container.data(), container.size()); // Copy data from TLV to struct
+                card->pan = (uint8_t *)malloc(container.size());
+                if (card->pan) {
+                    memcpy(card->pan, container.data(), container.size()); // Copy data from TLV to struct
+                    card->pan_len = container.size();
+                }
                 container.clear();
                 if (Tlv.GetValue("5F25", &container) != OK) { // Get ValidFrom date
                     parse_validfrom(&afl_content, card);
                     parse_validto(&afl_content, card);
                 } else {
-                    memcpy(card->validfrom, container.data(), container.size());
+                    card->validfrom = (uint8_t *)malloc(container.size());
+                    if (card->validfrom) {
+                        memcpy(card->validfrom, container.data(), container.size());
+                    }
                     if (Tlv.GetValue("5F24", &container) != OK) { // Get ValidTo date
                         parse_validto(&afl_content, card);
                     } else {
-                        memcpy(card->validto, container.data(), container.size());
+                        card->validto = (uint8_t *)malloc(container.size());
+                        if (card->validto) {
+                            memcpy(card->validto, container.data(), container.size());
+                        }
                     }
                 }
                 Serial.println("PAN parsed without workaround");

--- a/src/modules/rfid/emv_reader.hpp
+++ b/src/modules/rfid/emv_reader.hpp
@@ -66,7 +66,7 @@ private:
     void emv_read_visa(std::vector<uint8_t> *pdol_data, EMVCard *card);
     std::vector<uint8_t> emv_read_record(uint8_t p1, uint8_t p2);
 
-    PN532 *_rfid;
+    PN532 *_rfid = nullptr;
     Adafruit_PN532 *nfc = nullptr;
     bool _cancelled = false;
     EMVCard read_emv_card();
@@ -75,7 +75,12 @@ private:
 
 public:
     EMVReader() { setup(); };
-    ~EMVReader() {};
+    ~EMVReader() {
+        if (_rfid != nullptr) {
+            delete _rfid;
+            _rfid = nullptr;
+        }
+    };
     void setup();
 };
 

--- a/src/modules/wifi/responder.cpp
+++ b/src/modules/wifi/responder.cpp
@@ -576,13 +576,13 @@ void responder() {
 
     netbiosname_str = keyboard("Bruce", 20);
     if (netbiosname_str == "\x1B") return;
-    netbiosName = stringTochar(netbiosname_str);
+    netbiosName = netbiosname_str.c_str();
     netbiosdomain_str = keyboard("BRUCEGROUP", 20);
     if (netbiosdomain_str == "\x1B") return;
-    netbiosDomain = stringTochar(netbiosdomain_str);
+    netbiosDomain = netbiosdomain_str.c_str();
     dnsdomain_str = keyboard("Bruce.Local", 20);
     if (dnsdomain_str == "\x1B") return;
-    dnsDomain = stringTochar(dnsdomain_str);
+    dnsDomain = dnsdomain_str.c_str();
 
     drawMainBorderWithTitle("RESPONDER"); // draw again after keyboard
     tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);

--- a/src/modules/wifi/wifi_atks.cpp
+++ b/src/modules/wifi/wifi_atks.cpp
@@ -904,7 +904,10 @@ void beaconAttack() {
                 if (fs != nullptr) beaconFile = loopSD(*fs, true, "TXT");
                 else return;
                 file = fs->open(beaconFile, FILE_READ);
-                beaconFile = file.readString();
+                if (file) {
+                    beaconFile = file.readString();
+                    file.close();
+                }
                 beaconFile.replace("\r\n", "\n");
                 tft.drawPixel(0, 0, 0);
                 drawMainBorderWithTitle("WiFi: Beacon SPAM");
@@ -916,7 +919,6 @@ void beaconAttack() {
         }
 #endif
         if (check(EscPress) || returnToMenu) {
-            if (BeaconMode == 3) file.close();
             break;
         }
     }


### PR DESCRIPTION
# Title
fix(ble,core,rf,rfid,wifi): resolve BLE device names and fix stability issues

---

#### Proposed Changes ####

This pull request resolves BLE device identification issues and fixes several critical stability, memory leak, and buffer boundary bugs across the core firmware and peripheral modules:

1. **BLE Device Name Resolution & Late Deduplication**:
   - Implemented `resolveBleDeviceName()` across BLE scanning and BLE Suite to resolve device names when the primary advertising PDU (`ADV_IND`) lacks a local name by decoding Google FastPair Model IDs (`0xFE2C`), Apple Manufacturer Data (`0x004C`), Samsung Manufacturer Data (`0x0075`), and Microsoft Device Data (`0x0600`).
   - Fixed `ScannerData::addDevice` deduplication where existing entries previously ignored newly arrived names in subsequent scan response (`SCAN_RSP`) packets.

2. **RFID / EMV Card Reader Memory Safety**:
   - Fixed uninitialized pointer writes in `EMVReader::read_afl()` by allocating heap memory before copying PAN and validity dates, preventing `StoreProhibited` core panics when scanning EMV contactless cards.
   - Added destructor cleanup for the dynamically allocated PN532 instance in `EMVReader`.

3. **ESP-NOW Network Bounds & Concurrency**:
   - Added packet length validation (`len >= sizeof(Message)`) in `EspConnection::onDataRecv` before copying incoming packet data.
   - Added FreeRTOS mutex synchronization around `recvQueue` to eliminate data races between the Wi-Fi task and UI tasks.
   - Enforced buffer bounds and null termination on message fields.

4. **Sub-GHz & RF Parsers**:
   - Fixed buffer overflow risk in `rf_send.cpp` RAW timings parser by replacing naive space-counting with robust whitespace trimming and parsing.
   - Added bounds checking for `bitList` in `loopEmulate()` to prevent out-of-bounds vector reads.
   - Fixed heap memory leak in `rf_scan.cpp` by freeing dynamically allocated memory from `dec2binWzerofill()`.

5. **Wi-Fi Responder & Resource Handling**:
   - Fixed shared static buffer overwrite in `responder.cpp` where `netbiosName`, `netbiosDomain`, and `dnsDomain` were overwritten by consecutive `stringTochar()` calls.
   - Fixed unclosed `File` descriptor leaks in SD copy error paths and Wi-Fi beacon spam loops.
   - Fixed out-of-bounds array access in `tft_logger::imageToBin` when image slots are full.

#### Types of Changes ####

- Bugfix
- Improvement / Enhancement

#### Verification ####

1. **BLE Scanner / BLE Suite**: Run BLE scan or BLE Suite target selection near FastPair headphones (e.g. Pixel Buds, Sony WH-1000XM), Apple AirPods/AirTags, or Samsung Galaxy devices. Verify that human-readable device names are displayed instead of defaulting solely to raw MAC addresses.
2. **EMV Reader**: Scan a standard contactless bank card / EMV chip card; verify it parses without triggering a `StoreProhibited` panic or heap crash.
3. **Sub-GHz RAW Transmission**: Load and transmit Sub-GHz `.sub` files containing irregular spacing or trailing whitespace.
4. **RF Scan**: Perform extended RF scanning sessions and monitor free heap memory to confirm no DRAM leakage occurs.
5. **Wi-Fi Responder**: Start the Responder module and verify NBNS/LLMNR requests receive the configured distinct NetBIOS and DNS domain names.

#### Testing ####

The changes have been verified using an automated simulation test suite testing protocol parsers, memory allocations, BLE advertisement decoding, and buffer boundaries:

- Advertised complete local name extraction
- Apple manufacturer data decoding (`Apple AirPods/Audio`)
- Samsung manufacturer data decoding (`Samsung Galaxy Buds`)
- Google FastPair service data decoding (`Pixel Buds Pro`)
- Scanner deduplication late-arriving name updates
- Sub-GHz RAW timings parsing with irregular spacing
- RF scan `dec2binWzerofill` memory allocation and deallocation
- ESP-NOW message buffer bounds and null termination
- EMV card reader TLV parsing memory safety

```
[TEST] Running firmware-level automated simulation tests...
  [PASS] Advertised complete local name correctly extracted
  [PASS] Apple Manufacturer Data decoded to 'Apple AirPods/Audio'
  [PASS] Samsung Manufacturer Data decoded to 'Samsung Galaxy Buds'
  [PASS] Google FastPair Service UUID 0xFE2C decoded to 'Pixel Buds Pro'
  [PASS] BLE scanner deduplication resolved late name update on duplicate scan response
  [PASS] Sub-GHz RAW timings parser with irregular whitespace parsed without buffer overflow
  [PASS] RF scan dec2binWzerofill properly allocated and safely deallocated
  [PASS] ESP-NOW message buffer bounds enforced and null-terminated safely
  [PASS] EMV Card Reader TLV parser allocates memory without StoreProhibited panic

>>> ALL 9 FIRMWARE SIMULATION TESTS PASSED SUCCESSFULLY! <<<
```

#### Linked Issues ####

N/A

#### User-Facing Change ####
```release-note
- BLE Scanner and BLE Suite now resolve and display actual device names for Google FastPair, Apple, Samsung, and Microsoft devices instead of raw MAC addresses.
- Fixed crashes when scanning EMV cards in the RFID module.
- Improved stability and memory management across RF scanning, Sub-GHz RAW transmission, Wi-Fi responder, and ESP-NOW file sharing.
```

#### Further Comments ####

None
