### PR TITLE
fix(headless): don't block boot forever waiting for USB CDC host

### DIFF
--- a/include/VectorDisplay.h
+++ b/include/VectorDisplay.h
@@ -1256,7 +1256,13 @@ public:
 #ifndef NO_SERIAL
         if (doSerialBegin) {
             Serial.begin(speed);
-            while (!Serial);
+            // Wait for a USB CDC host (serial monitor) with a timeout instead of blocking
+            // forever. When the device is powered from a charger/wall adapter no USB host
+            // ever connects, so `while(!Serial)` kept headless boards stuck here before
+            // storage/WiFi/WebUI could start. With a PC attached the CDC link comes up
+            // well within the window, so the previous behavior is preserved.
+            uint32_t cdcWaitStart = millis();
+            while (!Serial && millis() - cdcWaitStart < 2000) delay(10);
         }
 #endif
         VectorDisplayClass::begin(width, height);


### PR DESCRIPTION
## Problem

Headless boards (e.g. `esp32-s3-devkitc-1` / ESP-General profile, no `HAS_SCREEN`) never finish booting when powered from a charger or wall adapter. They only start (WiFi at startup, WebUI startup app) the moment a serial monitor is opened on a PC. Reported in #2805 (and #2689).

## Root cause

For boards without `HAS_SCREEN`, the global `tft` object is a `tft_logger` that inherits `BRUCE_TFT_DRIVER = SerialDisplayClass` (`include/tftLogger.h`). In `setup()` the headless branch calls `tft.begin()`, which goes to:

```cpp
// include/VectorDisplay.h — SerialDisplayClass::begin()
Serial.begin(speed);
while (!Serial);   // <-- hangs forever without a USB host
```

With `ARDUINO_USB_MODE=1`, `Serial` is `HWCDC` (USB-Serial-JTAG). Its `operator bool()` (`isCDC_Connected()`) only returns `true` after a USB host has enumerated the CDC interface. On charger power no host ever appears, so the device spins in `while (!Serial)` inside `setup()` *before* `begin_storage()` / WiFi init / `startupApp` are ever reached. Opening a serial monitor enumerates the CDC device, the loop exits, and boot continues — exactly the reported symptom ("device only begins operating once the serial monitor is opened").

This is the only `while (!Serial)` blocking point in the repo (the HWCDC write/flush paths in arduino-esp32 3.3.9 are already timeout-bounded).

## Fix

Bound the wait to 2 seconds:

```cpp
uint32_t cdcWaitStart = millis();
while (!Serial && millis() - cdcWaitStart < 2000) delay(10);
```

- PC + serial monitor: the CDC link enumerates well within the window, so the previous behavior is preserved (early boot log still visible, CLI works as before).
- Standalone power (charger / power bank / wall adapter): boot proceeds after at most 2 s, so `wifiAtStartup` / `startupApp: WebUI` now work with no computer attached.

Fixes #2805
