### PR TITLE
feat(ble): add GATT Explorer, GATT Server, serial CLI, and resolve NimBLE 2.x / ESP32-S3 connection stability issues

### DIFF
--- a/boards/m5stack-cardputer/m5stack-cardputer.ini
+++ b/boards/m5stack-cardputer/m5stack-cardputer.ini
@@ -87,6 +87,16 @@ build_flags =
 	-DCC1101_MISO_PIN=SPI_MISO_PIN
 	;-DCC1101_GDO2_PIN=-1
 
+	; M5Stack Cap CC1101 (CC1101 + ST25R3916 NFC on the Cardputer-Adv Cap-Bus).
+	; Both chips share the default SPI port (SCLK=G40, MOSI=G14, MISO=G39).
+	; https://docs.m5stack.com/en/cap/Cap_CC1101
+	-DCAP_CC1101_POWER_EN=3
+	-DCAP_CC1101_SS_PIN=5
+	-DCAP_CC1101_GDO0_PIN=15
+	-DCAP_CC1101_SW0_PIN=13
+	-DCAP_NFC_SS_PIN=6
+	-DCAP_NFC_IRQ_PIN=4
+
 	; connections are the same as CC1101
 	-DUSE_NRF24_VIA_SPI
 	-DNRF24_CE_PIN=GROVE_SDA

--- a/patch_library_conflicts.py
+++ b/patch_library_conflicts.py
@@ -200,6 +200,50 @@ conflicts = [
         r'#define RFAL_NFCA_N_RETRANS         2U',
         '#define RFAL_NFCA_N_RETRANS         4U'
     ),
+    # NimBLEClient: Use standard ble_gap_connect when m_phyMask == 1M (Legacy PHY).
+    # On ESP32-S3, calling ble_gap_ext_connect for legacy peers causes the controller's
+    # Extended Link-Layer scheduler to reject the connection with 0x0D (Limited Resources).
+    (
+        ".pio/libdeps/*/NimBLE-Arduino/src/NimBLEClient.cpp",
+        r'#include "NimBLEClient\.h"',
+        '#include "NimBLEClient.h"\n#include <Arduino.h>'
+    ),
+    (
+        ".pio/libdeps/*/NimBLE-Arduino/src/NimBLEClient.cpp",
+        r'(?s)rc = ble_gap_ext_connect\(NimBLEDevice::m_ownAddrType,\s*peerAddr,\s*m_connectTimeout,\s*m_phyMask,\s*\(m_phyMask & BLE_GAP_LE_PHY_1M_MASK\) \? &m_connParams : nullptr,\s*\(m_phyMask & BLE_GAP_LE_PHY_2M_MASK\) \? &m_connParams : nullptr,\s*\(m_phyMask & BLE_GAP_LE_PHY_CODED_MASK\) \? &m_connParams : nullptr,\s*NimBLEClient::handleGapEvent,\s*this\);',
+        'if (m_phyMask == BLE_GAP_LE_PHY_1M_MASK) {\n'
+        '            rc = ble_gap_connect(NimBLEDevice::m_ownAddrType,\n'
+        '                                 peerAddr,\n'
+        '                                 m_connectTimeout,\n'
+        '                                 &m_connParams,\n'
+        '                                 NimBLEClient::handleGapEvent,\n'
+        '                                 this);\n'
+        '            Serial.printf("[NIMBLE-RAW] ble_gap_connect called -> rc=%d\\n", rc);\n'
+        '        } else {\n'
+        '            rc = ble_gap_ext_connect(NimBLEDevice::m_ownAddrType,\n'
+        '                                     peerAddr,\n'
+        '                                     m_connectTimeout,\n'
+        '                                     m_phyMask,\n'
+        '                                     (m_phyMask & BLE_GAP_LE_PHY_1M_MASK) ? &m_connParams : nullptr,\n'
+        '                                     (m_phyMask & BLE_GAP_LE_PHY_2M_MASK) ? &m_connParams : nullptr,\n'
+        '                                     (m_phyMask & BLE_GAP_LE_PHY_CODED_MASK) ? &m_connParams : nullptr,\n'
+        '                                     NimBLEClient::handleGapEvent,\n'
+        '                                     this);\n'
+        '            Serial.printf("[NIMBLE-RAW] ble_gap_ext_connect called -> rc=%d\\n", rc);\n'
+        '        }'
+    ),
+    # NimBLEClient: Zero min_ce_len / max_ce_len by default. Standard non-zero defaults (10ms-480ms)
+    # cause controllers to reject connections with 0x0D when they cannot guarantee 10ms uninterruptible CE.
+    (
+        ".pio/libdeps/*/NimBLE-Arduino/src/NimBLEClient.cpp",
+        r'BLE_GAP_INITIAL_CONN_MIN_CE_LEN,\s*BLE_GAP_INITIAL_CONN_MAX_CE_LEN',
+        '0, 0'
+    ),
+    (
+        ".pio/libdeps/*/NimBLE-Arduino/src/NimBLEClient.cpp",
+        r'm_connParams\.scan_window\s*=\s*scanWindow;\s*}',
+        'm_connParams.scan_window         = scanWindow;\n    m_connParams.min_ce_len          = 0;\n    m_connParams.max_ce_len          = 0;\n}'
+    ),
 ]
 
 for file_pattern, search, replace in conflicts:

--- a/src/core/menu_items/BleMenu.cpp
+++ b/src/core/menu_items/BleMenu.cpp
@@ -7,6 +7,8 @@
 #include "modules/ble/ble_spam.h"
 #if !defined(LITE_VERSION)
 #include "modules/ble/BLE_Suite.h"
+#include "modules/ble/gatt_explorer.h"
+#include "modules/ble/gatt_server.h"
 #else
 #include "modules/ble/ble_sniffer.h"
 #endif
@@ -27,6 +29,8 @@ void BleMenu::optionsMenu() {
 #if !defined(LITE_VERSION)
     options.push_back({"Media Cmds", [=]() { MediaCommands(hid_ble, true); }});
     options.push_back({"BLE Scan", ble_scan});
+    options.push_back({"GATT Explorer", gattExplorerMenu});
+    options.push_back({"GATT Server", gattServerMenu});
     options.push_back({"iBeacon", [=]() {
                            ibeacon("Bruce", "e4c159a0-8c82-11e6-bdf4-0800200c9a66", 0x004C);
                        }});

--- a/src/core/serial_commands/ble_commands.cpp
+++ b/src/core/serial_commands/ble_commands.cpp
@@ -1,0 +1,83 @@
+#include "ble_commands.h"
+#include "modules/ble/gatt_server.h"
+#include "modules/ble/gatt_explorer.h"
+#include <globals.h>
+
+#if !defined(LITE_VERSION)
+
+static uint32_t bleCallback(cmd *c) {
+    Command cmd(c);
+    Argument actionArg = cmd.getArgument("action");
+    String action = actionArg.getValue();
+    action.trim();
+    action.toLowerCase();
+
+    Argument param1Arg = cmd.getArgument("param1");
+    String param1 = param1Arg.getValue();
+    param1.trim();
+
+    Argument param2Arg = cmd.getArgument("param2");
+    String param2 = param2Arg.getValue();
+    param2.trim();
+
+    if (action == "server") {
+        if (param1 == "stop") {
+            stopGattServerService();
+            serialDevice->println("GATT Server stopped.");
+            return true;
+        } else if (param1 == "start" || param1 == "on" || param1 == "") {
+            int profile = param2.toInt();
+            if (profile < 0 || profile > 3) profile = 0;
+            if (startGattServerService(profile)) {
+                serialDevice->println("GATT Server started in profile " + String(profile));
+                return true;
+            } else {
+                serialDevice->println("Failed to start GATT Server.");
+                return false;
+            }
+        } else if (param1 == "status") {
+            serialDevice->println(String("GATT Server status: ") + (isGattServerActive() ? "RUNNING" : "STOPPED"));
+            return true;
+        }
+    } else if (action == "connect") {
+        if (param1 == "") {
+            serialDevice->println("Usage: ble connect <MAC> [pub|rnd]");
+            return false;
+        }
+        uint8_t addrType = 0; // BLE_ADDR_PUBLIC
+        if (param2.equalsIgnoreCase("rnd") || param2.equalsIgnoreCase("random") || param2 == "1") {
+            addrType = 1; // BLE_ADDR_RANDOM
+        }
+        bool ok = gattConnectCli(param1, addrType);
+        return ok;
+    } else if (action == "scan") {
+        int timeoutSec = param1.toInt();
+        if (timeoutSec <= 0) timeoutSec = 5;
+        gattScanCli(timeoutSec);
+        return true;
+    }
+
+    serialDevice->println(
+        "Invalid ble command.\n"
+        "Usage:\n"
+        "  ble server start [0-3]   (0=All-in-One, 1=DIS+Bat, 2=Echo, 3=NUS)\n"
+        "  ble server stop\n"
+        "  ble server status\n"
+        "  ble scan [seconds]\n"
+        "  ble connect <MAC> [pub|rnd]"
+    );
+    return false;
+}
+
+void createBleCommands(SimpleCLI *cli) {
+    Command bleCmd = cli->addCommand("ble", bleCallback);
+    bleCmd.addPosArg("action", "");
+    bleCmd.addPosArg("param1", "");
+    bleCmd.addPosArg("param2", "");
+}
+
+#else
+
+void createBleCommands(SimpleCLI *cli) {}
+
+#endif // !LITE_VERSION

--- a/src/core/serial_commands/ble_commands.h
+++ b/src/core/serial_commands/ble_commands.h
@@ -1,0 +1,8 @@
+#ifndef BLE_COMMANDS_H
+#define BLE_COMMANDS_H
+
+#include <SimpleCLI.h>
+
+void createBleCommands(SimpleCLI *cli);
+
+#endif // BLE_COMMANDS_H

--- a/src/core/serial_commands/cli.cpp
+++ b/src/core/serial_commands/cli.cpp
@@ -1,5 +1,6 @@
 #include "cli.h"
 #include "badusb_commands.h"
+#include "ble_commands.h"
 #include "core/sd_functions.h"
 #include "crypto_commands.h"
 #include "gpio_commands.h"
@@ -45,6 +46,7 @@ void SerialCli::setup() {
     createStorageCommands(&_cli);
     createUtilCommands(&_cli);
     createWifiCommands(&_cli);
+    createBleCommands(&_cli);
 
 #ifdef USB_as_HID
     createBadUsbCommands(&_cli);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -651,6 +651,9 @@ void setRFModuleMenu() {
 #if defined(ARDUINO_M5STICK_C_PLUS) || defined(ARDUINO_M5STICK_C_PLUS2)
         if (bruceConfigPins.CC1101_bus.mosi == GPIO_NUM_26) idx = 2;
 #endif
+#ifdef CAP_CC1101_SS_PIN
+        if (bruceConfigPins.CC1101_bus.cs == (gpio_num_t)CAP_CC1101_SS_PIN) idx = 2;
+#endif
     }
 
     options = {
@@ -660,6 +663,9 @@ void setRFModuleMenu() {
         {"CC1101 (Shared SPI)", [&pins_setup]() { pins_setup = 2; }},
 #else
         {"CC1101", [&]() { result = CC1101_SPI_MODULE; }},
+#endif
+#ifdef CAP_CC1101_SS_PIN
+        {"CC1101 M5 Cap", [&pins_setup]() { pins_setup = 3; }},
 #endif
         /* WIP:
          * #ifdef USE_CC1101_VIA_PCA9554
@@ -709,6 +715,27 @@ void setRFModuleMenu() {
             );
 #endif
         }
+#ifdef CAP_CC1101_SS_PIN
+        else if (pins_setup == 3) {
+            // M5Stack Cap CC1101: shares the default SPI port with the SD card and the cap's
+            // own ST25R3916. https://docs.m5stack.com/en/cap/Cap_CC1101
+            result = CC1101_SPI_MODULE;
+            bruceConfigPins.setCC1101Pins(
+                {(gpio_num_t)SPI_SCK_PIN,
+                 (gpio_num_t)SPI_MISO_PIN,
+                 (gpio_num_t)SPI_MOSI_PIN,
+                 (gpio_num_t)CAP_CC1101_SS_PIN,
+                 (gpio_num_t)CAP_CC1101_GDO0_PIN,
+                 GPIO_NUM_NC}
+            );
+        }
+#endif
+        // initRfModule() dispatches on rfModule, so the pin presets have to already say CC1101 or
+        // it takes the single-pin path and reports success without ever probing the chip - which
+        // is the whole point of the "not found" + wiring QR below. Left alone for the plain
+        // "CC1101" entry, which is still selectable blind so the pins can be set afterwards.
+        // Not saved yet: the error path below falls back to M5_RF_MODULE and saves that instead.
+        if (pins_setup > 0) bruceConfigPins.rfModule = CC1101_SPI_MODULE;
         if (initRfModule()) {
             bruceConfigPins.setRfModule(CC1101_SPI_MODULE);
             deinitRfModule();
@@ -784,6 +811,24 @@ void setRFIDModuleMenu() {
         {"ST25R3916 I2C",
          [=]() { bruceConfigPins.setRfidModule(ST25R3916_I2C_MODULE); },
          bruceConfigPins.rfidModule == ST25R3916_I2C_MODULE},
+#ifdef CAP_NFC_SS_PIN
+        // M5Stack Cap CC1101: its NFC half is an ST25R3916 on the default SPI port.
+        // https://docs.m5stack.com/en/cap/Cap_CC1101
+        {"CC1101 M5 Cap",
+         [=]() {
+             bruceConfigPins.setSR25RPins(
+                 {(gpio_num_t)SPI_SCK_PIN,
+                  (gpio_num_t)SPI_MISO_PIN,
+                  (gpio_num_t)SPI_MOSI_PIN,
+                  (gpio_num_t)CAP_NFC_SS_PIN,
+                  (gpio_num_t)CAP_NFC_IRQ_PIN,
+                  GPIO_NUM_NC}
+             );
+             bruceConfigPins.setRfidModule(ST25R3916_SPI_MODULE);
+         },
+         bruceConfigPins.rfidModule == ST25R3916_SPI_MODULE &&
+             bruceConfigPins.ST25R_bus.cs == (gpio_num_t)CAP_NFC_SS_PIN},
+#endif
 #endif
     };
     loopOptions(options, bruceConfigPins.rfidModule);

--- a/src/modules/ble/BLE_Suite.cpp
+++ b/src/modules/ble/BLE_Suite.cpp
@@ -13,6 +13,7 @@
 #if !defined(LITE_VERSION)
 #include "BLE_Suite.h"
 #include "HFP_Exploit.h"
+#include "gatt_explorer.h"
 #include "ble_common.h"
 #include "core/display.h"
 #include "core/mykeyboard.h"
@@ -48,6 +49,48 @@ static bool g_bleScanActive = false;
 
 // Device selection cache
 static SelectedDevice g_selectedDevice;
+
+int g_lastBleError = 0;
+int g_lastBleDisconnectReason = 0;
+
+String getBleErrorDescription(int reason) {
+    if (reason == 0) return "OK";
+    const char *str = NimBLEUtils::returnCodeToString(reason);
+    if (str && strlen(str) > 0 && strcmp(str, "Unknown") != 0) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "0x%02X: %s", reason, str);
+        return String(buf);
+    }
+    char buf[32];
+    snprintf(buf, sizeof(buf), "0x%02X (%d)", reason, reason);
+    return String(buf);
+}
+
+class SuiteClientCallbacks : public NimBLEClientCallbacks {
+public:
+    void onConnect(NimBLEClient *pClient) override {
+        Serial.printf("[BLE Suite] >>> Connection ESTABLISHED: peer=%s, handle=%d, MTU=%d <<<\n",
+                      pClient->getPeerAddress().toString().c_str(),
+                      pClient->getConnHandle(),
+                      pClient->getMTU());
+    }
+
+    void onConnectFail(NimBLEClient *pClient, int reason) override {
+        g_lastBleError = reason;
+        String desc = getBleErrorDescription(reason);
+        Serial.printf("[BLE Suite] >>> Connection FAILED: 0x%02X (%d) -> %s, peer=%s <<<\n",
+                      reason, reason, desc.c_str(), pClient->getPeerAddress().toString().c_str());
+    }
+
+    void onDisconnect(NimBLEClient *pClient, int reason) override {
+        g_lastBleDisconnectReason = reason;
+        if (g_lastBleError == 0) g_lastBleError = reason;
+        String desc = getBleErrorDescription(reason);
+        Serial.printf("[BLE Suite] >>> Disconnected: 0x%02X (%d) -> %s, peer=%s <<<\n",
+                      reason, reason, desc.c_str(), pClient->getPeerAddress().toString().c_str());
+    }
+};
+static SuiteClientCallbacks g_suiteCallbacks;
 
 //=============================================================================
 // Cleanup Function - Only stops scan, doesn't clear data
@@ -108,7 +151,7 @@ ScannerData::~ScannerData() {
 }
 
 void ScannerData::addDevice(
-    const String &name, const String &address, int rssi, bool fastPair, bool hasHFP, uint8_t type
+    const String &name, const String &address, int rssi, bool fastPair, bool hasHFP, uint8_t type, uint8_t addrType
 ) {
     if (xSemaphoreTake(mutex, 10 / portTICK_PERIOD_MS)) {
         bool isDuplicate = false;
@@ -120,18 +163,48 @@ void ScannerData::addDevice(
             }
         }
         if (!isDuplicate) {
-            deviceNames.push_back(name);
-            deviceAddresses.push_back(address);
-            deviceRssi.push_back(rssi);
-            deviceFastPair.push_back(fastPair);
-            deviceHasHFP.push_back(hasHFP);
-            deviceTypes.push_back(type);
-            foundCount++;
-            dataVersion++;
+            static const size_t MAX_SCANNER_DEVICES = 50;
+            if (deviceAddresses.size() >= MAX_SCANNER_DEVICES) {
+                // Priority Queue (Max RSSI): Find device with lowest RSSI
+                size_t minIdx = 0;
+                int minRssi = deviceRssi[0];
+                for (size_t i = 1; i < deviceRssi.size(); i++) {
+                    if (deviceRssi[i] < minRssi) {
+                        minRssi = deviceRssi[i];
+                        minIdx = i;
+                    }
+                }
+                if (rssi > minRssi) {
+                    deviceNames[minIdx] = name;
+                    deviceAddresses[minIdx] = address;
+                    deviceAddressTypes[minIdx] = addrType;
+                    deviceRssi[minIdx] = rssi;
+                    deviceFastPair[minIdx] = fastPair;
+                    deviceHasHFP[minIdx] = hasHFP;
+                    deviceTypes[minIdx] = type;
+                    foundCount++;
+                    dataVersion++;
 
-            if (snapshotCache) {
-                delete snapshotCache;
-                snapshotCache = nullptr;
+                    if (snapshotCache) {
+                        delete snapshotCache;
+                        snapshotCache = nullptr;
+                    }
+                }
+            } else {
+                deviceNames.push_back(name);
+                deviceAddresses.push_back(address);
+                deviceAddressTypes.push_back(addrType);
+                deviceRssi.push_back(rssi);
+                deviceFastPair.push_back(fastPair);
+                deviceHasHFP.push_back(hasHFP);
+                deviceTypes.push_back(type);
+                foundCount++;
+                dataVersion++;
+
+                if (snapshotCache) {
+                    delete snapshotCache;
+                    snapshotCache = nullptr;
+                }
             }
         }
         xSemaphoreGive(mutex);
@@ -153,6 +226,7 @@ DeviceSnapshot *ScannerData::getSnapshot() {
         snapshotCache->timestamp = millis();
         snapshotCache->names = deviceNames;
         snapshotCache->addresses = deviceAddresses;
+        snapshotCache->addressTypes = deviceAddressTypes;
         snapshotCache->rssi = deviceRssi;
         snapshotCache->fastPair = deviceFastPair;
         snapshotCache->hfp = deviceHasHFP;
@@ -170,6 +244,7 @@ bool ScannerData::getDeviceInfo(int index, DeviceInfo &info) {
     if (xSemaphoreTake(mutex, 10 / portTICK_PERIOD_MS)) {
         if (index >= 0 && index < (int)deviceAddresses.size()) {
             info.address = deviceAddresses[index];
+            info.addressType = (index < (int)deviceAddressTypes.size()) ? deviceAddressTypes[index] : BLE_ADDR_PUBLIC;
             info.name = deviceNames[index];
             info.rssi = deviceRssi[index];
             info.hasFastPair = deviceFastPair[index];
@@ -186,6 +261,7 @@ void ScannerData::clear() {
     if (xSemaphoreTake(mutex, 50 / portTICK_PERIOD_MS)) {
         deviceNames.clear();
         deviceAddresses.clear();
+        deviceAddressTypes.clear();
         deviceRssi.clear();
         deviceFastPair.clear();
         deviceHasHFP.clear();
@@ -305,9 +381,18 @@ bool BLEStateManager::initBLE(const String &name, int powerLevel) {
         return false;
     }
 
+    if (bleInitialized) {
+        NimBLEDevice::setPower((esp_power_level_t)powerLevel);
+        NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+        NimBLEDevice::setSecurityAuth(false, false, false);
+        return true;
+    }
+
     std::string nameStr = name.c_str();
     NimBLEDevice::init(nameStr);
     NimBLEDevice::setPower((esp_power_level_t)powerLevel);
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+    NimBLEDevice::setSecurityAuth(false, false, false);
 
     currentDeviceName = name;
     bleInitialized = true;
@@ -317,6 +402,7 @@ bool BLEStateManager::initBLE(const String &name, int powerLevel) {
 void BLEStateManager::deinitBLE(bool immediate) {
     if (!bleInitialized) return;
     if (immediate) cleanupAllClients();
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
     NimBLEDevice::deinit(true);
     bleInitialized = false;
     currentDeviceName = "";
@@ -356,15 +442,16 @@ size_t BLEStateManager::getActiveClientCount() { return activeClients.size(); }
 // BLE Attack Manager
 //=============================================================================
 
-void BLEAttackManager::prepareForConnection() {
+void BLEAttackManager::prepareForConnection(bool enableAuth) {
     if (BLEStateManager::isBLEActive()) {
         BLEStateManager::deinitBLE();
         delay(300);
     }
 
     BLEStateManager::initBLE("Bruce-Attack", ESP_PWR_LVL_P9);
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
     NimBLEDevice::setMTU(250);
-    NimBLEDevice::setSecurityAuth(true, true, true);
+    NimBLEDevice::setSecurityAuth(enableAuth, enableAuth, enableAuth);
     delay(300);
 }
 
@@ -374,26 +461,58 @@ void BLEAttackManager::cleanupAfterAttack() {
 }
 
 bool BLEAttackManager::connectToDevice(
-    NimBLEAddress target, NimBLEClient **outClient, bool useExploitHandshake
+    NimBLEAddress target, NimBLEClient **outClient, bool useExploitHandshake, int *outError
 ) {
-    NimBLEClient *pClient = NimBLEDevice::createClient();
-    if (!pClient) return false;
+    g_lastBleError = 0;
+    g_lastBleDisconnectReason = 0;
 
+    NimBLEClient *pClient = NimBLEDevice::createClient();
+    if (!pClient) {
+        if (outError) *outError = 0x107;
+        return false;
+    }
+
+#if CONFIG_BT_NIMBLE_EXT_ADV
+    pClient->setConnectPhy(BLE_GAP_LE_PHY_1M_MASK);
+#endif
+
+    NimBLEClient::Config cfg = pClient->getConfig();
+    cfg.exchangeMTU = 0; // Decouple immediate ATT MTU exchange
+    pClient->setConfig(cfg);
+
+    pClient->setClientCallbacks(&g_suiteCallbacks, false);
     BLEStateManager::registerClient(pClient);
 
     if (useExploitHandshake) {
-        pClient->setConnectTimeout(12);
+        pClient->setConnectTimeout(12 * 1000);
         pClient->setConnectionParams(6, 6, 0, 100);
     } else {
-        pClient->setConnectTimeout(8);
-        pClient->setConnectionParams(12, 12, 0, 400);
+        pClient->setConnectTimeout(8 * 1000);
     }
 
-    bool connected = pClient->connect(target, false);
+    Serial.printf("[BLE Suite] Connecting to target %s (%s)...\n",
+                  target.toString().c_str(),
+                  (target.getType() == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM");
+
+    bool connected = pClient->connect(target, true, false, false);
+    if (!connected) {
+        // Fallback with flipped address type
+        uint8_t fallbackType = (target.getType() == BLE_ADDR_PUBLIC) ? BLE_ADDR_RANDOM : BLE_ADDR_PUBLIC;
+        ble_addr_t flipped = *target.getBase();
+        flipped.type = fallbackType;
+        NimBLEAddress fallbackTarget(flipped);
+        connected = pClient->connect(fallbackTarget, true, false, false);
+    }
+
     if (connected) {
         *outClient = pClient;
         return true;
     }
+
+    int err = pClient->getLastError();
+    if (err == 0 && g_lastBleDisconnectReason != 0) err = g_lastBleDisconnectReason;
+    if (err != 0) g_lastBleError = err;
+    if (outError) *outError = g_lastBleError;
 
     BLEStateManager::unregisterClient(pClient);
     NimBLEDevice::deleteClient(pClient);
@@ -405,15 +524,20 @@ DeviceProfile BLEAttackManager::profileDevice(NimBLEAddress target) {
     std::string addressStr = target.toString();
     profile.address = String(addressStr.c_str());
     profile.connected = false;
+    profile.errorCode = 0;
+    profile.errorReason = "";
     profile.hasFastPair = false;
     profile.hasAVRCP = false;
     profile.hasHID = false;
     profile.hasBattery = false;
     profile.hasDeviceInfo = false;
 
-    prepareForConnection();
+    prepareForConnection(false);
     NimBLEClient *pClient = nullptr;
-    if (!connectToDevice(target, &pClient, false)) {
+    int err = 0;
+    if (!connectToDevice(target, &pClient, false, &err)) {
+        profile.errorCode = err;
+        profile.errorReason = getBleErrorDescription(err);
         cleanupAfterAttack();
         return profile;
     }
@@ -443,6 +567,15 @@ DeviceProfile BLEAttackManager::profileDevice(NimBLEAddress target) {
                 profile.characteristics.push_back(charInfo);
             }
         }
+    } else {
+        int dErr = pClient->getLastError();
+        if (dErr != 0) {
+            profile.errorCode = dErr;
+            profile.errorReason = getBleErrorDescription(dErr);
+        } else if (g_lastBleDisconnectReason != 0) {
+            profile.errorCode = g_lastBleDisconnectReason;
+            profile.errorReason = getBleErrorDescription(g_lastBleDisconnectReason);
+        }
     }
 
     pClient->disconnect();
@@ -458,29 +591,37 @@ DeviceProfile BLEAttackManager::profileDevice(NimBLEAddress target) {
 
 NimBLEClient *attemptConnectionWithStrategies(NimBLEAddress target, String &connectionMethod) {
     NimBLEClient *pClient = nullptr;
+    g_lastBleError = 0;
+    g_lastBleDisconnectReason = 0;
+
     showAttackProgress("Trying normal connection...", TFT_WHITE);
 
     BLEAttackManager bleManager;
-    bleManager.prepareForConnection();
-    if (bleManager.connectToDevice(target, &pClient, false)) {
+    bleManager.prepareForConnection(false);
+    int err = 0;
+    if (bleManager.connectToDevice(target, &pClient, false, &err)) {
         connectionMethod = "Normal connection";
         return pClient;
     }
+    if (err != 0) g_lastBleError = err;
     bleManager.cleanupAfterAttack();
 
     delay(500);
     showAttackProgress("Trying aggressive connection...", TFT_YELLOW);
-    bleManager.prepareForConnection();
+    bleManager.prepareForConnection(false);
     NimBLEDevice::setPower(ESP_PWR_LVL_P9);
     pClient = NimBLEDevice::createClient();
     if (pClient) {
+        pClient->setClientCallbacks(&g_suiteCallbacks, false);
         BLEStateManager::registerClient(pClient);
-        pClient->setConnectTimeout(12);
+        pClient->setConnectTimeout(12 * 1000);
         pClient->setConnectionParams(6, 6, 0, 100);
         if (pClient->connect(target, false)) {
             connectionMethod = "Aggressive connection";
             return pClient;
         }
+        int e = pClient->getLastError();
+        if (e != 0) g_lastBleError = e;
         BLEStateManager::unregisterClient(pClient);
         NimBLEDevice::deleteClient(pClient);
     }
@@ -498,14 +639,17 @@ NimBLEClient *attemptConnectionWithStrategies(NimBLEAddress target, String &conn
 
     pClient = NimBLEDevice::createClient();
     if (pClient) {
+        pClient->setClientCallbacks(&g_suiteCallbacks, false);
         BLEStateManager::registerClient(pClient);
-        pClient->setConnectTimeout(15);
+        pClient->setConnectTimeout(15 * 1000);
         pClient->setConnectionParams(12, 12, 0, 400);
         for (int attempt = 0; attempt < 3; attempt++) {
             if (pClient->connect(target, false)) {
                 connectionMethod = "Exploit-based connection";
                 return pClient;
             }
+            int e = pClient->getLastError();
+            if (e != 0) g_lastBleError = e;
             delay(300);
         }
         BLEStateManager::unregisterClient(pClient);
@@ -527,14 +671,17 @@ NimBLEClient *attemptConnectionWithStrategies(NimBLEAddress target, String &conn
         showAttackProgress("Trying HFP exploit connection...", TFT_CYAN);
         HFPExploitEngine hfp;
         if (hfp.establishHFPConnection(target)) {
-            NimBLEClient *pClient = NimBLEDevice::createClient();
+            pClient = NimBLEDevice::createClient();
             if (pClient) {
+                pClient->setClientCallbacks(&g_suiteCallbacks, false);
                 BLEStateManager::registerClient(pClient);
-                pClient->setConnectTimeout(8);
+                pClient->setConnectTimeout(8 * 1000);
                 if (pClient->connect(target, false)) {
                     connectionMethod = "HFP Exploit connection";
                     return pClient;
                 }
+                int e = pClient->getLastError();
+                if (e != 0) g_lastBleError = e;
                 BLEStateManager::unregisterClient(pClient);
                 NimBLEDevice::deleteClient(pClient);
             }
@@ -648,7 +795,7 @@ bool HIDExploitEngine::tryAppleMagicSpoof(NimBLEAddress target, HIDDeviceProfile
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(6);
+    pClient->setConnectTimeout(6 * 1000);
     pClient->setConnectionParams(12, 12, 0, 400);
     bool connected = pClient->connect(target, false);
 
@@ -682,7 +829,7 @@ bool HIDExploitEngine::tryWindowsHIDBypass(NimBLEAddress target, HIDDeviceProfil
         if (pClient) {
             BLEStateManager::registerClient(pClient);
 
-            pClient->setConnectTimeout(4);
+            pClient->setConnectTimeout(8 * 1000);
 
             if (attempt == 0) pClient->setConnectionParams(6, 6, 0, 100);
             else if (attempt == 1) pClient->setConnectionParams(200, 200, 0, 600);
@@ -722,7 +869,7 @@ bool HIDExploitEngine::tryAndroidJustWorks(NimBLEAddress target, HIDDeviceProfil
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(8);
+    pClient->setConnectTimeout(8 * 1000);
     pClient->setConnectionParams(12, 12, 0, 400);
     bool connected = pClient->connect(target, true);
 
@@ -755,7 +902,7 @@ bool HIDExploitEngine::tryBootProtocolInjection(NimBLEAddress target, HIDDeviceP
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(5);
+    pClient->setConnectTimeout(8 * 1000);
     pClient->setConnectionParams(6, 6, 0, 100);
     bool connected = pClient->connect(target, false);
 
@@ -801,7 +948,7 @@ bool HIDExploitEngine::tryRapidStateConfusion(NimBLEAddress target, HIDDevicePro
         if (pClient) {
             BLEStateManager::registerClient(pClient);
 
-            pClient->setConnectTimeout(1);
+            pClient->setConnectTimeout(4 * 1000);
             pClient->setConnectionParams(6, 6, 0, 100);
             bool connected = pClient->connect(target, false);
 
@@ -847,7 +994,7 @@ bool HIDExploitEngine::tryHIDReportPreconnection(NimBLEAddress target, HIDDevice
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(6);
+    pClient->setConnectTimeout(8 * 1000);
     bool connected = pClient->connect(target, false);
 
     if (connected) {
@@ -889,7 +1036,7 @@ bool HIDExploitEngine::tryConnectionParameterAttack(NimBLEAddress target, HIDDev
         if (pClient) {
             BLEStateManager::registerClient(pClient);
 
-            pClient->setConnectTimeout(4);
+            pClient->setConnectTimeout(8 * 1000);
             pClient->setConnectionParams(paramSets[i][0], paramSets[i][1], paramSets[i][2], paramSets[i][3]);
 
             bool connected = pClient->connect(target, false);
@@ -933,7 +1080,7 @@ bool HIDExploitEngine::trySecurityModeBypass(NimBLEAddress target, HIDDeviceProf
         NimBLEClient *pClient = NimBLEDevice::createClient();
         if (pClient) {
             BLEStateManager::registerClient(pClient);
-            pClient->setConnectTimeout(6);
+            pClient->setConnectTimeout(8 * 1000);
             bool connected = pClient->connect(target, true);
             if (connected) {
                 showAttackProgress("Security bypass successful!", TFT_GREEN);
@@ -967,7 +1114,7 @@ bool HIDExploitEngine::tryAddressSpoofingAttack(NimBLEAddress target, HIDDeviceP
         NimBLEClient *pClient = NimBLEDevice::createClient();
         if (pClient) {
             BLEStateManager::registerClient(pClient);
-            pClient->setConnectTimeout(5);
+            pClient->setConnectTimeout(8 * 1000);
             bool connected = pClient->connect(target, false);
             if (connected) {
                 showAttackProgress("Address spoofing worked!", TFT_GREEN);
@@ -999,7 +1146,7 @@ bool HIDExploitEngine::tryServiceDiscoveryHijack(NimBLEAddress target, HIDDevice
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(8);
+    pClient->setConnectTimeout(8 * 1000);
     bool connected = pClient->connect(target, false);
 
     if (connected) {
@@ -2265,7 +2412,7 @@ bool AuthBypassEngine::attemptSpoofConnection(NimBLEAddress target, const String
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(8);
+    pClient->setConnectTimeout(8 * 1000);
     pClient->setConnectionParams(12, 12, 0, 400);
     bool connected = pClient->connect(target, true);
 
@@ -2297,7 +2444,7 @@ bool AuthBypassEngine::forceRepairing(NimBLEAddress target) {
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(10);
+    pClient->setConnectTimeout(10 * 1000);
     bool connected = pClient->connect(target, false);
 
     if (connected) {
@@ -2329,7 +2476,7 @@ bool AuthBypassEngine::exploitAuthBypass(NimBLEAddress target) {
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(8);
+    pClient->setConnectTimeout(8 * 1000);
     bool connected = pClient->connect(target, true);
 
     if (connected) {
@@ -2354,7 +2501,7 @@ bool AuthBypassEngine::exploitAuthBypass(NimBLEAddress target) {
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(10);
+    pClient->setConnectTimeout(10 * 1000);
     connected = pClient->connect(target, true);
 
     if (connected) {
@@ -2389,7 +2536,7 @@ bool MultiConnectionAttack::connectionFloodSingle(NimBLEAddress target, int time
 
     BLEStateManager::registerClient(pClient);
 
-    pClient->setConnectTimeout(timeout);
+    pClient->setConnectTimeout(timeout * 1000);
     bool connected = pClient->connect(target, false);
 
     if (connected) {
@@ -2852,7 +2999,7 @@ bool PairingAttackServiceClass::bruteForcePIN(NimBLEAddress target) {
         NimBLEClient *pClient = NimBLEDevice::createClient();
         if (pClient) {
             BLEStateManager::registerClient(pClient);
-            pClient->setConnectTimeout(5);
+            pClient->setConnectTimeout(8 * 1000);
             if (pClient->connect(target, true)) {
                 showAttackProgress(String("Connected with PIN: " + String(commonPins[i])).c_str(), TFT_GREEN);
                 success = true;
@@ -2908,7 +3055,7 @@ bool DoSAttackServiceClass::connectionFlood(NimBLEAddress target) {
         NimBLEClient *pClient = NimBLEDevice::createClient();
         if (pClient) {
             BLEStateManager::registerClient(pClient);
-            pClient->setConnectTimeout(2);
+            pClient->setConnectTimeout(4 * 1000);
             bool connected = pClient->connect(target, false);
             if (connected) anySuccess = true;
             BLEStateManager::unregisterClient(pClient);
@@ -4161,15 +4308,15 @@ void BLE_Sniffer() {
 // Target Selection Functions
 //=============================================================================
 
-String selectTargetFromScan(const char *title) {
+bool performBleScan(const char *title) {
     // Simple memory check - if heap is low, warn but continue
     if (heap_caps_get_free_size(MALLOC_CAP_DEFAULT) < 10000) {
         displayError("Low memory, scan may be unstable", true);
         // Don't return - let the user decide
     }
 
-    // DO NOT clear scannerData here - it persists between operations
     g_selectedDevice.address = "";
+    g_selectedDevice.addressType = BLE_ADDR_PUBLIC;
     g_selectedDevice.name = "";
 
     bool bleWasActiveBefore = BLEConnected || (BLEDevice::getServer() != nullptr);
@@ -4181,14 +4328,14 @@ String selectTargetFromScan(const char *title) {
     // FIX: Always call initBLE - it handles the case where stack was deinit'd
     if (!BLEStateManager::initBLE("Bruce-Scanner", ESP_PWR_LVL_P9)) {
         displayError("Failed to init BLE");
-        return "";
+        return false;
     }
 
     if (g_pBLEScan == nullptr) {
         g_pBLEScan = NimBLEDevice::getScan();
         if (!g_pBLEScan) {
             displayError("Failed to get scanner");
-            return "";
+            return false;
         }
         g_pBLEScan->setActiveScan(true);
         g_pBLEScan->setInterval(SCAN_INT);
@@ -4198,6 +4345,7 @@ String selectTargetFromScan(const char *title) {
 
     // Clear previous results before scanning
     g_pBLEScan->clearResults();
+    scannerData.clear();
 
     BleUiGeom sg = bleUiGeom();
     drawMainBorderWithTitle(title);
@@ -4225,6 +4373,7 @@ String selectTargetFromScan(const char *title) {
             if (!device) continue;
 
             String address = String(device->getAddress().toString().c_str());
+            uint8_t addressType = device->getAddress().getType();
             String name = String(device->getName().c_str());
             if (name.isEmpty() || name == "(null)" || name == "null" || name == "NULL") {
                 // name = "Unknown";
@@ -4247,7 +4396,7 @@ String selectTargetFromScan(const char *title) {
                 if (uuidStr.find("1812") != std::string::npos) deviceType |= 0x02;
             }
 
-            scannerData.addDevice(name, address, rssi, fastPair, hasHFP, deviceType);
+            scannerData.addDevice(name, address, rssi, fastPair, hasHFP, deviceType, addressType);
         }
 
         // === PASSIVE SCAN ===
@@ -4264,6 +4413,7 @@ String selectTargetFromScan(const char *title) {
             if (!device) continue;
 
             String address = String(device->getAddress().toString().c_str());
+            uint8_t addressType = device->getAddress().getType();
             String name = String(device->getName().c_str());
             if (name.isEmpty() || name == "(null)" || name == "null" || name == "NULL") {
                 // name = "Unknown";
@@ -4286,12 +4436,12 @@ String selectTargetFromScan(const char *title) {
                 if (uuidStr.find("1812") != std::string::npos) deviceType |= 0x02;
             }
 
-            scannerData.addDevice(name, address, rssi, fastPair, hasHFP, deviceType);
+            scannerData.addDevice(name, address, rssi, fastPair, hasHFP, deviceType, addressType);
         }
     } catch (...) {
         displayError("BLE scan error");
         if (g_pBLEScan) { g_pBLEScan->clearResults(); }
-        return "";
+        return false;
     }
 
     if (g_pBLEScan) {
@@ -4301,11 +4451,9 @@ String selectTargetFromScan(const char *title) {
 
     DeviceSnapshot *snapshot = scannerData.getSnapshot();
     if (!snapshot || snapshot->count == 0) {
-        displayWarning("No BLE devices in range", true);
-        return "";
+        return false;
     }
 
-    // size_t deviceCount = snapshot->count;
     size_t deviceCount = scannerData.deviceAddresses.size();
 
     for (size_t i = 0; i < deviceCount - 1; i++) {
@@ -4318,6 +4466,9 @@ String selectTargetFromScan(const char *title) {
             if (swapNeeded) {
                 std::swap(snapshot->names[i], snapshot->names[j]);
                 std::swap(snapshot->addresses[i], snapshot->addresses[j]);
+                if (i < snapshot->addressTypes.size() && j < snapshot->addressTypes.size()) {
+                    std::swap(snapshot->addressTypes[i], snapshot->addressTypes[j]);
+                }
                 std::swap(snapshot->rssi[i], snapshot->rssi[j]);
 
                 bool tempFast = snapshot->fastPair[i];
@@ -4333,82 +4484,118 @@ String selectTargetFromScan(const char *title) {
         }
     }
 
-    // One row per device: ordinal, name, MAC tail, capability tags and a signal
-    // meter. Tags reserve their width before the name is measured, so a long
-    // name can no longer push the vulnerability markers off screen.
-    BleRowDrawer deviceRow = [snapshot](int idx, int x, int y, int w, bool sel) {
-        uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
-        uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
-        uint16_t dim = sel ? bruceConfig.bgColor : bleDim();
-        const int cw = FP * LW;
-        tft.setTextSize(FP);
+    return (scannerData.size() > 0);
+}
 
-        // the ordinal is the ID the list never had
-        tft.setTextColor(fg, bg);
-        tft.drawString(String(idx + 1), x, y, 1);
-        int cur = x + 3 * cw;
-        int right = x + w;
-
-        bleDrawRssi(right - 11, y, snapshot->rssi[idx], fg);
-        right -= 15;
-
-        String tags;
-        if (snapshot->fastPair[idx]) tags += " FP";
-        if (snapshot->hfp[idx]) tags += " HFP";
-        if (snapshot->types[idx] & 0x01) tags += " AUD";
-        if (snapshot->types[idx] & 0x02) tags += " HID";
-        if (tags.length()) {
-            int tw = tft.textWidth(tags.c_str());
-            tft.setTextColor(sel ? bruceConfig.bgColor : bleAccent(), bg);
-            tft.drawString(tags, right - tw, y, 1);
-            right -= tw + 2;
+String selectTargetFromScan(const char *title) {
+    if (scannerData.size() == 0) {
+        if (!performBleScan(title)) {
+            displayWarning("No BLE devices in range", true);
+            return "";
         }
+    }
 
-        // last two MAC octets tell apart devices advertising the same name
-        String mac = snapshot->addresses[idx];
-        String name = snapshot->names[idx];
-        String tail = (mac.length() >= 5) ? mac.substring(mac.length() - 5) : mac;
-        int tailW = name.equalsIgnoreCase(mac) ? 0 : tft.textWidth(tail.c_str()) + 4;
-        if (right - cur < tailW + 8 * cw) tailW = 0; // too narrow, the name wins
-
-        tft.setTextColor(fg, bg);
-        tft.drawString(bleFit(name, right - cur - tailW), cur, y, 1);
-        if (tailW) {
-            tft.setTextColor(dim, bg);
-            tft.drawRightString(tail, right, y, 1);
-        }
-    };
+    DeviceSnapshot *snapshot = scannerData.getSnapshot();
+    if (!snapshot || snapshot->count == 0) {
+        displayWarning("No BLE devices in range", true);
+        return "";
+    }
 
     int selectedIdx = 0;
-    bool exitLoop = false;
 
-    while (!exitLoop) {
+    while (true) {
+        size_t deviceCount = scannerData.deviceAddresses.size();
+        if (deviceCount == 0) return "";
+        int rowCount = (int)deviceCount + 1;
+
+        // One row per device: ordinal, name, MAC tail, capability tags and a signal
+        // meter. Tags reserve their width before the name is measured, so a long
+        // name can no longer push the vulnerability markers off screen.
+        BleRowDrawer deviceRow = [snapshot, deviceCount](int idx, int x, int y, int w, bool sel) {
+            uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+            uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+            uint16_t dim = sel ? bruceConfig.bgColor : bleDim();
+            const int cw = FP * LW;
+            tft.setTextSize(FP);
+
+            if (idx >= (int)deviceCount) {
+                tft.setTextColor(sel ? bruceConfig.bgColor : bleAccent(), bg);
+                tft.drawString("> Rescan Devices", x, y, 1);
+                return;
+            }
+
+            // the ordinal is the ID the list never had
+            tft.setTextColor(fg, bg);
+            tft.drawString(String(idx + 1), x, y, 1);
+            int cur = x + 3 * cw;
+            int right = x + w;
+
+            bleDrawRssi(right - 11, y, snapshot->rssi[idx], fg);
+            right -= 15;
+
+            String tags;
+            if (snapshot->fastPair[idx]) tags += " FP";
+            if (snapshot->hfp[idx]) tags += " HFP";
+            if (snapshot->types[idx] & 0x01) tags += " AUD";
+            if (snapshot->types[idx] & 0x02) tags += " HID";
+            if (tags.length()) {
+                int tw = tft.textWidth(tags.c_str());
+                tft.setTextColor(sel ? bruceConfig.bgColor : bleAccent(), bg);
+                tft.drawString(tags, right - tw, y, 1);
+                right -= tw + 2;
+            }
+
+            // last two MAC octets tell apart devices advertising the same name
+            String mac = snapshot->addresses[idx];
+            String name = snapshot->names[idx];
+            String tail = (mac.length() >= 5) ? mac.substring(mac.length() - 5) : mac;
+            int tailW = name.equalsIgnoreCase(mac) ? 0 : tft.textWidth(tail.c_str()) + 4;
+            if (right - cur < tailW + 8 * cw) tailW = 0; // too narrow, the name wins
+
+            tft.setTextColor(fg, bg);
+            tft.drawString(bleFit(name, right - cur - tailW), cur, y, 1);
+            if (tailW) {
+                tft.setTextColor(dim, bg);
+                tft.drawRightString(tail, right, y, 1);
+            }
+        };
+
         int chosen = bleListLoop(
-            "Select Device", (int)deviceCount, "SEL pick  ESC back", deviceRow, &selectedIdx
+            title, rowCount, "SEL pick  ESC back", deviceRow, &selectedIdx
         );
         if (chosen < 0) {
-            exitLoop = true;
-        } else {
-            selectedIdx = chosen;
-            String selectedMAC = snapshot->addresses[selectedIdx];
-            String selectedName = snapshot->names[selectedIdx];
-
-            selectedMAC.trim();
-            selectedMAC.toUpperCase();
-
-            g_selectedDevice.address = selectedMAC;
-            g_selectedDevice.name = selectedName;
-            g_selectedDevice.rssi = snapshot->rssi[selectedIdx];
-            g_selectedDevice.hasFastPair = snapshot->fastPair[selectedIdx];
-            g_selectedDevice.hasHFP = snapshot->hfp[selectedIdx];
-            g_selectedDevice.deviceType = snapshot->types[selectedIdx];
-
-            String returnMac = selectedMAC;
-            returnMac.trim();
-
-            return returnMac;
+            return "";
         }
-        delay(50);
+        if (chosen >= (int)deviceCount) {
+            if (!performBleScan(title)) {
+                displayWarning("No BLE devices in range", true);
+                return "";
+            }
+            snapshot = scannerData.getSnapshot();
+            selectedIdx = 0;
+            continue;
+        }
+
+        selectedIdx = chosen;
+        String selectedMAC = snapshot->addresses[selectedIdx];
+        uint8_t selectedAddrType = (selectedIdx < (int)snapshot->addressTypes.size()) ? snapshot->addressTypes[selectedIdx] : BLE_ADDR_PUBLIC;
+        String selectedName = snapshot->names[selectedIdx];
+
+        selectedMAC.trim();
+        selectedMAC.toUpperCase();
+
+        g_selectedDevice.address = selectedMAC;
+        g_selectedDevice.addressType = selectedAddrType;
+        g_selectedDevice.name = selectedName;
+        g_selectedDevice.rssi = snapshot->rssi[selectedIdx];
+        g_selectedDevice.hasFastPair = snapshot->fastPair[selectedIdx];
+        g_selectedDevice.hasHFP = snapshot->hfp[selectedIdx];
+        g_selectedDevice.deviceType = snapshot->types[selectedIdx];
+
+        String returnMac = selectedMAC;
+        returnMac.trim();
+
+        return returnMac;
     }
 
     return "";
@@ -4476,8 +4663,9 @@ String selectMultipleTargetsFromScan(const char *title, std::vector<NimBLEAddres
 
         picked[chosen] = !picked[chosen];
         if (picked[chosen]) {
+            uint8_t addrType = (chosen < (int)snapshot->addressTypes.size()) ? snapshot->addressTypes[chosen] : BLE_ADDR_PUBLIC;
             targets.push_back(
-                NimBLEAddress(std::string(snapshot->addresses[chosen].c_str()), BLE_ADDR_PUBLIC)
+                NimBLEAddress(std::string(snapshot->addresses[chosen].c_str()), addrType)
             );
         } else {
             for (auto it = targets.begin(); it != targets.end(); ++it) {
@@ -4497,10 +4685,27 @@ String selectMultipleTargetsFromScan(const char *title, std::vector<NimBLEAddres
 // parseAddress - Fixed MAC extraction
 //=============================================================================
 
-NimBLEAddress parseAddress(const String &addressInfo) {
+NimBLEAddress parseAddress(const String &addressInfo, uint8_t defaultType) {
     String cleanAddr = addressInfo;
     cleanAddr.trim();
     cleanAddr.toUpperCase();
+
+    uint8_t resolvedType = BLE_ADDR_PUBLIC;
+    if (defaultType != 0xFF) {
+        resolvedType = defaultType;
+    } else if (g_selectedDevice.address.length() > 0 && cleanAddr.indexOf(g_selectedDevice.address) != -1) {
+        resolvedType = g_selectedDevice.addressType;
+    } else {
+        DeviceInfo info;
+        for (size_t i = 0; i < scannerData.size(); i++) {
+            if (scannerData.getDeviceInfo(i, info)) {
+                if (cleanAddr.indexOf(info.address) != -1) {
+                    resolvedType = info.addressType;
+                    break;
+                }
+            }
+        }
+    }
 
     if (cleanAddr.endsWith(":0")) { cleanAddr = cleanAddr.substring(0, cleanAddr.length() - 2); }
 
@@ -4527,7 +4732,7 @@ NimBLEAddress parseAddress(const String &addressInfo) {
                         }
                     }
                 }
-                if (valid) { return NimBLEAddress(std::string(possibleMac.c_str()), BLE_ADDR_PUBLIC); }
+                if (valid) { return NimBLEAddress(std::string(possibleMac.c_str()), resolvedType); }
             }
         } else if (c == ':') {
             colonCount++;
@@ -4558,12 +4763,12 @@ NimBLEAddress parseAddress(const String &addressInfo) {
         }
         if (valid) {
             substr.toUpperCase();
-            return NimBLEAddress(std::string(substr.c_str()), BLE_ADDR_PUBLIC);
+            return NimBLEAddress(std::string(substr.c_str()), resolvedType);
         }
     }
 
     Serial.println("[WARN] Invalid MAC address format: " + addressInfo);
-    return NimBLEAddress(std::string(""), BLE_ADDR_PUBLIC);
+    return NimBLEAddress(std::string(""), resolvedType);
 }
 
 //=============================================================================
@@ -4822,7 +5027,7 @@ void BleSuiteMenu() {
 
     showWelcomeScreen();
 
-    const int MENU_ITEMS = 12;
+    const int MENU_ITEMS = 13;
     const char *menuItems[] = {
         "Quick Vulnerability Scan",
         "Deep Device Profiling",
@@ -4835,6 +5040,7 @@ void BleSuiteMenu() {
         "Payload Delivery",
         "Testing Tools",
         "Universal Attack Chain",
+        "GATT Explorer",
         "BLE Sniffer"
     };
 
@@ -4861,6 +5067,7 @@ void BleSuiteMenu() {
         }
 
         if (choice == MENU_ITEMS - 1) BLE_Sniffer();
+        else if (choice == MENU_ITEMS - 2) gattExplorerMenu();
         else executeAttackWithTargetScan(choice);
     }
 }
@@ -4887,40 +5094,135 @@ const char *getScanTitle(int attackIndex) {
 }
 
 void executeAttackWithTargetScan(int attackIndex) {
-    // FIX: Ensure BLE is initialized for the attack
-    BLEStateManager::initBLE("Bruce-Attack", ESP_PWR_LVL_P9);
+    const char *title = getScanTitle(attackIndex);
 
-    String targetInfo = selectTargetFromScan(getScanTitle(attackIndex));
-    if (targetInfo.isEmpty()) return;
-
-    NimBLEAddress target = parseAddress(targetInfo);
-    if (!confirmAttack(target.toString().c_str())) return;
-
-    SelectedDevice deviceInfo = g_selectedDevice;
-
-    switch (attackIndex) {
-        case 0: runQuickTest(target, deviceInfo); break;
-        case 1: runDeviceProfiling(target, deviceInfo); break;
-        case 2: showFastPairSubMenu(target, deviceInfo); break;
-        case 3: showHFPSubMenu(target, deviceInfo); break;
-        case 4: showAudioSubMenu(target, deviceInfo); break;
-        case 5: showHIDSubMenu(target, deviceInfo); break;
-        case 6: showMemorySubMenu(target, deviceInfo); break;
-        case 7: showDoSSubMenu(target, deviceInfo); break;
-        case 8: showPayloadSubMenu(target, deviceInfo); break;
-        case 9: showTestingSubMenu(target, deviceInfo); break;
-        case 10: runUniversalAttack(target, deviceInfo); break;
+    // Initial scan if we don't have devices yet
+    if (scannerData.size() == 0) {
+        if (!performBleScan(title)) {
+            displayWarning("No BLE devices in range", true);
+            return;
+        }
     }
 
-    showAttackProgress("Attack complete. Press any key to continue...", TFT_GREEN);
-    while (!check(EscPress) && !check(SelPress) && !check(PrevPress) && !check(NextPress)) delay(50);
+    DeviceSnapshot *snapshot = scannerData.getSnapshot();
+    if (!snapshot || snapshot->count == 0) {
+        displayWarning("No BLE devices in range", true);
+        return;
+    }
+
+    int selectedIdx = 0;
+
+    while (true) {
+        size_t deviceCount = scannerData.deviceAddresses.size();
+        if (deviceCount == 0) break;
+        int rowCount = (int)deviceCount + 1;
+
+        BleRowDrawer deviceRow = [snapshot, deviceCount](int idx, int x, int y, int w, bool sel) {
+            uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+            uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+            uint16_t dim = sel ? bruceConfig.bgColor : bleDim();
+            const int cw = FP * LW;
+            tft.setTextSize(FP);
+
+            if (idx >= (int)deviceCount) {
+                tft.setTextColor(sel ? bruceConfig.bgColor : bleAccent(), bg);
+                tft.drawString("> Rescan Devices", x, y, 1);
+                return;
+            }
+
+            // the ordinal is the ID the list never had
+            tft.setTextColor(fg, bg);
+            tft.drawString(String(idx + 1), x, y, 1);
+            int cur = x + 3 * cw;
+            int right = x + w;
+
+            bleDrawRssi(right - 11, y, snapshot->rssi[idx], fg);
+            right -= 15;
+
+            String tags;
+            if (snapshot->fastPair[idx]) tags += " FP";
+            if (snapshot->hfp[idx]) tags += " HFP";
+            if (snapshot->types[idx] & 0x01) tags += " AUD";
+            if (snapshot->types[idx] & 0x02) tags += " HID";
+            if (tags.length()) {
+                int tw = tft.textWidth(tags.c_str());
+                tft.setTextColor(sel ? bruceConfig.bgColor : bleAccent(), bg);
+                tft.drawString(tags, right - tw, y, 1);
+                right -= tw + 2;
+            }
+
+            // last two MAC octets tell apart devices advertising the same name
+            String mac = snapshot->addresses[idx];
+            String name = snapshot->names[idx];
+            String tail = (mac.length() >= 5) ? mac.substring(mac.length() - 5) : mac;
+            int tailW = name.equalsIgnoreCase(mac) ? 0 : tft.textWidth(tail.c_str()) + 4;
+            if (right - cur < tailW + 8 * cw) tailW = 0; // too narrow, the name wins
+
+            tft.setTextColor(fg, bg);
+            tft.drawString(bleFit(name, right - cur - tailW), cur, y, 1);
+            if (tailW) {
+                tft.setTextColor(dim, bg);
+                tft.drawRightString(tail, right, y, 1);
+            }
+        };
+
+        int chosen = bleListLoop(title, rowCount, "SEL select  ESC back", deviceRow, &selectedIdx);
+        if (chosen < 0) {
+            break;
+        }
+
+        if (chosen >= (int)deviceCount) {
+            if (!performBleScan(title)) {
+                displayWarning("No BLE devices in range", true);
+                break;
+            }
+            snapshot = scannerData.getSnapshot();
+            selectedIdx = 0;
+            continue;
+        }
+
+        selectedIdx = chosen;
+        String selectedMAC = snapshot->addresses[selectedIdx];
+        uint8_t selectedAddrType = (selectedIdx < (int)snapshot->addressTypes.size()) ? snapshot->addressTypes[selectedIdx] : BLE_ADDR_PUBLIC;
+        String selectedName = snapshot->names[selectedIdx];
+
+        selectedMAC.trim();
+        selectedMAC.toUpperCase();
+
+        g_selectedDevice.address = selectedMAC;
+        g_selectedDevice.addressType = selectedAddrType;
+        g_selectedDevice.name = selectedName;
+        g_selectedDevice.rssi = snapshot->rssi[selectedIdx];
+        g_selectedDevice.hasFastPair = snapshot->fastPair[selectedIdx];
+        g_selectedDevice.hasHFP = snapshot->hfp[selectedIdx];
+        g_selectedDevice.deviceType = snapshot->types[selectedIdx];
+
+        NimBLEAddress target(selectedMAC.c_str(), selectedAddrType);
+        SelectedDevice deviceInfo = g_selectedDevice;
+
+        BLEStateManager::initBLE("Bruce-Attack", ESP_PWR_LVL_P9);
+
+        switch (attackIndex) {
+            case 0: runQuickTest(target, deviceInfo); break;
+            case 1: runDeviceProfiling(target, deviceInfo); break;
+            case 2: showFastPairSubMenu(target, deviceInfo); break;
+            case 3: showHFPSubMenu(target, deviceInfo); break;
+            case 4: showAudioSubMenu(target, deviceInfo); break;
+            case 5: showHIDSubMenu(target, deviceInfo); break;
+            case 6: showMemorySubMenu(target, deviceInfo); break;
+            case 7: showDoSSubMenu(target, deviceInfo); break;
+            case 8: showPayloadSubMenu(target, deviceInfo); break;
+            case 9: showTestingSubMenu(target, deviceInfo); break;
+            case 10: runUniversalAttack(target, deviceInfo); break;
+        }
+    }
 
     if (g_pBLEScan) {
         g_pBLEScan->stop();
         g_pBLEScan->clearResults();
         g_bleScanActive = false;
     }
-    delay(100);
+    delay(50);
 }
 
 //=============================================================================
@@ -5352,11 +5654,16 @@ void runDeviceProfiling(NimBLEAddress target, SelectedDevice deviceInfo) {
             if (ch.canWrite) writableCount++;
         lines.push_back("Writable chars: " + String(writableCount));
     } else {
-        lines.push_back("Failed to connect for profiling");
+        lines.push_back("Connect failed!");
+        if (profile.errorReason.length() > 0) {
+            lines.push_back("Reason: " + profile.errorReason);
+        } else if (profile.errorCode != 0) {
+            lines.push_back("Err Code: 0x" + String(profile.errorCode, HEX));
+        }
     }
 
     cleanup.disable();
-    showDeviceInfoScreen("DEVICE PROFILE", lines, TFT_BLUE, TFT_WHITE);
+    showDeviceInfoScreen("DEVICE PROFILE", lines, profile.connected ? TFT_BLUE : TFT_RED, TFT_WHITE);
 }
 
 void runWriteAccessTest(NimBLEAddress target) {
@@ -5758,7 +6065,15 @@ void showAttackProgress(const char *message, uint16_t color) {
 }
 
 void showAttackResult(bool success, const char *message) {
-    String msg = message ? String(message) : String(success ? "Attack successful" : "Attack failed");
+    String msg;
+    if (message) {
+        msg = String(message);
+        if (!success && msg.startsWith("Failed to connect") && g_lastBleError != 0) {
+            msg += ": " + getBleErrorDescription(g_lastBleError);
+        }
+    } else {
+        msg = success ? "Attack successful" : "Attack failed";
+    }
     if (success) displaySuccess(msg, true);
     else displayError(msg, true);
 }

--- a/src/modules/ble/BLE_Suite.h
+++ b/src/modules/ble/BLE_Suite.h
@@ -56,6 +56,7 @@ enum FastPairExploitType {
 
 struct DeviceInfo {
     String address;
+    uint8_t addressType = BLE_ADDR_PUBLIC;
     String name;
     int rssi;
     bool hasFastPair;
@@ -69,6 +70,7 @@ struct DeviceSnapshot {
     uint32_t timestamp;
     std::vector<String> names;
     std::vector<String> addresses;
+    std::vector<uint8_t> addressTypes;
     std::vector<int> rssi;
     std::vector<bool> fastPair;
     std::vector<bool> hfp;
@@ -83,6 +85,7 @@ struct DeviceSnapshot {
 
 struct SelectedDevice {
     String address;
+    uint8_t addressType = BLE_ADDR_PUBLIC;
     String name;
     int rssi;
     bool hasFastPair;
@@ -97,6 +100,7 @@ struct SelectedDevice {
 struct ScannerData {
     std::vector<String> deviceNames;
     std::vector<String> deviceAddresses;
+    std::vector<uint8_t> deviceAddressTypes;
     std::vector<int> deviceRssi;
     std::vector<bool> deviceFastPair;
     std::vector<bool> deviceHasHFP;
@@ -111,7 +115,7 @@ struct ScannerData {
     ScannerData();
     ~ScannerData();
     void
-    addDevice(const String &name, const String &address, int rssi, bool fastPair, bool hasHFP, uint8_t type);
+    addDevice(const String &name, const String &address, int rssi, bool fastPair, bool hasHFP, uint8_t type, uint8_t addrType = BLE_ADDR_PUBLIC);
     void clear();
     size_t size();
     DeviceSnapshot *getSnapshot();
@@ -128,6 +132,8 @@ struct CharacteristicInfo {
 struct DeviceProfile {
     String address;
     bool connected;
+    int errorCode = 0;
+    String errorReason = "";
     bool hasFastPair;
     bool hasAVRCP;
     bool hasHID;
@@ -214,9 +220,9 @@ public:
 
 class BLEAttackManager {
 public:
-    void prepareForConnection();
+    void prepareForConnection(bool enableAuth = false);
     void cleanupAfterAttack();
-    bool connectToDevice(NimBLEAddress target, NimBLEClient **outClient, bool useExploitHandshake = false);
+    bool connectToDevice(NimBLEAddress target, NimBLEClient **outClient, bool useExploitHandshake = false, int *outError = nullptr);
     DeviceProfile profileDevice(NimBLEAddress target);
 };
 
@@ -526,6 +532,10 @@ public:
 
 void cleanupBLEStack();
 
+extern int g_lastBleError;
+extern int g_lastBleDisconnectReason;
+String getBleErrorDescription(int reason);
+
 NimBLEClient *attemptConnectionWithStrategies(NimBLEAddress target, String &connectionMethod);
 void BleSuiteMenu();
 void showAttackMenuWithTarget(NimBLEAddress target);
@@ -580,10 +590,11 @@ void executeAudioTest(int testIndex, NimBLEAddress target);
 void showAttackProgress(const char *message, uint16_t color = bruceConfig.priColor);
 void showAttackResult(bool success, const char *message = nullptr);
 bool confirmAttack(const char *targetName);
+bool performBleScan(const char *title = "SELECT TARGET");
 String selectTargetFromScan(const char *title);
 String selectMultipleTargetsFromScan(const char *title, std::vector<NimBLEAddress> &targets);
 String getScriptFromUser();
-NimBLEAddress parseAddress(const String &addressInfo);
+NimBLEAddress parseAddress(const String &addressInfo, uint8_t defaultType = 0xFF);
 bool requireSimpleConfirmation(const char *message);
 int8_t showAdaptiveMessage(
     const char *line1, const char *btn1, const char *btn2, const char *btn3, uint16_t color,

--- a/src/modules/ble/HFP_Exploit.cpp
+++ b/src/modules/ble/HFP_Exploit.cpp
@@ -17,7 +17,7 @@ bool HFPExploitEngine::testCVE202536911(NimBLEAddress target) {
     NimBLEClient *pClient = NimBLEDevice::createClient();
     if (!pClient) return false;
 
-    pClient->setConnectTimeout(5);
+    pClient->setConnectTimeout(8 * 1000);
     bool connected = pClient->connect(target, false);
 
     if (!connected) {
@@ -63,7 +63,7 @@ bool HFPExploitEngine::establishHFPConnection(NimBLEAddress target) {
     NimBLEClient *pClient = NimBLEDevice::createClient();
     if (!pClient) return false;
 
-    pClient->setConnectTimeout(8);
+    pClient->setConnectTimeout(8 * 1000);
     bool connected = pClient->connect(target, false);
 
     if (connected && isHFPServiceAvailable(pClient)) {

--- a/src/modules/ble/ble_ninebot.cpp
+++ b/src/modules/ble/ble_ninebot.cpp
@@ -107,7 +107,7 @@ void BLENinebot::setup() {
 
     pClient = NimBLEDevice::createClient();
     pClient->setClientCallbacks(new ScooterClientCallbacks(), false);
-    pClient->setConnectTimeout(3);
+    pClient->setConnectTimeout(3 * 1000);
 
     delay(CMD_DELAY);
     loop();

--- a/src/modules/ble/ble_sniffer.cpp
+++ b/src/modules/ble/ble_sniffer.cpp
@@ -152,8 +152,13 @@ void BLE_Sniffer() {
                     packet.payloadHex = payloadToHex(packet.payload);
                     packet.channel = 37 + (i % 3);
 
+                    static const size_t MAX_SNIFFER_PACKETS = 50;
+                    while (snifferPackets.size() >= MAX_SNIFFER_PACKETS) {
+                        snifferPackets.erase(snifferPackets.begin());
+                    }
+
                     snifferPackets.push_back(packet);
-                    snifferPacketCount++;
+                    snifferPacketCount = snifferPackets.size();
                 }
 
                 pSnifferScan->stop();

--- a/src/modules/ble/gatt_explorer.cpp
+++ b/src/modules/ble/gatt_explorer.cpp
@@ -1,0 +1,1726 @@
+#if !defined(LITE_VERSION)
+
+#include "gatt_explorer.h"
+#include "gatt_server.h"
+#include "BLE_Suite.h"
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/sd_functions.h"
+#include "core/utils.h"
+#include <LittleFS.h>
+#include <NimBLEDevice.h>
+#include <SD.h>
+#include <globals.h>
+#include <algorithm>
+#include <functional>
+#include <vector>
+
+//=============================================================================
+// Types & Enums
+//=============================================================================
+
+enum GattFilterMode {
+    FILTER_CONNECTABLE = 0,
+    FILTER_WITH_SERVICES,
+    FILTER_HID,
+    FILTER_UART,
+    FILTER_AUDIO,
+    FILTER_SENSORS,
+    FILTER_CUSTOM_128,
+};
+
+struct GattSettings {
+    int minRssi = -95;        // -95 (All), -85, -75, -65
+    int timeoutSec = 5;       // 3, 5, 8, 12
+    int addrTypeFilter = 0;   // 0: Any, 1: Public only, 2: Random only
+    int maxDevices = 40;      // Ring buffer capacity: 20, 40, 60, 80
+};
+
+struct GattScannedDevice {
+    NimBLEAddress address;
+    uint8_t addressType = BLE_ADDR_PUBLIC;
+    String name;
+    int rssi = -100;
+    bool isConnectable = true;
+    std::vector<String> serviceUuids;
+    std::vector<String> serviceNames;
+    uint32_t lastSeen = 0;
+    String tag;
+};
+
+//=============================================================================
+// State
+//=============================================================================
+
+static GattSettings g_gattSettings;
+static std::vector<GattScannedDevice> g_discoveredDevices;
+static GattScannedDevice g_latestScannedDevice;
+static bool g_hasLatestScanned = false;
+static uint32_t g_scanPackets = 0;
+static volatile bool g_scanActive = false;
+static GattFilterMode g_currentFilter = FILTER_CONNECTABLE;
+static SemaphoreHandle_t g_gattScanMutex = nullptr;
+
+static void gattEnsureScanMutex() {
+    if (!g_gattScanMutex) {
+        g_gattScanMutex = xSemaphoreCreateMutex();
+    }
+}
+
+//=============================================================================
+// UI Layout & Helper Functions (Small Font / Compact Mode)
+//=============================================================================
+
+struct GattUiGeom {
+    int listL, listW;
+    int top;
+    int rowH;
+    int rows;
+    int footY;
+};
+
+static GattUiGeom gattUiGeom() {
+    GattUiGeom g;
+    g.listL = 8;
+    g.listW = tftWidth - 16;
+    g.top = BORDER_PAD_Y + 8 * FM + 3;
+    g.footY = tftHeight - 8 * FP - 6;
+    g.rowH = 8 * FP + 5;
+    int avail = g.footY - g.top - 2;
+    if (avail < g.rowH) avail = g.rowH;
+    g.rows = avail / g.rowH;
+    if (g.rows < 1) g.rows = 1;
+    return g;
+}
+
+static uint16_t gattDimColor() {
+    return getColorVariation(bruceConfig.priColor, 8, -1);
+}
+
+static String gattFitText(const String &text, int maxPx) {
+    if (maxPx <= 0) return "";
+    tft.setTextSize(FP);
+    if (tft.textWidth(text.c_str()) <= maxPx) return text;
+    String s = text;
+    while (s.length() > 1 && tft.textWidth((s + "..").c_str()) > maxPx) {
+        s.remove(s.length() - 1);
+    }
+    return s + "..";
+}
+
+static void gattWrapInto(const String &text, int w, std::vector<String> &out) {
+    tft.setTextSize(FP);
+    const int len = text.length();
+    if (len == 0) {
+        out.push_back("");
+        return;
+    }
+    int start = 0;
+    while (start < len) {
+        int end = start, lastSpace = -1;
+        while (end < len) {
+            if (text.charAt(end) == ' ') lastSpace = end;
+            if (tft.textWidth(text.substring(start, end + 1).c_str()) > w) break;
+            end++;
+        }
+        int cut = (end >= len) ? len : (lastSpace > start ? lastSpace : end);
+        out.push_back(text.substring(start, cut));
+        start = (cut < len && text.charAt(cut) == ' ') ? cut + 1 : cut;
+    }
+}
+
+static void gattDrawRssi(int x, int y, int rssi, uint16_t color) {
+    int bars = 0;
+    if (rssi > -55) bars = 4;
+    else if (rssi > -68) bars = 3;
+    else if (rssi > -80) bars = 2;
+    else if (rssi > -92) bars = 1;
+    for (int i = 0; i < 4; i++) {
+        int h = 2 + i * 2;
+        if (i < bars) tft.fillRect(x + i * 3, y + 8 - h, 2, h, color);
+        else tft.drawFastHLine(x + i * 3, y + 7, 2, color);
+    }
+}
+
+typedef std::function<void(int idx, int x, int y, int w, bool selected)> GattRowDrawer;
+
+static int gattListLoop(
+    const char *title, int count, const String &hint, GattRowDrawer drawRow, int *cursor = nullptr
+) {
+    if (count <= 0) return -1;
+    GattUiGeom g = gattUiGeom();
+    int sel = (cursor && *cursor >= 0 && *cursor < count) ? *cursor : 0;
+    int off = 0, lastSel = -1, lastOff = -1;
+
+    if (sel >= g.rows) off = sel - g.rows + 1;
+    drawMainBorderWithTitle(title);
+
+    for (;;) {
+        if (sel != lastSel || off != lastOff) {
+            tft.setTextSize(FP);
+            for (int i = 0; i < g.rows; i++) {
+                int y = g.top + i * g.rowH;
+                int idx = off + i;
+                bool selected = (idx == sel);
+                tft.fillRect(
+                    g.listL,
+                    y - 2,
+                    g.listW,
+                    g.rowH,
+                    selected ? bruceConfig.priColor : bruceConfig.bgColor
+                );
+                if (idx < count) drawRow(idx, g.listL + 3, y, g.listW - 6, selected);
+            }
+
+            // Position & hint footer
+            tft.fillRect(g.listL, g.footY, g.listW, 8 * FP, bruceConfig.bgColor);
+            tft.setTextSize(FP);
+            String pos = String(sel + 1) + "/" + String(count);
+            int posW = tft.textWidth(pos.c_str());
+            tft.setTextColor(gattDimColor(), bruceConfig.bgColor);
+            tft.drawString(gattFitText(hint, g.listW - posW - 8), g.listL, g.footY, 1);
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawRightString(pos, g.listL + g.listW, g.footY, 1);
+
+            lastSel = sel;
+            lastOff = off;
+            if (cursor) *cursor = sel;
+        }
+
+        if (check(EscPress)) return -1;
+        else if (check(PrevPress) || check(UpPress)) sel = (sel > 0) ? sel - 1 : count - 1;
+        else if (check(NextPress) || check(DownPress)) sel = (sel < count - 1) ? sel + 1 : 0;
+        else if (check(SelPress)) {
+            if (cursor) *cursor = sel;
+            return sel;
+        }
+
+        if (sel < off) off = sel;
+        if (sel >= off + g.rows) off = sel - g.rows + 1;
+        if (off > count - g.rows) off = std::max(0, count - g.rows);
+        if (off < 0) off = 0;
+        vTaskDelay(20 / portTICK_PERIOD_MS);
+    }
+}
+
+struct GattMenuItem {
+    String label;
+    std::function<void()> action;
+};
+
+static int gattMenu(
+    const char *title,
+    const std::vector<GattMenuItem> &items,
+    const String &hint = "SEL choose  ESC back",
+    int *cursor = nullptr
+) {
+    if (items.empty()) return -1;
+    int count = items.size();
+    auto drawer = [&items](int idx, int x, int y, int w, bool sel) {
+        uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+        uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+        tft.setTextColor(fg, bg);
+        tft.setTextSize(FP);
+        tft.drawString(gattFitText(items[idx].label, w), x, y, 1);
+    };
+
+    int chosen = gattListLoop(title, count, hint, drawer, cursor);
+    if (chosen >= 0 && chosen < count) {
+        if (items[chosen].action) {
+            items[chosen].action();
+        }
+    }
+    return chosen;
+}
+
+static void gattShowScrollableReport(const char *title, const std::vector<String> &lines) {
+    GattUiGeom g = gattUiGeom();
+    const int barW = 3;
+    const int textX = g.listL + barW + 4;
+    const int textW = g.listW - barW - 4;
+
+    std::vector<String> rows;
+    for (size_t i = 0; i < lines.size(); i++) {
+        gattWrapInto(lines[i], textW, rows);
+    }
+
+    const int perPage = g.rows;
+    int off = 0, lastOff = -1;
+
+    drawMainBorderWithTitle(title);
+    tft.fillRect(g.listL, g.top - 2, barW, perPage * g.rowH, bruceConfig.priColor);
+
+    for (;;) {
+        if (off != lastOff) {
+            lastOff = off;
+            tft.setTextSize(FP);
+            for (int i = 0; i < perPage; i++) {
+                int y = g.top + i * g.rowH;
+                tft.fillRect(textX, y - 2, textW, g.rowH, bruceConfig.bgColor);
+                size_t idx = (size_t)(off + i);
+                if (idx >= rows.size()) continue;
+                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                tft.drawString(rows[idx], textX, y, 1);
+            }
+
+            tft.fillRect(g.listL, g.footY, g.listW, 8 * FP, bruceConfig.bgColor);
+            bool more = (int)rows.size() > perPage;
+            tft.setTextColor(gattDimColor(), bruceConfig.bgColor);
+            tft.drawString(more ? "UP/DN scroll  ESC/SEL back" : "SEL / ESC back", g.listL, g.footY, 1);
+            if (more) {
+                int last = std::min((int)rows.size(), off + perPage);
+                String pos = String(off + 1) + "-" + String(last) + "/" + String((int)rows.size());
+                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                tft.drawRightString(pos, g.listL + g.listW, g.footY, 1);
+            }
+        }
+
+        if (check(EscPress) || check(SelPress)) return;
+        else if (check(PrevPress) || check(UpPress)) off = std::max(0, off - 1);
+        else if (check(NextPress) || check(DownPress)) {
+            if (off + perPage < (int)rows.size()) off++;
+        }
+        vTaskDelay(20 / portTICK_PERIOD_MS);
+    }
+}
+
+//=============================================================================
+// Helper: UUID Name Resolution
+//=============================================================================
+
+static String getGattServiceName(const String &uuidStr) {
+    String lower = uuidStr;
+    lower.toLowerCase();
+
+    // Standard 16-bit Service UUIDs (or 16-bit inside standard Bluetooth Base UUID)
+    if (lower == "1800" || lower.indexOf("00001800-0000-1000-8000-00805f9b34fb") != -1) return "Generic Access";
+    if (lower == "1801" || lower.indexOf("00001801-0000-1000-8000-00805f9b34fb") != -1) return "Generic Attribute";
+    if (lower == "180a" || lower.indexOf("0000180a-0000-1000-8000-00805f9b34fb") != -1) return "Device Info";
+    if (lower == "180f" || lower.indexOf("0000180f-0000-1000-8000-00805f9b34fb") != -1) return "Battery Service";
+    if (lower == "1812" || lower.indexOf("00001812-0000-1000-8000-00805f9b34fb") != -1) return "HID (Human Interface)";
+    if (lower == "180d" || lower.indexOf("0000180d-0000-1000-8000-00805f9b34fb") != -1) return "Heart Rate";
+    if (lower == "181a" || lower.indexOf("0000181a-0000-1000-8000-00805f9b34fb") != -1) return "Environmental";
+    if (lower == "1809" || lower.indexOf("00001809-0000-1000-8000-00805f9b34fb") != -1) return "Health Thermometer";
+    if (lower == "1808" || lower.indexOf("00001808-0000-1000-8000-00805f9b34fb") != -1) return "Glucose";
+    if (lower == "1810" || lower.indexOf("00001810-0000-1000-8000-00805f9b34fb") != -1) return "Blood Pressure";
+    if (lower == "1815" || lower.indexOf("00001815-0000-1000-8000-00805f9b34fb") != -1) return "Automation IO";
+    if (lower == "1816" || lower.indexOf("00001816-0000-1000-8000-00805f9b34fb") != -1) return "Cycling Speed";
+    if (lower == "1818" || lower.indexOf("00001818-0000-1000-8000-00805f9b34fb") != -1) return "Cycling Power";
+    if (lower == "1826" || lower.indexOf("00001826-0000-1000-8000-00805f9b34fb") != -1) return "Fitness Machine";
+    if (lower == "1843" || lower.indexOf("00001843-0000-1000-8000-00805f9b34fb") != -1) return "Audio Input Control";
+    if (lower == "1844" || lower.indexOf("00001844-0000-1000-8000-00805f9b34fb") != -1) return "Volume Control";
+    if (lower == "110a" || lower.indexOf("0000110a-0000-1000-8000-00805f9b34fb") != -1) return "A2DP Audio Sink";
+    if (lower == "110b" || lower.indexOf("0000110b-0000-1000-8000-00805f9b34fb") != -1) return "A2DP Source";
+    if (lower == "110e" || lower.indexOf("0000110e-0000-1000-8000-00805f9b34fb") != -1) return "AVRCP Target";
+    if (lower == "110f" || lower.indexOf("0000110f-0000-1000-8000-00805f9b34fb") != -1) return "AVRCP Controller";
+    if (lower == "111e" || lower.indexOf("0000111e-0000-1000-8000-00805f9b34fb") != -1) return "Handsfree (HFP)";
+    if (lower == "fe2c" || lower.indexOf("0000fe2c-0000-1000-8000-00805f9b34fb") != -1) return "Google FastPair";
+    if (lower == "fee0" || lower.indexOf("0000fee0-0000-1000-8000-00805f9b34fb") != -1) return "Mi Band / Smart";
+    if (lower == "ffe0" || lower.indexOf("0000ffe0-0000-1000-8000-00805f9b34fb") != -1) return "HM-10 / UART";
+    if (lower.indexOf("6e400001") != -1) return "Nordic NUS (UART)";
+    if (lower.indexOf("0000fff0") != -1) return "Vendor Serial";
+
+    if (lower.length() > 8) return "Custom 128-bit";
+    return "Service 0x" + uuidStr;
+}
+
+static String getGattCharName(const String &uuidStr) {
+    String lower = uuidStr;
+    lower.toLowerCase();
+
+    if (lower == "2a00" || lower.indexOf("00002a00-") != -1) return "Device Name";
+    if (lower == "2a01" || lower.indexOf("00002a01-") != -1) return "Appearance";
+    if (lower == "2a04" || lower.indexOf("00002a04-") != -1) return "Conn Params";
+    if (lower == "2a05" || lower.indexOf("00002a05-") != -1) return "Service Changed";
+    if (lower == "2a19" || lower.indexOf("00002a19-") != -1) return "Battery Level";
+    if (lower == "2a24" || lower.indexOf("00002a24-") != -1) return "Model Number";
+    if (lower == "2a25" || lower.indexOf("00002a25-") != -1) return "Serial Number";
+    if (lower == "2a26" || lower.indexOf("00002a26-") != -1) return "Firmware Rev";
+    if (lower == "2a27" || lower.indexOf("00002a27-") != -1) return "Hardware Rev";
+    if (lower == "2a28" || lower.indexOf("00002a28-") != -1) return "Software Rev";
+    if (lower == "2a29" || lower.indexOf("00002a29-") != -1) return "Manufacturer";
+    if (lower == "2a4a" || lower.indexOf("00002a4a-") != -1) return "HID Info";
+    if (lower == "2a4b" || lower.indexOf("00002a4b-") != -1) return "Report Map";
+    if (lower == "2a4c" || lower.indexOf("00002a4c-") != -1) return "HID Ctrl Point";
+    if (lower == "2a4d" || lower.indexOf("00002a4d-") != -1) return "HID Report";
+    if (lower == "2a4e" || lower.indexOf("00002a4e-") != -1) return "Protocol Mode";
+    if (lower == "2a37" || lower.indexOf("00002a37-") != -1) return "Heart Rate Meas";
+    if (lower == "2a1c" || lower.indexOf("00002a1c-") != -1) return "Temperature Meas";
+    if (lower == "2a6e" || lower.indexOf("00002a6e-") != -1) return "Temperature";
+    if (lower == "2a6f" || lower.indexOf("00002a6f-") != -1) return "Humidity";
+    if (lower.indexOf("6e400002") != -1) return "NUS TX (Write)";
+    if (lower.indexOf("6e400003") != -1) return "NUS RX (Notify)";
+    if (lower == "ffe1" || lower.indexOf("0000ffe1-") != -1) return "Serial Data";
+
+    return "Char 0x" + uuidStr;
+}
+
+static const char *getFilterModeName(GattFilterMode mode) {
+    switch (mode) {
+        case FILTER_CONNECTABLE: return "Connectable Only";
+        case FILTER_WITH_SERVICES: return "With Advertised Services";
+        case FILTER_HID: return "HID / Input (0x1812)";
+        case FILTER_UART: return "Serial / NUS / UART";
+        case FILTER_AUDIO: return "Audio / Media / AVRCP";
+        case FILTER_SENSORS: return "Sensors / Health";
+        case FILTER_CUSTOM_128: return "Custom 128-bit UUIDs";
+        default: return "All Connectable";
+    }
+}
+
+//=============================================================================
+// Continuous Scanner Callbacks
+//=============================================================================
+
+class GattScanCallbacks : public NimBLEScanCallbacks {
+    void onResult(const NimBLEAdvertisedDevice *dev) override {
+        if (!dev) return;
+        g_scanPackets++;
+
+        // 1. RSSI threshold check
+        int rssi = dev->getRSSI();
+        if (rssi == 0) rssi = -100;
+        if (rssi < g_gattSettings.minRssi) return;
+
+        // 2. Address type filter check
+        uint8_t addrType = dev->getAddressType();
+        if (g_gattSettings.addrTypeFilter == 1 && addrType != BLE_ADDR_PUBLIC) return;
+        if (g_gattSettings.addrTypeFilter == 2 && addrType == BLE_ADDR_PUBLIC) return;
+
+        bool isConn = dev->isConnectable();
+
+        // 3. Collect service UUIDs
+        std::vector<String> serviceUuids;
+        std::vector<String> serviceNames;
+        size_t serviceCount = dev->getServiceUUIDCount();
+        for (size_t i = 0; i < serviceCount; i++) {
+            NimBLEUUID u = dev->getServiceUUID(i);
+            String uStr = String(u.toString().c_str());
+            serviceUuids.push_back(uStr);
+            serviceNames.push_back(getGattServiceName(uStr));
+        }
+
+        String name = String(dev->getName().c_str());
+        name.trim();
+        if (name == "(null)" || name == "null" || name == "NULL" || name == "<no name>") {
+            name = "";
+        }
+
+        String mac = String(dev->getAddress().toString().c_str());
+        mac.toUpperCase();
+
+        // Determine specialized tag
+        String tag = isConn ? "GATT" : "ADV";
+        for (const auto &u : serviceUuids) {
+            if (u.indexOf("1812") != -1 || u.indexOf("1124") != -1) { tag = "HID"; break; }
+            if (u.indexOf("6e400001") != -1 || u.indexOf("ffe0") != -1 || u.indexOf("fff0") != -1) { tag = "UART"; break; }
+            if (u.indexOf("110e") != -1 || u.indexOf("110f") != -1 || u.indexOf("1843") != -1) { tag = "AUD"; break; }
+            if (u.indexOf("180d") != -1 || u.indexOf("181a") != -1 || u.indexOf("1809") != -1 || u.indexOf("180f") != -1) { tag = "SENS"; break; }
+            if (u.indexOf("fe2c") != -1) { tag = "FP"; break; }
+        }
+
+        gattEnsureScanMutex();
+        if (!g_gattScanMutex || xSemaphoreTake(g_gattScanMutex, pdMS_TO_TICKS(15)) != pdTRUE) {
+            return;
+        }
+
+        g_latestScannedDevice.address = dev->getAddress();
+        g_latestScannedDevice.addressType = addrType;
+        g_latestScannedDevice.name = (name.length() > 0) ? name : mac;
+        g_latestScannedDevice.rssi = rssi;
+        g_latestScannedDevice.isConnectable = isConn;
+        g_latestScannedDevice.tag = tag;
+        g_hasLatestScanned = true;
+
+        // 4. Update existing device if already seen
+        for (auto &existing : g_discoveredDevices) {
+            if (String(existing.address.toString().c_str()).equalsIgnoreCase(mac)) {
+                existing.rssi = rssi;
+                if (name.length() > 0) existing.name = name;
+                if (isConn) existing.isConnectable = true;
+                if (!serviceUuids.empty()) {
+                    for (size_t si = 0; si < serviceUuids.size(); si++) {
+                        bool foundUuid = false;
+                        for (const auto &eu : existing.serviceUuids) {
+                            if (eu.equalsIgnoreCase(serviceUuids[si])) { foundUuid = true; break; }
+                        }
+                        if (!foundUuid) {
+                            existing.serviceUuids.push_back(serviceUuids[si]);
+                            existing.serviceNames.push_back(serviceNames[si]);
+                        }
+                    }
+                }
+                existing.lastSeen = millis();
+                if (tag != "GATT" && tag != "ADV") {
+                    existing.tag = tag;
+                } else if (existing.tag == "ADV" && isConn) {
+                    existing.tag = "GATT";
+                }
+                xSemaphoreGive(g_gattScanMutex);
+                return;
+            }
+        }
+
+        // 5. Filter Mode Matching for new devices
+        bool match = false;
+        switch (g_currentFilter) {
+            case FILTER_CONNECTABLE:
+                match = true;
+                break;
+            case FILTER_WITH_SERVICES:
+                match = (!serviceUuids.empty());
+                break;
+            case FILTER_HID:
+                match = (tag == "HID");
+                break;
+            case FILTER_UART:
+                match = (tag == "UART");
+                break;
+            case FILTER_AUDIO:
+                match = (tag == "AUD");
+                break;
+            case FILTER_SENSORS:
+                match = (tag == "SENS");
+                break;
+            case FILTER_CUSTOM_128:
+                for (const auto &u : serviceUuids) {
+                    if (u.length() > 8) { match = true; tag = "128b"; break; }
+                }
+                break;
+        }
+
+        if (!match) {
+            xSemaphoreGive(g_gattScanMutex);
+            return;
+        }
+
+        GattScannedDevice newDev;
+        newDev.address = dev->getAddress();
+        newDev.addressType = addrType;
+        newDev.name = (name.length() > 0) ? name : mac;
+        newDev.rssi = rssi;
+        newDev.isConnectable = isConn;
+        newDev.serviceUuids = serviceUuids;
+        newDev.serviceNames = serviceNames;
+        newDev.lastSeen = millis();
+        newDev.tag = tag;
+
+        // Priority Queue (Max RSSI): keep devices with strongest signal
+        size_t cap = (g_gattSettings.maxDevices > 0) ? (size_t)g_gattSettings.maxDevices : 40;
+        if (g_discoveredDevices.size() >= cap) {
+            // Find device with the weakest (lowest) RSSI
+            auto minIt = std::min_element(
+                g_discoveredDevices.begin(), g_discoveredDevices.end(),
+                [](const GattScannedDevice &a, const GattScannedDevice &b) {
+                    return a.rssi < b.rssi;
+                }
+            );
+            if (minIt != g_discoveredDevices.end() && newDev.rssi > minIt->rssi) {
+                *minIt = newDev; // Replace weakest device with stronger device
+            }
+        } else {
+            g_discoveredDevices.push_back(newDev);
+        }
+
+        xSemaphoreGive(g_gattScanMutex);
+    }
+};
+
+static GattScanCallbacks g_gattScanCallbacks;
+
+struct BleConnDiagInfo {
+    int lastErrorCode = 0;
+    int lastDisconnectReason = 0;
+    uint8_t ownAddrType = BLE_OWN_ADDR_PUBLIC;
+    uint8_t peerAddrType = BLE_ADDR_PUBLIC;
+    uint8_t phyMask = 1;
+    uint16_t itvlMin = 0;
+    uint16_t itvlMax = 0;
+    uint16_t latency = 0;
+    uint16_t timeout = 0;
+    uint16_t scanItvl = 0;
+    uint16_t scanWin = 0;
+    int strategyTried = 0;
+    int totalStrategies = 0;
+};
+static BleConnDiagInfo g_lastConnDiag;
+
+class GattExplorerClientCallbacks : public NimBLEClientCallbacks {
+public:
+    void onConnect(NimBLEClient *pClient) override {
+        NimBLEConnInfo info = pClient->getConnInfo();
+        Serial.println(F("\n[BLE-DBG] >>> Connection ESTABLISHED! <<<"));
+        Serial.printf("[BLE-DBG] Handle: %d, Peer: %s, MTU: %d\n",
+                      pClient->getConnHandle(),
+                      pClient->getPeerAddress().toString().c_str(),
+                      pClient->getMTU());
+        Serial.printf("[BLE-DBG] Interval: %.2f ms, Latency: %d, Supervision Timeout: %d ms\n",
+                      info.getConnInterval() * 1.25f,
+                      info.getConnLatency(),
+                      info.getConnTimeout() * 10);
+    }
+
+    void onConnectFail(NimBLEClient *pClient, int reason) override {
+        g_lastBleError = reason;
+        g_lastConnDiag.lastErrorCode = reason;
+        String desc = getBleErrorDescription(reason);
+        Serial.printf("\n[BLE-DBG] >>> Connection FAILED! Reason: 0x%02X (%d) -> %s <<<\n",
+                      reason, reason, desc.c_str());
+        Serial.printf("[BLE-DBG] Target: %s (Type: %s)\n",
+                      pClient->getPeerAddress().toString().c_str(),
+                      (pClient->getPeerAddress().getType() == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM");
+    }
+
+    void onDisconnect(NimBLEClient *pClient, int reason) override {
+        g_lastBleDisconnectReason = reason;
+        g_lastConnDiag.lastDisconnectReason = reason;
+        if (g_lastBleError == 0) g_lastBleError = reason;
+        String desc = getBleErrorDescription(reason);
+        Serial.printf("\n[BLE-DBG] >>> Disconnected! Reason: 0x%02X (%d) -> %s <<<\n",
+                      reason, reason, desc.c_str());
+    }
+
+    bool onConnParamsUpdateRequest(NimBLEClient *pClient, const ble_gap_upd_params *params) override {
+        Serial.printf("[BLE-DBG] Remote ConnParamsUpdateRequest: min=%.2fms max=%.2fms lat=%d tmo=%dms -> Accepted\n",
+                      params->itvl_min * 1.25f, params->itvl_max * 1.25f, params->latency, params->supervision_timeout * 10);
+        return true;
+    }
+};
+
+static GattExplorerClientCallbacks g_gattClientCallbacks;
+
+//=============================================================================
+// Forward Declarations
+//=============================================================================
+
+static void runContinuousScan(GattFilterMode filterMode);
+static void showDiscoveredDevicesList();
+static void exploreGattDevice(GattScannedDevice &device);
+static void browseServicesAndChars(NimBLEClient *pClient, const GattScannedDevice &device);
+static void handleCharacteristicActions(NimBLEClient *pClient, NimBLERemoteCharacteristic *pChar, const String &serviceName);
+static void readStandardDeviceInfo(NimBLEClient *pClient);
+static bool dumpDeviceGattToStorage(NimBLEClient *pClient, const GattScannedDevice &device, String *outFilePath = nullptr);
+static void runAutoDumpAll();
+static void gattSettingsMenu();
+
+//=============================================================================
+// Continuous Scan Implementation
+//=============================================================================
+
+static void runContinuousScan(GattFilterMode filterMode) {
+    g_currentFilter = filterMode;
+    g_scanPackets = 0;
+    gattEnsureScanMutex();
+    if (g_gattScanMutex && xSemaphoreTake(g_gattScanMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        g_discoveredDevices.clear();
+        g_hasLatestScanned = false;
+        xSemaphoreGive(g_gattScanMutex);
+    }
+
+    BLEStateManager::initBLE("Bruce-GATT", ESP_PWR_LVL_P9);
+
+    NimBLEScan *pScan = NimBLEDevice::getScan();
+    if (!pScan) {
+        displayError("Failed to get BLE scan engine");
+        return;
+    }
+
+    pScan->setScanCallbacks(&g_gattScanCallbacks, true);
+    pScan->setActiveScan(true);
+    pScan->setInterval(100);
+    pScan->setWindow(99);
+    pScan->setDuplicateFilter(false);
+    pScan->setMaxResults(0);
+    pScan->clearResults();
+
+    drawMainBorderWithTitle("GATT SCAN (LIVE)");
+
+    // Start scanning indefinitely (duration = 0)
+    pScan->start(0, false);
+    g_scanActive = true;
+
+    uint32_t lastUiUpdate = 0;
+    int animFrame = 0;
+    const char *spinner = "|/-\\";
+
+    while (g_scanActive) {
+        // User abort check: ESC or SEL stops continuous scanning
+        if (check(EscPress) || check(SelPress) || check(PrevPress) || check(NextPress)) {
+            break;
+        }
+
+        uint32_t now = millis();
+        if (now - lastUiUpdate > 150) {
+            lastUiUpdate = now;
+            animFrame = (animFrame + 1) % 4;
+
+            int devCount = 0;
+            bool hasLatest = false;
+            GattScannedDevice latestCopy;
+            if (g_gattScanMutex && xSemaphoreTake(g_gattScanMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+                devCount = (int)g_discoveredDevices.size();
+                hasLatest = g_hasLatestScanned;
+                if (hasLatest) {
+                    latestCopy = g_latestScannedDevice;
+                }
+                xSemaphoreGive(g_gattScanMutex);
+            }
+
+            tft.setTextSize(FP);
+
+            // Row 1: Filter info
+            tft.fillRect(BORDER_PAD_X, BORDER_PAD_Y + 12, tftWidth - 2 * BORDER_PAD_X, 10 * FP, bruceConfig.bgColor);
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawString("Filter: " + String(getFilterModeName(filterMode)), BORDER_PAD_X, BORDER_PAD_Y + 12);
+
+            // Row 2: Live status & spinner
+            tft.fillRect(BORDER_PAD_X, BORDER_PAD_Y + 26, tftWidth - 2 * BORDER_PAD_X, 10 * FP, bruceConfig.bgColor);
+            tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
+            tft.drawString(
+                "[" + String(spinner[animFrame]) + "] Scanning... Found: " + String(devCount),
+                BORDER_PAD_X,
+                BORDER_PAD_Y + 26
+            );
+
+            // Row 3: Packets
+            tft.fillRect(BORDER_PAD_X, BORDER_PAD_Y + 40, tftWidth - 2 * BORDER_PAD_X, 10 * FP, bruceConfig.bgColor);
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawString("Packets RX: " + String(g_scanPackets), BORDER_PAD_X, BORDER_PAD_Y + 40);
+
+            // Row 4-5: Latest found device
+            tft.fillRect(BORDER_PAD_X, BORDER_PAD_Y + 54, tftWidth - 2 * BORDER_PAD_X, 24 * FP, bruceConfig.bgColor);
+            if (hasLatest) {
+                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                String devLine = "[" + latestCopy.tag + "] " + latestCopy.name + " (" + String(latestCopy.rssi) + "dBm)";
+                tft.drawString(gattFitText(devLine, tftWidth - 2 * BORDER_PAD_X), BORDER_PAD_X, BORDER_PAD_Y + 54);
+
+                String addrLine = "MAC: " + String(latestCopy.address.toString().c_str()) + " " +
+                                  ((latestCopy.addressType == BLE_ADDR_PUBLIC) ? "[PUB]" : "[RND]");
+                tft.drawString(gattFitText(addrLine, tftWidth - 2 * BORDER_PAD_X), BORDER_PAD_X, BORDER_PAD_Y + 66);
+            } else {
+                tft.setTextColor(bruceConfig.secColor, bruceConfig.bgColor);
+                tft.drawString("Listening for connectable beacons...", BORDER_PAD_X, BORDER_PAD_Y + 54);
+            }
+
+            // Footer instructions
+            tft.fillRect(BORDER_PAD_X, tftHeight - 16, tftWidth - 2 * BORDER_PAD_X, 10 * FP, bruceConfig.bgColor);
+            tft.setTextColor(gattDimColor(), bruceConfig.bgColor);
+            tft.drawCentreString("Press [SEL] or [ESC] to Stop", tftWidth / 2, tftHeight - 14, 1);
+        }
+
+        vTaskDelay(30 / portTICK_PERIOD_MS);
+    }
+
+    // Stop active scan cleanly and allow controller to settle
+    if (pScan) {
+        pScan->stop();
+        pScan->clearResults();
+    }
+    g_scanActive = false;
+    vTaskDelay(150 / portTICK_PERIOD_MS);
+
+    if (g_gattScanMutex && xSemaphoreTake(g_gattScanMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+        std::sort(g_discoveredDevices.begin(), g_discoveredDevices.end(), [](const GattScannedDevice &a, const GattScannedDevice &b) {
+            return a.rssi > b.rssi;
+        });
+        xSemaphoreGive(g_gattScanMutex);
+    }
+
+    if (g_discoveredDevices.empty()) {
+        displayWarning("No connectable GATT devices found", true);
+        return;
+    }
+
+    showDiscoveredDevicesList();
+}
+
+//=============================================================================
+// Discovered Devices Interactive List (Compact / FP Font)
+//=============================================================================
+
+static void showDiscoveredDevicesList() {
+    int cursor = 0;
+
+    while (true) {
+        if (g_discoveredDevices.empty()) {
+            displayWarning("No devices in list", true);
+            return;
+        }
+
+        int totalCount = (int)g_discoveredDevices.size() + 3; // devices + Rescan + Auto-Dump + Back
+        int devCount = (int)g_discoveredDevices.size();
+
+        auto drawer = [devCount](int idx, int x, int y, int w, bool sel) {
+            uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+            uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+            tft.setTextColor(fg, bg);
+            tft.setTextSize(FP);
+
+            if (idx < devCount) {
+                const auto &d = g_discoveredDevices[idx];
+                // Draw RSSI bars
+                gattDrawRssi(x, y, d.rssi, fg);
+                int textX = x + 16;
+                int textW = w - 16;
+
+                String typeTag = (d.addressType == BLE_ADDR_PUBLIC) ? "P" : "R";
+                String label = "[" + d.tag + ":" + typeTag + "] " + d.name + " " + String(d.rssi) + "dBm";
+                tft.drawString(gattFitText(label, textW), textX, y, 1);
+            } else if (idx == devCount) {
+                tft.drawString("> Rescan Devices", x, y, 1);
+            } else if (idx == devCount + 1) {
+                tft.drawString("> Auto-Dump All to SD", x, y, 1);
+            } else if (idx == devCount + 2) {
+                tft.drawString("< Back to GATT Menu", x, y, 1);
+            }
+        };
+
+        int chosen = gattListLoop("GATT TARGETS", totalCount, "SEL explore  ESC back", drawer, &cursor);
+
+        if (chosen < 0 || chosen == devCount + 2) {
+            break;
+        } else if (chosen == devCount) {
+            runContinuousScan(g_currentFilter);
+        } else if (chosen == devCount + 1) {
+            runAutoDumpAll();
+        } else if (chosen < devCount) {
+            exploreGattDevice(g_discoveredDevices[chosen]);
+        }
+    }
+}
+
+//=============================================================================
+// Robust Multi-Strategy GATT Connection
+//=============================================================================
+
+static bool gattConnectWithStrategies(const NimBLEAddress &target, NimBLEClient **outClient, int *outError) {
+    if (outError) *outError = 0;
+    g_lastBleDisconnectReason = 0;
+    g_lastBleError = 0;
+
+    memset(&g_lastConnDiag, 0, sizeof(g_lastConnDiag));
+    g_lastConnDiag.ownAddrType = BLE_OWN_ADDR_PUBLIC;
+    g_lastConnDiag.peerAddrType = target.getType();
+    g_lastConnDiag.phyMask = BLE_GAP_LE_PHY_1M_MASK;
+
+    BLEStateManager::initBLE("Bruce-GATT", ESP_PWR_LVL_P9);
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+    NimBLEDevice::setSecurityAuth(false, false, false);
+
+    // Prepare target addresses: primary (detected address type) and fallback (flipped address type)
+    NimBLEAddress primaryTarget = target;
+    uint8_t primaryType = target.getType();
+    uint8_t fallbackType = (primaryType == BLE_ADDR_PUBLIC) ? BLE_ADDR_RANDOM : BLE_ADDR_PUBLIC;
+    ble_addr_t flippedAddr = *target.getBase();
+    flippedAddr.type = fallbackType;
+    NimBLEAddress fallbackTarget(flippedAddr);
+
+    struct StrategyConfig {
+        const char *name;
+        const NimBLEAddress *targetAddr;
+        bool useCustomParams;
+        uint16_t itvlMin;
+        uint16_t itvlMax;
+        uint16_t latency;
+        uint16_t timeout;
+        uint16_t scanItvl;
+        uint16_t scanWin;
+    };
+
+    const StrategyConfig strategies[] = {
+        // Strategy 1: Primary target address type with native ESP-IDF / NimBLE stack defaults (best controller compatibility)
+        {"Primary [Stack Native Defaults]", &primaryTarget, false, 0, 0, 0, 0, 0, 0},
+        // Strategy 2: Fallback target address type with native stack defaults
+        {"Fallback [Flipped Type Defaults]", &fallbackTarget, false, 0, 0, 0, 0, 0, 0},
+        // Strategy 3: Primary target with relaxed smartphone timing (30ms - 50ms)
+        {"Primary [Relaxed 30-50ms]", &primaryTarget, true, 24, 40, 0, 500, 32, 16},
+        // Strategy 4: Fallback target with relaxed smartphone timing (30ms - 50ms)
+        {"Fallback [Flipped Type 30-50ms]", &fallbackTarget, true, 24, 40, 0, 500, 32, 16},
+    };
+
+    const size_t totalStrats = sizeof(strategies) / sizeof(strategies[0]);
+    g_lastConnDiag.totalStrategies = (int)totalStrats;
+
+    Serial.println(F("\n=================================================="));
+    Serial.printf("[BLE-DBG] Starting GATT Connection Handshake Sequence\n");
+    Serial.printf("[BLE-DBG] Target MAC: %s (%s)\n", target.toString().c_str(), (primaryType == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM");
+    Serial.printf("[BLE-DBG] Local Own Addr Type: %s (MAC: %s)\n",
+                  (NimBLEDevice::getAddress().getType() == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM",
+                  NimBLEDevice::getAddress().toString().c_str());
+#if CONFIG_BT_NIMBLE_EXT_ADV
+    Serial.printf("[BLE-DBG] PHY Control: Forced LE 1M PHY (0x%02X)\n", BLE_GAP_LE_PHY_1M_MASK);
+#endif
+    Serial.println(F("=================================================="));
+
+    int lastErr = 0;
+
+    for (size_t i = 0; i < totalStrats; i++) {
+        if (check(EscPress)) {
+            Serial.println(F("[BLE-DBG] Aborted by user keypress."));
+            if (outError) *outError = lastErr;
+            return false;
+        }
+
+        const auto &strat = strategies[i];
+        g_lastConnDiag.strategyTried = (int)i + 1;
+        g_lastConnDiag.peerAddrType = strat.targetAddr->getType();
+        g_lastConnDiag.itvlMin = strat.itvlMin;
+        g_lastConnDiag.itvlMax = strat.itvlMax;
+        g_lastConnDiag.latency = strat.latency;
+        g_lastConnDiag.timeout = strat.timeout;
+        g_lastConnDiag.scanItvl = strat.scanItvl;
+        g_lastConnDiag.scanWin = strat.scanWin;
+
+        NimBLEClient *pClient = NimBLEDevice::createClient();
+        if (!pClient) {
+            lastErr = 0x107;
+            g_lastConnDiag.lastErrorCode = 0x107;
+            continue;
+        }
+
+#if CONFIG_BT_NIMBLE_EXT_ADV
+        // Enforce pure 1M PHY connection on ESP32-S3 builds to prevent Extended Multi-PHY rejection
+        pClient->setConnectPhy(BLE_GAP_LE_PHY_1M_MASK);
+#endif
+
+        NimBLEClient::Config cfg = pClient->getConfig();
+        cfg.exchangeMTU = 0; // Decouple immediate ATT MTU exchange
+        cfg.connectFailRetries = 1;
+        pClient->setConfig(cfg);
+
+        pClient->setClientCallbacks(&g_gattClientCallbacks, false);
+        pClient->setConnectTimeout((g_gattSettings.timeoutSec > 0 ? g_gattSettings.timeoutSec : 5) * 1000);
+
+        if (strat.useCustomParams) {
+            pClient->setConnectionParams(strat.itvlMin, strat.itvlMax, strat.latency, strat.timeout, strat.scanItvl, strat.scanWin);
+        }
+
+        Serial.printf("[BLE-DBG] [Strat %d/%d] %s -> Target: %s (%s)\n",
+                      (int)i + 1, (int)totalStrats, strat.name,
+                      strat.targetAddr->toString().c_str(),
+                      (strat.targetAddr->getType() == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM");
+        if (strat.useCustomParams) {
+            Serial.printf("[BLE-DBG]   Params: itvl=%.2f-%.2fms lat=%d tmo=%dms scanItvl=%.2fms scanWin=%.2fms\n",
+                          strat.itvlMin * 1.25f, strat.itvlMax * 1.25f, strat.latency, strat.timeout * 10,
+                          strat.scanItvl * 0.625f, strat.scanWin * 0.625f);
+        } else {
+            Serial.printf("[BLE-DBG]   Params: Stack Native Defaults\n");
+        }
+
+        // Explicitly pass exchangeMTU = false so it doesn't trigger immediate ATT MTU request on connection
+        if (pClient->connect(*strat.targetAddr, true, false, false)) {
+            Serial.printf("[BLE-DBG] >>> SUCCESS with Strat %d: %s <<<\n\n", (int)i + 1, strat.name);
+            *outClient = pClient;
+            return true;
+        }
+
+        int err = pClient->getLastError();
+        if (err == 0 && g_lastBleDisconnectReason != 0) err = g_lastBleDisconnectReason;
+        if (err == 0 && g_lastBleError != 0) err = g_lastBleError;
+        if (err != 0) lastErr = err;
+        g_lastConnDiag.lastErrorCode = lastErr;
+
+        NimBLEDevice::deleteClient(pClient);
+        pClient = nullptr;
+
+        // Delay briefly between strategies before the next attempt
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+    }
+
+    if (outError) *outError = lastErr;
+    Serial.printf("[BLE-DBG] Connection sequence FAILED. Final Code: 0x%02X (%d)\n\n", lastErr, lastErr);
+    return false;
+}
+
+//=============================================================================
+// On-Screen Connection Diagnostics Display
+//=============================================================================
+
+static void showBleConnectDiagnostics(const BleConnDiagInfo &diag, const GattScannedDevice &device) {
+    drawMainBorderWithTitle("BLE CONNECT DIAG");
+    tft.setTextSize(FP);
+
+    int y = BORDER_PAD_Y + 16;
+    const int step = 11;
+
+    // Status Code & Error description
+    tft.setTextColor(TFT_RED, bruceConfig.bgColor);
+    String codeStr = "Code: 0x" + String(diag.lastErrorCode, HEX) + " (" + String(diag.lastErrorCode) + ")";
+    tft.drawString(codeStr, BORDER_PAD_X, y); y += step;
+    tft.drawString(gattFitText(getBleErrorDescription(diag.lastErrorCode), tftWidth - 2 * BORDER_PAD_X), BORDER_PAD_X, y); y += step + 2;
+
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    tft.drawString("Target: " + gattFitText(device.name, tftWidth - 2 * BORDER_PAD_X), BORDER_PAD_X, y); y += step;
+    tft.drawString("MAC:    " + String(device.address.toString().c_str()), BORDER_PAD_X, y); y += step;
+
+    String typeLine = "Peer: " + String((device.addressType == BLE_ADDR_PUBLIC) ? "PUB" : "RND") +
+                      "  Own: " + String((diag.ownAddrType == BLE_ADDR_PUBLIC) ? "PUB" : "RND");
+    tft.drawString(typeLine, BORDER_PAD_X, y); y += step;
+
+#if CONFIG_BT_NIMBLE_EXT_ADV
+    String phyLine = "PHY: LE 1M (Forced S3)  RSSI: " + String(device.rssi) + "dBm";
+#else
+    String phyLine = "PHY: LE 1M (Legacy)  RSSI: " + String(device.rssi) + "dBm";
+#endif
+    tft.drawString(phyLine, BORDER_PAD_X, y); y += step;
+
+    String paramLine = "Int: " + String(diag.itvlMin * 5 / 4) + "-" + String(diag.itvlMax * 5 / 4) + "ms Tmo:" + String(diag.timeout * 10) + "ms";
+    tft.drawString(paramLine, BORDER_PAD_X, y); y += step;
+
+    String stratLine = "Strat tried: " + String(diag.strategyTried) + "/" + String(diag.totalStrategies) + " [Failed]";
+    tft.drawString(stratLine, BORDER_PAD_X, y); y += step + 3;
+
+    tft.setTextColor(bruceConfig.secColor, bruceConfig.bgColor);
+    tft.drawCentreString("Press SEL or ESC to return", tftWidth / 2, tftHeight - BORDER_PAD_Y - 9, 1);
+
+    while (true) {
+        if (check(EscPress) || check(SelPress) || check(PrevPress) || check(NextPress)) {
+            break;
+        }
+        vTaskDelay(20 / portTICK_PERIOD_MS);
+    }
+}
+
+//=============================================================================
+// GATT Device Exploration & Connection
+//=============================================================================
+
+static void exploreGattDevice(GattScannedDevice &device) {
+    drawMainBorderWithTitle("GATT CONNECTING");
+    tft.setTextSize(FP);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+
+    int rowY = BORDER_PAD_Y + 16;
+    const int step = 11;
+    tft.drawString("Target: " + gattFitText(device.name, tftWidth - 20), BORDER_PAD_X, rowY); rowY += step;
+    tft.drawString("MAC:    " + String(device.address.toString().c_str()), BORDER_PAD_X, rowY); rowY += step;
+    tft.drawString("Type:   " + String((device.addressType == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM"), BORDER_PAD_X, rowY); rowY += step;
+    tft.drawString("Signal: " + String(device.rssi) + " dBm", BORDER_PAD_X, rowY); rowY += step + 2;
+    tft.drawString("Connecting to GATT server...", BORDER_PAD_X, rowY);
+
+    NimBLEClient *pClient = nullptr;
+    int connError = 0;
+    bool connected = gattConnectWithStrategies(device.address, &pClient, &connError);
+
+    if (!connected || !pClient) {
+        showBleConnectDiagnostics(g_lastConnDiag, device);
+        return;
+    }
+
+    tft.drawString("Connected! Discovering attributes...", BORDER_PAD_X, rowY + step);
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+
+    pClient->discoverAttributes();
+
+    const auto &services = pClient->getServices(true);
+    if (services.empty()) {
+        displayWarning("No GATT services exposed", true);
+        pClient->disconnect();
+        NimBLEDevice::deleteClient(pClient);
+        return;
+    }
+
+    displaySuccess("Found " + String((int)services.size()) + " services!");
+    delay(300);
+
+    // Device Operation Menu
+    int devCursor = 0;
+    while (pClient->isConnected()) {
+        std::vector<GattMenuItem> devOps;
+
+        devOps.push_back({"1. Browse Services & Chars", [pClient, &device]() {
+            browseServicesAndChars(pClient, device);
+        }});
+
+        devOps.push_back({"2. Read Device Info & Batt", [pClient]() {
+            readStandardDeviceInfo(pClient);
+        }});
+
+        devOps.push_back({"3. Dump GATT Tree to Storage", [pClient, &device]() {
+            String path;
+            if (dumpDeviceGattToStorage(pClient, device, &path)) {
+                displaySuccess("Saved: " + path, true);
+            } else {
+                displayError("Dump failed", true);
+            }
+        }});
+
+        devOps.push_back({"4. Disconnect & Back", [pClient]() {
+            if (pClient->isConnected()) pClient->disconnect();
+        }});
+
+        int sel = gattMenu(device.name.c_str(), devOps, "SEL choose  ESC back", &devCursor);
+        if (sel == -1 || sel == (int)devOps.size() - 1 || !pClient->isConnected()) {
+            break;
+        }
+    }
+
+    if (pClient->isConnected()) {
+        pClient->disconnect();
+    }
+    NimBLEDevice::deleteClient(pClient);
+    delay(50);
+}
+
+//=============================================================================
+// Hierarchical Services & Characteristics Browser (Compact / FP Font)
+//=============================================================================
+
+static void browseServicesAndChars(NimBLEClient *pClient, const GattScannedDevice &device) {
+    if (!pClient || !pClient->isConnected()) {
+        displayError("Device disconnected", true);
+        return;
+    }
+
+    int serviceCursor = 0;
+
+    while (pClient->isConnected()) {
+        const auto &services = pClient->getServices(true);
+        if (services.empty()) {
+            displayWarning("No services found", true);
+            return;
+        }
+
+        int srvCount = (int)services.size();
+        int totalCount = srvCount + 1; // services + back
+
+        auto srvDrawer = [&services, srvCount](int idx, int x, int y, int w, bool sel) {
+            uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+            uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+            tft.setTextColor(fg, bg);
+            tft.setTextSize(FP);
+
+            if (idx < srvCount) {
+                NimBLERemoteService *srv = services[idx];
+                String uStr = String(srv->getUUID().toString().c_str());
+                String sName = getGattServiceName(uStr);
+                String label = "[" + String(idx + 1) + "] " + sName;
+                tft.drawString(gattFitText(label, w), x, y, 1);
+            } else {
+                tft.drawString("< Back to Device Menu", x, y, 1);
+            }
+        };
+
+        int chosenSrv = gattListLoop("GATT SERVICES", totalCount, "SEL view chars  ESC back", srvDrawer, &serviceCursor);
+        if (chosenSrv < 0 || chosenSrv == srvCount) {
+            break;
+        }
+
+        NimBLERemoteService *selectedSrv = services[chosenSrv];
+        String sUStr = String(selectedSrv->getUUID().toString().c_str());
+        String sName = getGattServiceName(sUStr);
+
+        int charCursor = 0;
+
+        // Browse characteristics of selected service
+        while (pClient->isConnected()) {
+            const auto &chars = selectedSrv->getCharacteristics(true);
+            if (chars.empty()) {
+                displayWarning("No characteristics in service", true);
+                break;
+            }
+
+            int charCount = (int)chars.size();
+            int charTotalCount = charCount + 1;
+
+            auto charDrawer = [&chars, charCount](int idx, int x, int y, int w, bool sel) {
+                uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+                uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+                tft.setTextColor(fg, bg);
+                tft.setTextSize(FP);
+
+                if (idx < charCount) {
+                    NimBLERemoteCharacteristic *ch = chars[idx];
+                    String cuStr = String(ch->getUUID().toString().c_str());
+                    String cName = getGattCharName(cuStr);
+
+                    String flags = "";
+                    if (ch->canRead()) flags += "R";
+                    if (ch->canWrite() || ch->canWriteNoResponse()) flags += "W";
+                    if (ch->canNotify()) flags += "N";
+                    if (ch->canIndicate()) flags += "I";
+
+                    String cLabel = cName;
+                    if (flags.length() > 0) cLabel += " [" + flags + "]";
+                    tft.drawString(gattFitText(cLabel, w), x, y, 1);
+                } else {
+                    tft.drawString("< Back to Services", x, y, 1);
+                }
+            };
+
+            int chosenChar = gattListLoop(sName.c_str(), charTotalCount, "SEL actions  ESC back", charDrawer, &charCursor);
+            if (chosenChar < 0 || chosenChar == charCount) {
+                break;
+            }
+
+            handleCharacteristicActions(pClient, chars[chosenChar], sName);
+        }
+    }
+}
+
+//=============================================================================
+// Characteristic Actions (Read / Write / Live Notify / Details)
+//=============================================================================
+
+static void handleCharacteristicActions(NimBLEClient *pClient, NimBLERemoteCharacteristic *pChar, const String &serviceName) {
+    if (!pChar || !pClient) return;
+
+    String cuStr = String(pChar->getUUID().toString().c_str());
+    String cName = getGattCharName(cuStr);
+    int actCursor = 0;
+
+    while (pClient->isConnected()) {
+        std::vector<GattMenuItem> actOptions;
+
+        if (pChar->canRead()) {
+            actOptions.push_back({"1. Read Value", [pChar, cName, cuStr]() {
+                NimBLEAttValue val = pChar->readValue();
+
+                std::vector<String> lines;
+                lines.push_back("Name: " + cName);
+                lines.push_back("UUID: " + cuStr);
+                lines.push_back("Size: " + String(val.size()) + " bytes");
+                lines.push_back("");
+
+                if (val.size() == 0) {
+                    lines.push_back("[Value is empty / 0 bytes]");
+                } else {
+                    lines.push_back("--- HEX ---");
+                    String hexStr = "";
+                    for (size_t i = 0; i < val.size(); i++) {
+                        if (val[i] < 0x10) hexStr += "0";
+                        hexStr += String(val[i], HEX) + " ";
+                        if ((i + 1) % 8 == 0 && i < val.size() - 1) {
+                            lines.push_back(hexStr);
+                            hexStr = "";
+                        }
+                    }
+                    if (hexStr.length() > 0) lines.push_back(hexStr);
+
+                    lines.push_back("");
+                    lines.push_back("--- ASCII ---");
+                    String asciiStr = "";
+                    for (size_t i = 0; i < val.size(); i++) {
+                        char c = (char)val[i];
+                        asciiStr += (c >= 32 && c <= 126) ? c : '.';
+                    }
+                    lines.push_back(asciiStr);
+                }
+
+                gattShowScrollableReport("CHAR READ", lines);
+            }});
+        }
+
+        if (pChar->canWrite() || pChar->canWriteNoResponse()) {
+            actOptions.push_back({"2. Write String", [pChar]() {
+                String input = keyboard("", 64, "Input String to Write:");
+                if (input != "\x1B" && input.length() > 0) {
+                    bool ok = pChar->writeValue((const uint8_t *)input.c_str(), input.length(), pChar->canWrite());
+                    if (ok) displaySuccess("Written: " + String(input.length()) + " B", true);
+                    else displayError("Write failed", true);
+                }
+            }});
+
+            actOptions.push_back({"3. Write Hex Bytes", [pChar]() {
+                String hexIn = hex_keyboard("", 64, "Input Hex Bytes (e.g. 0102FF):");
+                if (hexIn != "\x1B" && hexIn.length() > 0) {
+                    hexIn.replace(" ", "");
+                    hexIn.replace(":", "");
+                    if (hexIn.length() % 2 != 0) hexIn = "0" + hexIn;
+
+                    std::vector<uint8_t> bytes;
+                    for (size_t i = 0; i < hexIn.length(); i += 2) {
+                        String byteHex = hexIn.substring(i, i + 2);
+                        uint8_t b = (uint8_t)strtol(byteHex.c_str(), nullptr, 16);
+                        bytes.push_back(b);
+                    }
+
+                    if (!bytes.empty()) {
+                        bool ok = pChar->writeValue(bytes.data(), bytes.size(), pChar->canWrite());
+                        if (ok) displaySuccess("Written " + String((int)bytes.size()) + " hex bytes", true);
+                        else displayError("Hex write failed", true);
+                    }
+                }
+            }});
+        }
+
+        if (pChar->canNotify() || pChar->canIndicate()) {
+            actOptions.push_back({"4. Live Notify Stream", [pChar, cName]() {
+                drawMainBorderWithTitle("LIVE STREAM");
+                tft.setTextSize(FP);
+                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+
+                tft.drawString("Stream: " + gattFitText(cName, tftWidth - 20), BORDER_PAD_X, BORDER_PAD_Y + 12);
+                tft.drawString("Press [SEL] or [ESC] to stop", BORDER_PAD_X, BORDER_PAD_Y + 24);
+                tft.drawFastHLine(BORDER_PAD_X, BORDER_PAD_Y + 36, tftWidth - 2 * BORDER_PAD_X, bruceConfig.priColor);
+
+                static int s_notifyCount = 0;
+                static String s_lastNotifyData = "";
+                s_notifyCount = 0;
+
+                bool subOk = pChar->subscribe(true, [](NimBLERemoteCharacteristic *chr, uint8_t *pData, size_t length, bool isNotify) {
+                    s_notifyCount = s_notifyCount + 1;
+                    String hex = "";
+                    String ascii = "";
+                    for (size_t i = 0; i < length; i++) {
+                        if (pData[i] < 0x10) hex += "0";
+                        hex += String(pData[i], HEX) + " ";
+                        char c = (char)pData[i];
+                        ascii += (c >= 32 && c <= 126) ? c : '.';
+                    }
+                    s_lastNotifyData = "#" + String(s_notifyCount) + " [" + String(length) + "B]: " + hex;
+                });
+
+                if (!subOk) {
+                    displayError("Subscription failed", true);
+                    return;
+                }
+
+                int lastPrintedCount = 0;
+                int lineY = BORDER_PAD_Y + 42;
+                while (true) {
+                    if (check(EscPress) || check(SelPress)) break;
+
+                    if (s_notifyCount != lastPrintedCount) {
+                        lastPrintedCount = s_notifyCount;
+                        tft.fillRect(BORDER_PAD_X, lineY, tftWidth - 2 * BORDER_PAD_X, 10 * FP, bruceConfig.bgColor);
+                        tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                        tft.drawString(gattFitText(s_lastNotifyData, tftWidth - 2 * BORDER_PAD_X), BORDER_PAD_X, lineY);
+
+                        lineY += 12;
+                        if (lineY > tftHeight - 20) {
+                            lineY = BORDER_PAD_Y + 42;
+                            tft.fillRect(BORDER_PAD_X, lineY, tftWidth - 2 * BORDER_PAD_X, tftHeight - lineY - 18, bruceConfig.bgColor);
+                        }
+                    }
+                    vTaskDelay(30 / portTICK_PERIOD_MS);
+                }
+
+                pChar->unsubscribe();
+                displaySuccess("Unsubscribed", true);
+            }});
+        }
+
+        actOptions.push_back({"5. Characteristic Details", [pChar, cName, cuStr]() {
+            std::vector<String> lines;
+            lines.push_back("Name:     " + cName);
+            lines.push_back("UUID:     " + cuStr);
+            lines.push_back("Handle:   0x" + String(pChar->getHandle(), HEX));
+            lines.push_back("Read:     " + String(pChar->canRead() ? "YES" : "NO"));
+            lines.push_back("Write:    " + String(pChar->canWrite() ? "YES" : "NO"));
+            lines.push_back("WriteNR:  " + String(pChar->canWriteNoResponse() ? "YES" : "NO"));
+            lines.push_back("Notify:   " + String(pChar->canNotify() ? "YES" : "NO"));
+            lines.push_back("Indicate: " + String(pChar->canIndicate() ? "YES" : "NO"));
+
+            gattShowScrollableReport("CHAR DETAILS", lines);
+        }});
+
+        actOptions.push_back({"< Back to Characteristics", []() {}});
+
+        int actSel = gattMenu(cName.c_str(), actOptions, "SEL choose  ESC back", &actCursor);
+        if (actSel == -1 || actSel == (int)actOptions.size() - 1 || !pClient->isConnected()) {
+            break;
+        }
+    }
+}
+
+//=============================================================================
+// Read Standard Device Information (DIS 0x180A) & Battery (0x180F)
+//=============================================================================
+
+static void readStandardDeviceInfo(NimBLEClient *pClient) {
+    if (!pClient || !pClient->isConnected()) {
+        displayError("Not connected", true);
+        return;
+    }
+
+    drawMainBorderWithTitle("DEVICE REPORT");
+    tft.setTextSize(FP);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+    tft.drawString("Querying Device Information...", BORDER_PAD_X, BORDER_PAD_Y + 16);
+
+    String manufacturer = "N/A";
+    String model = "N/A";
+    String serial = "N/A";
+    String firmware = "N/A";
+    String hardware = "N/A";
+    String battery = "N/A";
+
+    NimBLERemoteService *pDis = pClient->getService(NimBLEUUID((uint16_t)0x180A));
+    if (pDis) {
+        NimBLERemoteCharacteristic *cMfr = pDis->getCharacteristic(NimBLEUUID((uint16_t)0x2A29));
+        if (cMfr && cMfr->canRead()) manufacturer = String(cMfr->readValue().c_str());
+
+        NimBLERemoteCharacteristic *cMod = pDis->getCharacteristic(NimBLEUUID((uint16_t)0x2A24));
+        if (cMod && cMod->canRead()) model = String(cMod->readValue().c_str());
+
+        NimBLERemoteCharacteristic *cSer = pDis->getCharacteristic(NimBLEUUID((uint16_t)0x2A25));
+        if (cSer && cSer->canRead()) serial = String(cSer->readValue().c_str());
+
+        NimBLERemoteCharacteristic *cFw = pDis->getCharacteristic(NimBLEUUID((uint16_t)0x2A26));
+        if (cFw && cFw->canRead()) firmware = String(cFw->readValue().c_str());
+
+        NimBLERemoteCharacteristic *cHw = pDis->getCharacteristic(NimBLEUUID((uint16_t)0x2A27));
+        if (cHw && cHw->canRead()) hardware = String(cHw->readValue().c_str());
+    }
+
+    NimBLERemoteService *pBatt = pClient->getService(NimBLEUUID((uint16_t)0x180F));
+    if (pBatt) {
+        NimBLERemoteCharacteristic *cBatt = pBatt->getCharacteristic(NimBLEUUID((uint16_t)0x2A19));
+        if (cBatt && cBatt->canRead()) {
+            NimBLEAttValue v = cBatt->readValue();
+            if (v.size() > 0) battery = String((int)v[0]) + "%";
+        }
+    }
+
+    std::vector<String> lines;
+    lines.push_back("Manufacturer: " + manufacturer);
+    lines.push_back("Model Number: " + model);
+    lines.push_back("Serial Num:   " + serial);
+    lines.push_back("Firmware Rev: " + firmware);
+    lines.push_back("Hardware Rev: " + hardware);
+    lines.push_back("Battery Lvl:  " + battery);
+
+    gattShowScrollableReport("DEVICE REPORT", lines);
+}
+
+//=============================================================================
+// Dump GATT Tree to SD / LittleFS
+//=============================================================================
+
+static bool dumpDeviceGattToStorage(NimBLEClient *pClient, const GattScannedDevice &device, String *outFilePath) {
+    if (!pClient || !pClient->isConnected()) return false;
+
+    FS *fs;
+    String storageType = "";
+    if (getFsStorage(fs) && fs == &SD) {
+        storageType = "SD";
+    } else if (setupLittleFS()) {
+        fs = &LittleFS;
+        storageType = "LittleFS";
+    }
+
+    if (!fs || storageType.isEmpty()) return false;
+
+    if (!fs->exists("/ble_dumps")) fs->mkdir("/ble_dumps");
+
+    String cleanMac = String(device.address.toString().c_str());
+    cleanMac.replace(":", "");
+    String filepath = "/ble_dumps/GATT_" + cleanMac + ".txt";
+
+    File file = fs->open(filepath, FILE_WRITE);
+    if (!file) return false;
+
+    file.println("==================================================");
+    file.println("BRUCE GATT EXPLORER DUMP");
+    file.println("==================================================");
+    file.println("Device Name: " + device.name);
+    file.println("Address:     " + String(device.address.toString().c_str()));
+    file.println("Addr Type:   " + String((device.addressType == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM"));
+    file.println("RSSI:        " + String(device.rssi) + " dBm");
+    file.println("Dump Time:   " + String(millis()) + " ms");
+    file.println("==================================================\n");
+
+    const auto &services = pClient->getServices(true);
+    for (size_t s = 0; s < services.size(); s++) {
+        NimBLERemoteService *srv = services[s];
+        String sUStr = String(srv->getUUID().toString().c_str());
+        String sName = getGattServiceName(sUStr);
+
+        file.printf("[%d] SERVICE: %s (UUID: %s)\n", (int)(s + 1), sName.c_str(), sUStr.c_str());
+
+        const auto &chars = srv->getCharacteristics(true);
+        for (size_t c = 0; c < chars.size(); c++) {
+            NimBLERemoteCharacteristic *ch = chars[c];
+            String cuStr = String(ch->getUUID().toString().c_str());
+            String cName = getGattCharName(cuStr);
+
+            String flags = "";
+            if (ch->canRead()) flags += "READ ";
+            if (ch->canWrite()) flags += "WRITE ";
+            if (ch->canWriteNoResponse()) flags += "WRITE_NR ";
+            if (ch->canNotify()) flags += "NOTIFY ";
+            if (ch->canIndicate()) flags += "INDICATE ";
+            flags.trim();
+
+            file.printf("    - CHAR: %s (UUID: %s) [0x%04X] [%s]\n", cName.c_str(), cuStr.c_str(), ch->getHandle(), flags.c_str());
+
+            if (ch->canRead()) {
+                NimBLEAttValue val = ch->readValue();
+                if (val.size() > 0) {
+                    String hexStr = "";
+                    String ascStr = "";
+                    for (size_t b = 0; b < val.size(); b++) {
+                        if (val[b] < 0x10) hexStr += "0";
+                        hexStr += String(val[b], HEX) + " ";
+                        char chChar = (char)val[b];
+                        ascStr += (chChar >= 32 && chChar <= 126) ? chChar : '.';
+                    }
+                    file.printf("        HEX: %s\n", hexStr.c_str());
+                    file.printf("        ASC: \"%s\"\n", ascStr.c_str());
+                } else {
+                    file.println("        VAL: [0 bytes]");
+                }
+            }
+        }
+        file.println("");
+    }
+
+    file.println("==================================================");
+    file.println("END OF DUMP");
+    file.println("==================================================");
+    file.close();
+
+    if (outFilePath) *outFilePath = storageType + ":" + filepath;
+    return true;
+}
+
+//=============================================================================
+// Auto-Dump All Discovered Devices
+//=============================================================================
+
+static void runAutoDumpAll() {
+    if (g_discoveredDevices.empty()) {
+        displayWarning("No devices discovered to dump", true);
+        return;
+    }
+
+    drawMainBorderWithTitle("AUTO-DUMP ALL");
+    tft.setTextSize(FP);
+    tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+
+    int total = g_discoveredDevices.size();
+    int successCount = 0;
+    int lineY = BORDER_PAD_Y + 14;
+
+    for (int i = 0; i < total; i++) {
+        if (check(EscPress)) {
+            tft.drawString("Aborted by user.", BORDER_PAD_X, lineY);
+            break;
+        }
+
+        const auto &dev = g_discoveredDevices[i];
+        String progress = "[" + String(i + 1) + "/" + String(total) + "] " + dev.name;
+        tft.drawString(gattFitText(progress, tftWidth - 20), BORDER_PAD_X, lineY);
+        lineY += 12;
+
+        NimBLEClient *pClient = nullptr;
+        bool connected = gattConnectWithStrategies(dev.address, &pClient, nullptr);
+        if (connected && pClient) {
+            vTaskDelay(100 / portTICK_PERIOD_MS);
+            pClient->discoverAttributes();
+            String path;
+            if (dumpDeviceGattToStorage(pClient, dev, &path)) {
+                successCount++;
+            }
+            pClient->disconnect();
+            NimBLEDevice::deleteClient(pClient);
+        }
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+
+        if (lineY > tftHeight - 24) {
+            lineY = BORDER_PAD_Y + 14;
+            tft.fillRect(BORDER_PAD_X, lineY, tftWidth - 2 * BORDER_PAD_X, tftHeight - lineY - 14, bruceConfig.bgColor);
+        }
+    }
+
+    std::vector<String> lines;
+    lines.push_back("Auto-Dump Finished!");
+    lines.push_back("Success: " + String(successCount) + " / " + String(total) + " devices");
+    lines.push_back("Files saved in: /ble_dumps/");
+
+    gattShowScrollableReport("AUTO-DUMP SUMMARY", lines);
+}
+
+//=============================================================================
+// Settings Menu (Compact / FP Font)
+//=============================================================================
+
+static void gattSettingsMenu() {
+    int cursor = 0;
+    while (true) {
+        std::vector<GattMenuItem> setOptions;
+
+        String rssiLabel = "1. Min RSSI: " + ((g_gattSettings.minRssi <= -95) ? String("None (-95dBm)") : String(g_gattSettings.minRssi) + " dBm");
+        setOptions.push_back({rssiLabel, []() {
+            if (g_gattSettings.minRssi <= -95) g_gattSettings.minRssi = -85;
+            else if (g_gattSettings.minRssi == -85) g_gattSettings.minRssi = -75;
+            else if (g_gattSettings.minRssi == -75) g_gattSettings.minRssi = -65;
+            else g_gattSettings.minRssi = -95;
+        }});
+
+        String toLabel = "2. Timeout: " + String(g_gattSettings.timeoutSec) + " sec";
+        setOptions.push_back({toLabel, []() {
+            if (g_gattSettings.timeoutSec == 3) g_gattSettings.timeoutSec = 5;
+            else if (g_gattSettings.timeoutSec == 5) g_gattSettings.timeoutSec = 8;
+            else if (g_gattSettings.timeoutSec == 8) g_gattSettings.timeoutSec = 12;
+            else g_gattSettings.timeoutSec = 3;
+        }});
+
+        String addrLabel = "3. Addr Type: ";
+        if (g_gattSettings.addrTypeFilter == 0) addrLabel += "Any";
+        else if (g_gattSettings.addrTypeFilter == 1) addrLabel += "Public Only";
+        else addrLabel += "Random Only";
+        setOptions.push_back({addrLabel, []() {
+            g_gattSettings.addrTypeFilter = (g_gattSettings.addrTypeFilter + 1) % 3;
+        }});
+
+        String maxLabel = "4. Max Devices (RSSI): " + String(g_gattSettings.maxDevices) + " dev";
+        setOptions.push_back({maxLabel, []() {
+            if (g_gattSettings.maxDevices == 20) g_gattSettings.maxDevices = 40;
+            else if (g_gattSettings.maxDevices == 40) g_gattSettings.maxDevices = 60;
+            else if (g_gattSettings.maxDevices == 60) g_gattSettings.maxDevices = 80;
+            else g_gattSettings.maxDevices = 20;
+
+            if (g_discoveredDevices.size() > (size_t)g_gattSettings.maxDevices) {
+                std::sort(g_discoveredDevices.begin(), g_discoveredDevices.end(), [](const GattScannedDevice &a, const GattScannedDevice &b) {
+                    return a.rssi > b.rssi;
+                });
+                g_discoveredDevices.resize(g_gattSettings.maxDevices);
+            }
+        }});
+
+        setOptions.push_back({"< Back to GATT Menu", []() {}});
+
+        int sel = gattMenu("GATT SETTINGS", setOptions, "SEL toggle  ESC back", &cursor);
+        if (sel == -1 || sel == (int)setOptions.size() - 1) {
+            break;
+        }
+    }
+}
+
+//=============================================================================
+// Main GATT Explorer Menu (Compact / FP Font)
+//=============================================================================
+
+void gattExplorerMenu() {
+    int cursor = 0;
+    while (true) {
+        std::vector<GattMenuItem> menuOps;
+
+        menuOps.push_back({"1. Scan Connectable (Live)", [=]() {
+            runContinuousScan(FILTER_CONNECTABLE);
+        }});
+
+        menuOps.push_back({"2. Filter by Service", [=]() {
+            int fltCursor = 0;
+            while (true) {
+                std::vector<GattMenuItem> fltOps;
+                fltOps.push_back({"1. All Connectable", [=]() { runContinuousScan(FILTER_CONNECTABLE); }});
+                fltOps.push_back({"2. With Advertised Services", [=]() { runContinuousScan(FILTER_WITH_SERVICES); }});
+                fltOps.push_back({"3. HID / Input (0x1812)", [=]() { runContinuousScan(FILTER_HID); }});
+                fltOps.push_back({"4. Serial / NUS / UART", [=]() { runContinuousScan(FILTER_UART); }});
+                fltOps.push_back({"5. Audio / Media (0x110E)", [=]() { runContinuousScan(FILTER_AUDIO); }});
+                fltOps.push_back({"6. Sensors / Health (0x180D)", [=]() { runContinuousScan(FILTER_SENSORS); }});
+                fltOps.push_back({"7. Custom 128-bit UUIDs", [=]() { runContinuousScan(FILTER_CUSTOM_128); }});
+                fltOps.push_back({"< Back", []() {}});
+
+                int sel = gattMenu("SERVICE FILTERS", fltOps, "SEL choose  ESC back", &fltCursor);
+                if (sel == -1 || sel == (int)fltOps.size() - 1) {
+                    break;
+                }
+            }
+        }});
+
+        menuOps.push_back({"3. Auto-Dump to Storage", [=]() {
+            runAutoDumpAll();
+        }});
+
+        menuOps.push_back({"4. Settings", [=]() {
+            gattSettingsMenu();
+        }});
+
+        menuOps.push_back({"5. GATT Test Server", [=]() {
+            gattServerMenu();
+        }});
+
+        menuOps.push_back({"< Back to Bluetooth", []() {}});
+
+        int sel = gattMenu("GATT EXPLORER", menuOps, "SEL choose  ESC back", &cursor);
+        if (sel == -1 || sel == (int)menuOps.size() - 1) {
+            break;
+        }
+    }
+}
+
+//=============================================================================
+// CLI Automation Functions
+//=============================================================================
+
+bool gattConnectCli(const String &macStr, uint8_t addrType) {
+    NimBLEAddress target(std::string(macStr.c_str()), addrType);
+    Serial.printf("[BLE-CLI] Initiating connection to %s (%s)...\n",
+                  target.toString().c_str(),
+                  (addrType == BLE_ADDR_PUBLIC) ? "PUBLIC" : "RANDOM");
+
+    NimBLEClient *pClient = nullptr;
+    int connError = 0;
+    bool connected = gattConnectWithStrategies(target, &pClient, &connError);
+
+    if (!connected || !pClient) {
+        Serial.printf("[BLE-CLI] Connection FAILED. Code: 0x%02X (%d) -> %s\n",
+                      connError, connError, getBleErrorDescription(connError).c_str());
+        return false;
+    }
+
+    Serial.println(F("[BLE-CLI] Connected successfully! Discovering services..."));
+    if (pClient->discoverAttributes()) {
+        const auto &services = pClient->getServices(true);
+        Serial.printf("[BLE-CLI] Found %d services:\n", (int)services.size());
+        for (auto *srv : services) {
+            Serial.printf("[BLE-CLI]  + Service: %s\n", srv->getUUID().toString().c_str());
+            const auto &chars = srv->getCharacteristics(true);
+            for (auto *chr : chars) {
+                String props = "";
+                if (chr->canRead()) props += "R ";
+                if (chr->canWrite()) props += "W ";
+                if (chr->canNotify()) props += "N ";
+                if (chr->canIndicate()) props += "I ";
+                Serial.printf("[BLE-CLI]     - Char: %s [%s]\n", chr->getUUID().toString().c_str(), props.c_str());
+            }
+        }
+    } else {
+        Serial.println(F("[BLE-CLI] discoverAttributes failed or incomplete."));
+    }
+
+    Serial.println(F("[BLE-CLI] Disconnecting..."));
+    pClient->disconnect();
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+    NimBLEDevice::deleteClient(pClient);
+    Serial.println(F("[BLE-CLI] Done."));
+    return true;
+}
+
+void gattScanCli(int timeoutSec) {
+    if (timeoutSec <= 0) timeoutSec = 5;
+    Serial.printf("[BLE-CLI] Starting %d-second scan for connectable GATT devices...\n", timeoutSec);
+
+    BLEStateManager::initBLE("Bruce-GATT-Scan", ESP_PWR_LVL_P9);
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+
+    NimBLEScan *pScan = NimBLEDevice::getScan();
+    pScan->clearResults();
+    pScan->setActiveScan(true);
+    pScan->setInterval(96);
+    pScan->setWindow(48);
+
+    NimBLEScanResults results = pScan->getResults(timeoutSec * 1000, false);
+    Serial.printf("[BLE-CLI] Scan finished. Found %d devices:\n", (int)results.getCount());
+
+    for (int i = 0; i < results.getCount(); i++) {
+        const auto *dev = results.getDevice(i);
+        if (!dev) continue;
+        Serial.printf("[BLE-CLI] %2d. %s [%s] RSSI:%d dBm Name:\"%s\" Conn:%s\n",
+                      i + 1,
+                      dev->getAddress().toString().c_str(),
+                      (dev->getAddress().getType() == BLE_ADDR_PUBLIC) ? "PUB" : "RND",
+                      dev->getRSSI(),
+                      dev->getName().c_str(),
+                      dev->isConnectable() ? "YES" : "NO");
+    }
+
+    pScan->stop();
+    pScan->clearResults();
+}
+
+#endif // !LITE_VERSION

--- a/src/modules/ble/gatt_explorer.h
+++ b/src/modules/ble/gatt_explorer.h
@@ -1,0 +1,14 @@
+#ifndef GATT_EXPLORER_H
+#define GATT_EXPLORER_H
+
+#include <Arduino.h>
+
+#if !defined(LITE_VERSION)
+
+void gattExplorerMenu();
+bool gattConnectCli(const String &macStr, uint8_t addrType = 0);
+void gattScanCli(int timeoutSec = 5);
+
+#endif // !LITE_VERSION
+
+#endif // GATT_EXPLORER_H

--- a/src/modules/ble/gatt_server.cpp
+++ b/src/modules/ble/gatt_server.cpp
@@ -1,0 +1,791 @@
+#if !defined(LITE_VERSION)
+
+#include "gatt_server.h"
+#include "BLE_Suite.h"
+#include "core/display.h"
+#include "core/mykeyboard.h"
+#include "core/utils.h"
+#include <NimBLEDevice.h>
+#include <globals.h>
+#include <esp_mac.h>
+#include <algorithm>
+#include <deque>
+#include <functional>
+#include <vector>
+
+//=============================================================================
+// Constants & UUIDs
+//=============================================================================
+
+// Standard Services
+#define UUID_SVC_DIS              "180A"
+#define UUID_CHR_MFG_NAME         "2A29"
+#define UUID_CHR_MODEL_NUM        "2A24"
+#define UUID_CHR_SERIAL_NUM       "2A25"
+#define UUID_CHR_FW_REV           "2A26"
+#define UUID_CHR_HW_REV           "2A27"
+#define UUID_CHR_SW_REV           "2A28"
+
+#define UUID_SVC_BATTERY          "180F"
+#define UUID_CHR_BATTERY_LEVEL    "2A19"
+
+#define UUID_SVC_ENVIRONMENTAL    "181A"
+#define UUID_CHR_TEMPERATURE      "2A6E"
+#define UUID_CHR_HUMIDITY         "2A6F"
+
+// Custom Echo & Stream Service
+#define UUID_SVC_ECHO             "FFE0"
+#define UUID_CHR_ECHO_RW          "FFE1"
+#define UUID_CHR_STREAM_COUNT     "FFE2"
+
+// Nordic UART Service (NUS)
+#define UUID_SVC_NUS              "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
+#define UUID_CHR_NUS_RX           "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
+#define UUID_CHR_NUS_TX           "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
+
+//=============================================================================
+// State
+//=============================================================================
+
+struct GattServerState {
+    volatile bool isRunning = false;
+    volatile bool isConnected = false;
+    String peerAddress = "None";
+    uint16_t peerMtu = 23;
+    uint32_t readCount = 0;
+    uint32_t writeCount = 0;
+    uint32_t notifyCount = 0;
+    String lastWriteVal = "";
+    std::deque<String> logLines;
+    SemaphoreHandle_t logMutex = nullptr;
+
+    void initMutex() {
+        if (!logMutex) {
+            logMutex = xSemaphoreCreateMutex();
+        }
+    }
+
+    void addLog(const String &msg) {
+        initMutex();
+        if (logMutex && xSemaphoreTake(logMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+            logLines.push_back(msg);
+            while (logLines.size() > 25) {
+                logLines.pop_front();
+            }
+            xSemaphoreGive(logMutex);
+        }
+    }
+
+    void reset() {
+        isRunning = false;
+        isConnected = false;
+        peerAddress = "None";
+        peerMtu = 23;
+        readCount = 0;
+        writeCount = 0;
+        notifyCount = 0;
+        lastWriteVal = "";
+        initMutex();
+        if (logMutex && xSemaphoreTake(logMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+            logLines.clear();
+            xSemaphoreGive(logMutex);
+        }
+    }
+};
+
+static GattServerState g_srvState;
+
+// Active characteristic pointers for dynamic updates
+static NimBLECharacteristic *g_pBatChar = nullptr;
+static NimBLECharacteristic *g_pTempChar = nullptr;
+static NimBLECharacteristic *g_pHumChar = nullptr;
+static NimBLECharacteristic *g_pEchoChar = nullptr;
+static NimBLECharacteristic *g_pStreamChar = nullptr;
+static NimBLECharacteristic *g_pNusTxChar = nullptr;
+
+//=============================================================================
+// UI Layout Helpers
+//=============================================================================
+
+struct SrvUiGeom {
+    int listL, listW;
+    int top;
+    int rowH;
+    int rows;
+    int footY;
+};
+
+static SrvUiGeom srvUiGeom() {
+    SrvUiGeom g;
+    g.listL = 8;
+    g.listW = tftWidth - 16;
+    g.top = BORDER_PAD_Y + 8 * FM + 3;
+    g.footY = tftHeight - 8 * FP - 6;
+    g.rowH = 8 * FP + 5;
+    int avail = g.footY - g.top - 2;
+    if (avail < g.rowH) avail = g.rowH;
+    g.rows = avail / g.rowH;
+    if (g.rows < 1) g.rows = 1;
+    return g;
+}
+
+static uint16_t srvDimColor() {
+    return getColorVariation(bruceConfig.priColor, 8, -1);
+}
+
+static String srvFitText(const String &text, int maxPx) {
+    if (maxPx <= 0) return "";
+    tft.setTextSize(FP);
+    if (tft.textWidth(text.c_str()) <= maxPx) return text;
+    String s = text;
+    while (s.length() > 1 && tft.textWidth((s + "..").c_str()) > maxPx) {
+        s.remove(s.length() - 1);
+    }
+    return s + "..";
+}
+
+struct SrvMenuItem {
+    String label;
+    std::function<void()> action;
+};
+
+static int srvListLoop(
+    const char *title, int count, const String &hint,
+    std::function<void(int idx, int x, int y, int w, bool sel)> drawRow, int *cursor = nullptr
+) {
+    if (count <= 0) return -1;
+    SrvUiGeom g = srvUiGeom();
+    int sel = (cursor && *cursor >= 0 && *cursor < count) ? *cursor : 0;
+    int off = 0, lastSel = -1, lastOff = -1;
+
+    if (sel >= g.rows) off = sel - g.rows + 1;
+    drawMainBorderWithTitle(title);
+
+    for (;;) {
+        if (sel != lastSel || off != lastOff) {
+            tft.setTextSize(FP);
+            for (int i = 0; i < g.rows; i++) {
+                int y = g.top + i * g.rowH;
+                int idx = off + i;
+                bool selected = (idx == sel);
+                tft.fillRect(
+                    g.listL,
+                    y - 2,
+                    g.listW,
+                    g.rowH,
+                    selected ? bruceConfig.priColor : bruceConfig.bgColor
+                );
+                if (idx < count) drawRow(idx, g.listL + 3, y, g.listW - 6, selected);
+            }
+
+            // Position & hint footer
+            tft.fillRect(g.listL, g.footY, g.listW, 8 * FP, bruceConfig.bgColor);
+            tft.setTextSize(FP);
+            String pos = String(sel + 1) + "/" + String(count);
+            int posW = tft.textWidth(pos.c_str());
+            tft.setTextColor(srvDimColor(), bruceConfig.bgColor);
+            tft.drawString(srvFitText(hint, g.listW - posW - 8), g.listL, g.footY, 1);
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawRightString(pos, g.listL + g.listW, g.footY, 1);
+
+            lastSel = sel;
+            lastOff = off;
+            if (cursor) *cursor = sel;
+        }
+
+        if (check(EscPress)) return -1;
+        else if (check(PrevPress) || check(UpPress)) sel = (sel > 0) ? sel - 1 : count - 1;
+        else if (check(NextPress) || check(DownPress)) sel = (sel < count - 1) ? sel + 1 : 0;
+        else if (check(SelPress)) {
+            if (cursor) *cursor = sel;
+            return sel;
+        }
+
+        if (sel < off) off = sel;
+        if (sel >= off + g.rows) off = sel - g.rows + 1;
+        if (off > count - g.rows) off = std::max(0, count - g.rows);
+        if (off < 0) off = 0;
+        vTaskDelay(20 / portTICK_PERIOD_MS);
+    }
+}
+
+static int srvMenu(
+    const char *title,
+    const std::vector<SrvMenuItem> &items,
+    const String &hint = "SEL choose  ESC back",
+    int *cursor = nullptr
+) {
+    if (items.empty()) return -1;
+    int count = items.size();
+    auto drawer = [&items](int idx, int x, int y, int w, bool sel) {
+        uint16_t fg = sel ? bruceConfig.bgColor : bruceConfig.priColor;
+        uint16_t bg = sel ? bruceConfig.priColor : bruceConfig.bgColor;
+        tft.setTextColor(fg, bg);
+        tft.setTextSize(FP);
+        tft.drawString(srvFitText(items[idx].label, w), x, y, 1);
+    };
+
+    int chosen = srvListLoop(title, count, hint, drawer, cursor);
+    if (chosen >= 0 && chosen < count) {
+        if (items[chosen].action) {
+            items[chosen].action();
+        }
+    }
+    return chosen;
+}
+
+//=============================================================================
+// Server & Characteristic Callbacks
+//=============================================================================
+
+class BruceGattServerCallbacks : public NimBLEServerCallbacks {
+public:
+    void onConnect(NimBLEServer *pServer, NimBLEConnInfo &connInfo) override {
+        g_srvState.isConnected = true;
+        g_srvState.peerAddress = String(connInfo.getAddress().toString().c_str());
+        g_srvState.peerMtu = connInfo.getMTU();
+        g_srvState.addLog("[CONN] " + g_srvState.peerAddress);
+        Serial.printf("[GATT-SRV] Connected by: %s (MTU: %d)\n", g_srvState.peerAddress.c_str(), g_srvState.peerMtu);
+    }
+
+    void onDisconnect(NimBLEServer *pServer, NimBLEConnInfo &connInfo, int reason) override {
+        g_srvState.isConnected = false;
+        String peer = String(connInfo.getAddress().toString().c_str());
+        g_srvState.addLog("[DISC] " + peer + " (0x" + String(reason, HEX) + ")");
+        Serial.printf("[GATT-SRV] Disconnected by %s (Reason: 0x%02X)\n", peer.c_str(), reason);
+
+        // Automatically resume advertising
+        if (g_srvState.isRunning && pServer && pServer->getAdvertising()) {
+            pServer->getAdvertising()->start();
+            g_srvState.addLog("[ADV] Advertising resumed");
+        }
+    }
+
+    void onMTUChange(uint16_t MTU, NimBLEConnInfo &connInfo) override {
+        g_srvState.peerMtu = MTU;
+        g_srvState.addLog("[MTU] Updated: " + String(MTU) + " B");
+        Serial.printf("[GATT-SRV] MTU changed to: %d\n", MTU);
+    }
+};
+
+class GenericCharCallbacks : public NimBLECharacteristicCallbacks {
+public:
+    void onRead(NimBLECharacteristic *pChar, NimBLEConnInfo &connInfo) override {
+        g_srvState.readCount++;
+        String uuidStr = pChar->getUUID().toString().c_str();
+        g_srvState.addLog("[READ] " + uuidStr);
+        Serial.printf("[GATT-SRV] Read Char: %s\n", uuidStr.c_str());
+    }
+
+    void onWrite(NimBLECharacteristic *pChar, NimBLEConnInfo &connInfo) override {
+        g_srvState.writeCount++;
+        String uuidStr = pChar->getUUID().toString().c_str();
+        std::string raw = pChar->getValue();
+        String strVal = String(raw.c_str());
+        g_srvState.lastWriteVal = strVal;
+
+        String displayVal = strVal;
+        if (displayVal.length() > 16) {
+            displayVal = displayVal.substring(0, 14) + "..";
+        }
+        g_srvState.addLog("[WRITE] " + uuidStr + ": \"" + displayVal + "\"");
+        Serial.printf("[GATT-SRV] Write Char %s -> '%s'\n", uuidStr.c_str(), strVal.c_str());
+
+        // If this is Echo characteristic, update value and echo back via notification
+        if (uuidStr.equalsIgnoreCase(UUID_CHR_ECHO_RW) || pChar == g_pEchoChar) {
+            pChar->setValue("Echo: " + raw);
+            if (g_srvState.isConnected) {
+                pChar->notify();
+                g_srvState.notifyCount++;
+            }
+        }
+    }
+};
+
+class NusRxCharCallbacks : public NimBLECharacteristicCallbacks {
+public:
+    void onWrite(NimBLECharacteristic *pChar, NimBLEConnInfo &connInfo) override {
+        g_srvState.writeCount++;
+        std::string raw = pChar->getValue();
+        String strVal = String(raw.c_str());
+        g_srvState.lastWriteVal = strVal;
+
+        String displayVal = strVal;
+        if (displayVal.length() > 18) {
+            displayVal = displayVal.substring(0, 16) + "..";
+        }
+        g_srvState.addLog("[NUS RX] \"" + displayVal + "\"");
+        Serial.printf("[GATT-SRV] NUS RX: '%s'\n", strVal.c_str());
+
+        // Send ACK over NUS TX if available
+        if (g_pNusTxChar && g_srvState.isConnected) {
+            String ack = "ACK: " + strVal;
+            g_pNusTxChar->setValue(ack.c_str());
+            g_pNusTxChar->notify();
+            g_srvState.notifyCount++;
+            g_srvState.addLog("[NUS TX] Sent ACK");
+        }
+    }
+};
+
+static BruceGattServerCallbacks g_serverCallbacks;
+static GenericCharCallbacks g_genericCharCallbacks;
+static NusRxCharCallbacks g_nusRxCallbacks;
+
+//=============================================================================
+// Server Profiles & Service Initialization
+//=============================================================================
+
+static String getOwnMacString() {
+    uint8_t mac[6];
+    esp_read_mac(mac, ESP_MAC_BT);
+    char buf[18];
+    snprintf(buf, sizeof(buf), "%02X:%02X:%02X:%02X:%02X:%02X",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    return String(buf);
+}
+
+static void buildServerServices(NimBLEServer *pServer, int profileMode) {
+    g_pBatChar = nullptr;
+    g_pTempChar = nullptr;
+    g_pHumChar = nullptr;
+    g_pEchoChar = nullptr;
+    g_pStreamChar = nullptr;
+    g_pNusTxChar = nullptr;
+
+    bool addDis = (profileMode == 0 || profileMode == 1);
+    bool addBat = (profileMode == 0 || profileMode == 1);
+    bool addEnv = (profileMode == 0);
+    bool addEcho = (profileMode == 0 || profileMode == 2);
+    bool addNus = (profileMode == 0 || profileMode == 3);
+
+    // 1. Device Information Service (0x180A)
+    if (addDis) {
+        NimBLEService *pDis = pServer->createService(UUID_SVC_DIS);
+        if (pDis) {
+            NimBLECharacteristic *pMfg = pDis->createCharacteristic(UUID_CHR_MFG_NAME, NIMBLE_PROPERTY::READ);
+            if (pMfg) { pMfg->setValue("Bruce Project"); pMfg->setCallbacks(&g_genericCharCallbacks); }
+
+            NimBLECharacteristic *pModel = pDis->createCharacteristic(UUID_CHR_MODEL_NUM, NIMBLE_PROPERTY::READ);
+            if (pModel) { pModel->setValue("ESP32-Bruce"); pModel->setCallbacks(&g_genericCharCallbacks); }
+
+            NimBLECharacteristic *pSerial = pDis->createCharacteristic(UUID_CHR_SERIAL_NUM, NIMBLE_PROPERTY::READ);
+            if (pSerial) { pSerial->setValue(getOwnMacString().c_str()); pSerial->setCallbacks(&g_genericCharCallbacks); }
+
+            NimBLECharacteristic *pFw = pDis->createCharacteristic(UUID_CHR_FW_REV, NIMBLE_PROPERTY::READ);
+            if (pFw) { pFw->setValue("Bruce v2.0"); pFw->setCallbacks(&g_genericCharCallbacks); }
+
+            NimBLECharacteristic *pHw = pDis->createCharacteristic(UUID_CHR_HW_REV, NIMBLE_PROPERTY::READ);
+            if (pHw) { pHw->setValue("ESP32-D0WD/S3"); pHw->setCallbacks(&g_genericCharCallbacks); }
+        }
+    }
+
+    // 2. Battery Service (0x180F)
+    if (addBat) {
+        NimBLEService *pBat = pServer->createService(UUID_SVC_BATTERY);
+        if (pBat) {
+            g_pBatChar = pBat->createCharacteristic(
+                UUID_CHR_BATTERY_LEVEL,
+                NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY
+            );
+            if (g_pBatChar) {
+                int bat = getBattery();
+                uint8_t batVal = (bat > 0 && bat <= 100) ? (uint8_t)bat : 98;
+                g_pBatChar->setValue(&batVal, 1);
+                g_pBatChar->setCallbacks(&g_genericCharCallbacks);
+            }
+        }
+    }
+
+    // 3. Environmental Sensing Service (0x181A)
+    if (addEnv) {
+        NimBLEService *pEnv = pServer->createService(UUID_SVC_ENVIRONMENTAL);
+        if (pEnv) {
+            g_pTempChar = pEnv->createCharacteristic(
+                UUID_CHR_TEMPERATURE,
+                NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY
+            );
+            if (g_pTempChar) {
+                int16_t tempC = 2450; // 24.50 °C
+                g_pTempChar->setValue((uint8_t *)&tempC, 2);
+                g_pTempChar->setCallbacks(&g_genericCharCallbacks);
+            }
+
+            g_pHumChar = pEnv->createCharacteristic(
+                UUID_CHR_HUMIDITY,
+                NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY
+            );
+            if (g_pHumChar) {
+                uint16_t humVal = 4800; // 48.00 %
+                g_pHumChar->setValue((uint8_t *)&humVal, 2);
+                g_pHumChar->setCallbacks(&g_genericCharCallbacks);
+            }
+        }
+    }
+
+    // 4. Custom Echo & Read/Write/Stream Service (0xFFE0)
+    if (addEcho) {
+        NimBLEService *pEcho = pServer->createService(UUID_SVC_ECHO);
+        if (pEcho) {
+            g_pEchoChar = pEcho->createCharacteristic(
+                UUID_CHR_ECHO_RW,
+                NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR | NIMBLE_PROPERTY::NOTIFY
+            );
+            if (g_pEchoChar) {
+                g_pEchoChar->setValue("Bruce GATT Echo Char");
+                g_pEchoChar->setCallbacks(&g_genericCharCallbacks);
+            }
+
+            g_pStreamChar = pEcho->createCharacteristic(
+                UUID_CHR_STREAM_COUNT,
+                NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY | NIMBLE_PROPERTY::INDICATE
+            );
+            if (g_pStreamChar) {
+                g_pStreamChar->setValue("Stream Tick #0");
+                g_pStreamChar->setCallbacks(&g_genericCharCallbacks);
+            }
+        }
+    }
+
+    // 5. Nordic UART Service (NUS)
+    if (addNus) {
+        NimBLEService *pNus = pServer->createService(UUID_SVC_NUS);
+        if (pNus) {
+            NimBLECharacteristic *pNusRx = pNus->createCharacteristic(
+                UUID_CHR_NUS_RX,
+                NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR
+            );
+            if (pNusRx) {
+                pNusRx->setCallbacks(&g_nusRxCallbacks);
+            }
+
+            g_pNusTxChar = pNus->createCharacteristic(
+                UUID_CHR_NUS_TX,
+                NIMBLE_PROPERTY::NOTIFY
+            );
+            if (g_pNusTxChar) {
+                g_pNusTxChar->setCallbacks(&g_genericCharCallbacks);
+            }
+        }
+    }
+}
+
+//=============================================================================
+// Live Server Service Control & Interactive Monitor
+//=============================================================================
+
+bool startGattServerService(int profileMode) {
+    if (g_srvState.isRunning) {
+        return true;
+    }
+    g_srvState.reset();
+    g_srvState.isRunning = true;
+
+    uint64_t chipid = ESP.getEfuseMac();
+    String serverName = "Bruce-GATT-" + String((uint16_t)(chipid), HEX);
+    serverName.toUpperCase();
+
+    // 1. Initialize BLE with maximum power and zero authentication hurdles
+    BLEStateManager::initBLE(serverName, ESP_PWR_LVL_P9);
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
+    NimBLEDevice::setSecurityAuth(false, false, false);
+
+    // 2. Create and configure Server
+    NimBLEServer *pServer = NimBLEDevice::createServer();
+    if (!pServer) {
+        g_srvState.isRunning = false;
+        return false;
+    }
+
+    pServer->setCallbacks(&g_serverCallbacks, false);
+
+    // 3. Build active GATT database
+    buildServerServices(pServer, profileMode);
+    pServer->start();
+
+    // 4. Configure Advertising (Connectable, Legacy 1M PHY for universal compatibility)
+    NimBLEAdvertising *pAdv = NimBLEDevice::getAdvertising();
+    pAdv->reset();
+    pAdv->setName(serverName.c_str());
+
+    // Advertise primary standard services in the 31-byte packet
+    if (profileMode == 0 || profileMode == 1) {
+        pAdv->addServiceUUID(UUID_SVC_BATTERY);
+        pAdv->addServiceUUID(UUID_SVC_DIS);
+    } else if (profileMode == 2) {
+        pAdv->addServiceUUID(UUID_SVC_ECHO);
+    } else if (profileMode == 3) {
+        pAdv->addServiceUUID(UUID_SVC_NUS);
+    }
+
+    pAdv->enableScanResponse(true);
+    pAdv->start();
+
+    g_srvState.addLog("[INIT] Server name: " + serverName);
+    g_srvState.addLog("[ADV] Connectable 1M PHY started");
+    Serial.printf("[GATT-SRV] Server Started: %s (MAC: %s)\n", serverName.c_str(), getOwnMacString().c_str());
+    return true;
+}
+
+void stopGattServerService() {
+    if (!g_srvState.isRunning) return;
+    g_srvState.isRunning = false;
+    g_srvState.addLog("[STOP] Stopping server...");
+
+    g_pBatChar = nullptr;
+    g_pTempChar = nullptr;
+    g_pHumChar = nullptr;
+    g_pEchoChar = nullptr;
+    g_pStreamChar = nullptr;
+    g_pNusTxChar = nullptr;
+
+    NimBLEServer *pServer = NimBLEDevice::getServer();
+    if (pServer) {
+        if (pServer->getAdvertising()) {
+            pServer->getAdvertising()->stop();
+        }
+        std::vector<uint16_t> peers = pServer->getPeerDevices();
+        for (uint16_t handle : peers) {
+            pServer->disconnect(handle);
+        }
+    }
+
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+    BLEStateManager::deinitBLE(true);
+    Serial.println(F("[GATT-SRV] Server Stopped."));
+}
+
+bool isGattServerActive() {
+    return g_srvState.isRunning;
+}
+
+void runGattServer(int profileMode) {
+    if (!startGattServerService(profileMode)) {
+        displayError("Failed to create BLE Server");
+        return;
+    }
+
+    String profileName = "All-in-One";
+    if (profileMode == 1) profileName = "DIS & Battery";
+    else if (profileMode == 2) profileName = "Echo & Stream";
+    else if (profileMode == 3) profileName = "Nordic UART";
+
+    uint64_t chipid = ESP.getEfuseMac();
+    String serverName = "Bruce-GATT-" + String((uint16_t)(chipid), HEX);
+    serverName.toUpperCase();
+    String ownMac = getOwnMacString();
+
+    // UI Initial Frame
+    tft.fillScreen(bruceConfig.bgColor);
+    drawMainBorderWithTitle("GATT SERVER (ONLINE)");
+
+    uint32_t lastTickMs = millis();
+    uint32_t tickCount = 0;
+    bool lastConn = false;
+    uint32_t lastReadCount = 0;
+    uint32_t lastWriteCount = 0;
+    uint32_t lastNotifyCount = 0;
+    size_t lastLogSize = 0;
+
+    int boxX = BORDER_PAD_X + 2;
+    int boxW = tftWidth - 2 * BORDER_PAD_X - 4;
+    int topY = STATUS_BAR_HEIGHT + 2;
+    int headerH = 50;
+    int logTopY = topY + headerH + 6;
+    int logBottomY = tftHeight - 8 * FP - 8;
+    int maxLogRows = (logBottomY - logTopY) / (8 * FP + 3);
+    if (maxLogRows < 2) maxLogRows = 2;
+
+    while (g_srvState.isRunning) {
+        // Handle Periodic Data Updates & Live Streams (every 1000ms)
+        uint32_t now = millis();
+        if (now - lastTickMs >= 1000) {
+            lastTickMs = now;
+            tickCount++;
+
+            // Stream Characteristic Tick
+            if (g_pStreamChar) {
+                String tickMsg = "Tick #" + String(tickCount);
+                g_pStreamChar->setValue(tickMsg.c_str());
+                if (g_srvState.isConnected) {
+                    g_pStreamChar->notify();
+                    g_srvState.notifyCount++;
+                }
+            }
+
+            // Simulated temperature variation (e.g. 24.50 C .. 25.20 C)
+            if (g_pTempChar) {
+                int16_t tempC = 2450 + (int16_t)((tickCount % 8) * 10);
+                g_pTempChar->setValue((uint8_t *)&tempC, 2);
+            }
+
+            // Update Battery Level
+            if (g_pBatChar) {
+                int bat = getBattery();
+                uint8_t batVal = (bat > 0 && bat <= 100) ? (uint8_t)bat : (uint8_t)(95 - (tickCount / 60) % 10);
+                g_pBatChar->setValue(&batVal, 1);
+            }
+        }
+
+        // Draw / Refresh Status Header
+        bool conn = g_srvState.isConnected;
+        bool needHeaderRedraw = (conn != lastConn) || (g_srvState.readCount != lastReadCount) ||
+                                (g_srvState.writeCount != lastWriteCount) || (g_srvState.notifyCount != lastNotifyCount);
+
+        if (needHeaderRedraw) {
+            lastConn = conn;
+            lastReadCount = g_srvState.readCount;
+            lastWriteCount = g_srvState.writeCount;
+            lastNotifyCount = g_srvState.notifyCount;
+
+            tft.fillRect(boxX, topY, boxW, headerH, bruceConfig.bgColor);
+            tft.setTextSize(FP);
+
+            // Row 1: Name & Profile
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawString(srvFitText("Name: " + serverName, boxW / 2 + 10), boxX, topY, 1);
+            tft.setTextColor(srvDimColor(), bruceConfig.bgColor);
+            tft.drawRightString(srvFitText("[" + profileName + "]", boxW / 2 - 10), boxX + boxW, topY, 1);
+
+            // Row 2: MAC & Status Banner
+            int r2Y = topY + 8 * FP + 3;
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawString("MAC: " + ownMac, boxX, r2Y, 1);
+
+            if (conn) {
+                tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
+                tft.drawRightString("[CONNECTED]", boxX + boxW, r2Y, 1);
+            } else {
+                tft.setTextColor(TFT_YELLOW, bruceConfig.bgColor);
+                tft.drawRightString("[ADVERTISING]", boxX + boxW, r2Y, 1);
+            }
+
+            // Row 3: Peer / Statistics
+            int r3Y = r2Y + 8 * FP + 3;
+            if (conn) {
+                tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+                tft.drawString(srvFitText("Peer: " + g_srvState.peerAddress + " (MTU " + String(g_srvState.peerMtu) + ")", boxW), boxX, r3Y, 1);
+            } else {
+                tft.setTextColor(srvDimColor(), bruceConfig.bgColor);
+                tft.drawString("Ready for connections (1M PHY)", boxX, r3Y, 1);
+            }
+
+            // Row 4: Counters
+            int r4Y = r3Y + 8 * FP + 3;
+            String statStr = "Reads: " + String(g_srvState.readCount) + "  Writes: " + String(g_srvState.writeCount) + "  Notifs: " + String(g_srvState.notifyCount);
+            tft.setTextColor(srvDimColor(), bruceConfig.bgColor);
+            tft.drawString(statStr, boxX, r4Y, 1);
+
+            // Divider
+            tft.drawFastHLine(boxX, topY + headerH + 2, boxW, srvDimColor());
+        }
+
+        // Draw / Refresh Event Log Window
+        size_t curLogSize = 0;
+        if (g_srvState.logMutex && xSemaphoreTake(g_srvState.logMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+            curLogSize = g_srvState.logLines.size();
+            xSemaphoreGive(g_srvState.logMutex);
+        }
+
+        if (curLogSize != lastLogSize || needHeaderRedraw) {
+            lastLogSize = curLogSize;
+            tft.fillRect(boxX, logTopY, boxW, logBottomY - logTopY, bruceConfig.bgColor);
+            tft.setTextSize(FP);
+
+            std::vector<String> linesToDraw;
+            if (g_srvState.logMutex && xSemaphoreTake(g_srvState.logMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+                int startIdx = std::max(0, (int)g_srvState.logLines.size() - maxLogRows);
+                for (size_t i = startIdx; i < g_srvState.logLines.size(); i++) {
+                    linesToDraw.push_back(g_srvState.logLines[i]);
+                }
+                xSemaphoreGive(g_srvState.logMutex);
+            }
+
+            int row = 0;
+            for (const auto &line : linesToDraw) {
+                int lineY = logTopY + row * (8 * FP + 3);
+
+                if (line.startsWith("[CONN]")) tft.setTextColor(TFT_GREEN, bruceConfig.bgColor);
+                else if (line.startsWith("[DISC]")) tft.setTextColor(TFT_RED, bruceConfig.bgColor);
+                else if (line.startsWith("[WRITE]")) tft.setTextColor(TFT_CYAN, bruceConfig.bgColor);
+                else if (line.startsWith("[READ]")) tft.setTextColor(TFT_WHITE, bruceConfig.bgColor);
+                else if (line.startsWith("[ADV]")) tft.setTextColor(TFT_YELLOW, bruceConfig.bgColor);
+                else tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+
+                tft.drawString(srvFitText(line, boxW), boxX, lineY, 1);
+                row++;
+            }
+
+            // Footer
+            tft.fillRect(boxX, logBottomY + 2, boxW, 8 * FP, bruceConfig.bgColor);
+            tft.setTextSize(FP);
+            tft.setTextColor(srvDimColor(), bruceConfig.bgColor);
+            tft.drawString("ESC: Stop Server", boxX, logBottomY + 2, 1);
+            tft.setTextColor(bruceConfig.priColor, bruceConfig.bgColor);
+            tft.drawRightString("SEL: Manual Notify", boxX + boxW, logBottomY + 2, 1);
+        }
+
+        // Handle User Input
+        if (check(EscPress)) {
+            g_srvState.isRunning = false;
+            break;
+        }
+
+        if (check(SelPress)) {
+            // Send Manual Test Notification
+            if (g_pEchoChar && g_srvState.isConnected) {
+                String manualMsg = "Manual Test Event #" + String(tickCount);
+                g_pEchoChar->setValue(manualMsg.c_str());
+                g_pEchoChar->notify();
+                g_srvState.notifyCount++;
+                g_srvState.addLog("[MANUAL NOTIFY] Sent");
+            } else if (!g_srvState.isConnected) {
+                g_srvState.addLog("[WARN] No client connected");
+            }
+            vTaskDelay(150 / portTICK_PERIOD_MS);
+        }
+
+        vTaskDelay(40 / portTICK_PERIOD_MS);
+    }
+
+    // Cleanup and Stop Server
+    stopGattServerService();
+    displayInfo("GATT Server Stopped", false);
+    vTaskDelay(400 / portTICK_PERIOD_MS);
+}
+
+//=============================================================================
+// Main GATT Server Menu
+//=============================================================================
+
+void gattServerMenu() {
+    int cursor = 0;
+    while (true) {
+        std::vector<SrvMenuItem> menuOps;
+
+        menuOps.push_back({"1. Multi-Service Server (All-in-One)", [=]() {
+            runGattServer(0);
+        }});
+
+        menuOps.push_back({"2. Standard DIS & Battery Server", [=]() {
+            runGattServer(1);
+        }});
+
+        menuOps.push_back({"3. Custom Echo & Stream Server", [=]() {
+            runGattServer(2);
+        }});
+
+        menuOps.push_back({"4. Nordic UART Serial (NUS)", [=]() {
+            runGattServer(3);
+        }});
+
+        menuOps.push_back({"< Back to Bluetooth", []() {}});
+
+        int sel = srvMenu("GATT SERVER", menuOps, "SEL start  ESC back", &cursor);
+        if (sel == -1 || sel == (int)menuOps.size() - 1) {
+            break;
+        }
+    }
+}
+
+#endif // !LITE_VERSION

--- a/src/modules/ble/gatt_server.h
+++ b/src/modules/ble/gatt_server.h
@@ -1,0 +1,16 @@
+#ifndef GATT_SERVER_H
+#define GATT_SERVER_H
+
+#include <Arduino.h>
+
+#if !defined(LITE_VERSION)
+
+void gattServerMenu();
+void runGattServer(int profileMode = 0);
+bool startGattServerService(int profileMode = 0);
+void stopGattServerService();
+bool isGattServerActive();
+
+#endif // !LITE_VERSION
+
+#endif // GATT_SERVER_H

--- a/src/modules/rf/rf_utils.cpp
+++ b/src/modules/rf/rf_utils.cpp
@@ -239,6 +239,17 @@ bool initRfModule(String mode, float frequency) {
     if (!frequency) frequency = bruceConfigPins.rfFreq;
 
     if (bruceConfigPins.rfModule == CC1101_SPI_MODULE) { // CC1101 in use
+#ifdef CAP_CC1101_POWER_EN
+        // M5Stack Cap CC1101: POWER_EN gates the whole cap, and the cap's ST25R3916
+        // hangs off this same SPI bus, so park its CS high before we talk to the radio.
+        if (bruceConfigPins.CC1101_bus.cs == (gpio_num_t)CAP_CC1101_SS_PIN) {
+            pinMode(CAP_NFC_SS_PIN, OUTPUT);
+            digitalWrite(CAP_NFC_SS_PIN, HIGH);
+            pinMode(CAP_CC1101_POWER_EN, OUTPUT);
+            digitalWrite(CAP_CC1101_POWER_EN, HIGH);
+            vTaskDelay(10 / portTICK_PERIOD_MS); // cap DC-DC needs a moment
+        }
+#endif
         SPIClass *ccSpi = acquireSPIBus(
             bruceConfigPins.CC1101_bus.sck, bruceConfigPins.CC1101_bus.miso, bruceConfigPins.CC1101_bus.mosi
         );
@@ -412,6 +423,28 @@ void setMHZ(float frequency) {
             digitalWrite(CC1101_SW0_PIN, HIGH);
             antenna = 2;
             vTaskDelay(10 / portTICK_PERIOD_MS); // time to settle the antenna signal
+        }
+#endif
+#ifdef CAP_CC1101_SW0_PIN
+        // M5Stack Cap CC1101 antenna path: the SP3T switches are driven by RF_SW0 (a GPIO) and
+        // RF_SW1, which is the CC1101's own GDO2 pin - not routed to the ESP32, so it is forced
+        // high/low through IOCFG2. Written on every call because Init() resets IOCFG2.
+        // Truth table taken from M5's driver (uiflow libs/cap/cc1101.py); the docs' table lists
+        // different SW0/SW1 values for 315/433 MHz - if one band comes out deaf, swap them here.
+        // also: only fires through this setMHZ() wrapper. rf_jammer's direct
+        // ELECHOUSE_cc1101.setMHZ() hops bypass it, so hopping across a band boundary keeps the
+        // old antenna path. Route those through the wrapper if cross-band jamming is ever needed.
+        if (bruceConfigPins.CC1101_bus.cs == (gpio_num_t)CAP_CC1101_SS_PIN) {
+            static uint8_t capBand = 200; // 200 = unknown, forces a settle delay on first use
+            uint8_t band = frequency < 374 ? 0 : (frequency < 650.5 ? 1 : 2); // 315 / 433 / 868-915
+            pinMode(CAP_CC1101_SW0_PIN, OUTPUT);
+            digitalWrite(CAP_CC1101_SW0_PIN, band == 0 ? LOW : HIGH);
+            // 0x2F = GDO2 forced low, 0x6F = same with the output inverted, i.e. forced high.
+            ELECHOUSE_cc1101.SpiWriteReg(CC1101_IOCFG2, band == 1 ? 0x2F : 0x6F);
+            if (band != capBand) {
+                capBand = band;
+                vTaskDelay(10 / portTICK_PERIOD_MS); // time to settle the antenna signal
+            }
         }
 #endif
         const bool preciseCalibration = (bruceConfigPins.rfFxdFreq);

--- a/src/modules/rfid/ST25R3916.cpp
+++ b/src/modules/rfid/ST25R3916.cpp
@@ -62,6 +62,16 @@ static void _setNfcPower(bool enabled) {
     ioExpander.setPinDirection(IO_EXP_NFC, OUTPUT);
     ioExpander.turnPinOnOff(IO_EXP_NFC, enabled ? HIGH : LOW);
 #endif
+#ifdef CAP_CC1101_POWER_EN
+    // M5Stack Cap CC1101: POWER_EN gates the whole cap, and the cap's CC1101 hangs off
+    // this same SPI bus, so park its CS high before we talk to the NFC chip.
+    if (bruceConfigPins.ST25R_bus.cs == (gpio_num_t)CAP_NFC_SS_PIN) {
+        pinMode(CAP_CC1101_SS_PIN, OUTPUT);
+        digitalWrite(CAP_CC1101_SS_PIN, HIGH);
+        pinMode(CAP_CC1101_POWER_EN, OUTPUT);
+        digitalWrite(CAP_CC1101_POWER_EN, enabled ? HIGH : LOW);
+    }
+#endif
 }
 
 namespace {


### PR DESCRIPTION
#### Proposed Changes ####


The PR provides fixes for some BLE connection issues on ESP32 / ESP32-S3 targets (resolving HCI `0x0D`, `0x3E`, and timeout issues in NimBLE-Arduino 2.x), alongside new GATT related features:

1. **Protocol & Driver Stability Fixes:**
    - **ESP32-S3 0x0D Multi-PHY Fallback:** On ESP32-S3 with `CONFIG_BT_NIMBLE_EXT_ADV=1`, standard connection attempts use `ble_gap_ext_connect()` with multi-PHY masks (`1M|2M|Coded`), which legacy BLE 4.2 peers reject with `HCI_ERR_CONN_REJ_LIMITED_RESOURCES (0x0D)`. Enforced fallback to legacy `ble_gap_connect()` when `BLE_GAP_LE_PHY_1M_MASK` is set.
    - **NimBLE 2.x Timeout Correction:** Corrected `setConnectTimeout` parameters from seconds to milliseconds (e.g. `8000` ms instead of `5`–`8` ms), preventing instant GAP timeouts before link-layer handshake completion.
    - **Connection Event Length Relaxation:** Explicitly set `min_ce_len = 0` and `max_ce_len = 0` in `setConnectionParams()` to avoid scheduler slot conflicts and `0x3B` / `0x0D` rejects.
    - **Full RPA / Random Address Support:** Preserved `advertisedDevice.getAddressType()` from scan results and passed it to `NimBLEAddress`, enabling reliable connections to iOS, macOS, and Android devices using Random Resolvable Private Addresses.
    - **Deferred ATT MTU Exchange:** Connected with `exchangeMTU = false` and deferred MTU negotiation until after link establishment, preventing AOSP/Fluoride buffer collisions.
    - **Static Callback Safety & Threading:** Explicitly passed `deleteCallbacks = false` to prevent heap corruption on `NimBLEDevice::deinit()` and replaced `portENTER_CRITICAL()` with FreeRTOS mutexes to prevent CPU watchdog timeouts.

2. **GATT Explorer (`src/modules/ble/gatt_explorer.*`):**
    - Interactive scanning and target connection.
    - Lists services, characteristics, descriptors, and properties (Read/Write/Notify/Indicate).
    - Integrated into `BleMenu.cpp` and accessible via CLI.

3. **Configurable GATT Server (`src/modules/ble/gatt_server.*`):**
    - Host selectable BLE service profiles directly on Bruce:
        - **All-in-One:** Combined DIS, Battery, and Echo endpoints.
        - **DIS + Battery:** Device Information (`0x180A`) and Battery Service (`0x180F`).
        - **Echo / Stream:** Bidirectional loopback (`0xFFE0` / `0xFFE1`).
        - **Nordic UART Service (NUS):** Serial RX/TX over BLE (`6E400001-...`).
    - Serves as unencrypted test fixtures without forced pairing gates.

4. **Serial CLI Command Interface (`src/core/serial_commands/ble_commands.*`):**
    - `ble scan [seconds]` – Scan and print RSSI, MAC, address type, and advertised UUIDs.
    - `ble connect <mac> [public|random]` – Connect and traverse GATT hierarchy headlessly.
    - `ble server <start|stop|status> [profile]` – Manage GATT server background service.

#### Types of Changes ####

- Bugfix & New Feature

#### Verification ####

The changes can be verified on ESP32 / ESP32-S3 hardware (e.g. M5Stack Cardputer, LilyGO T-Embed) through the following steps:

1. **GATT Explorer & Connection Fixes:**
    - Run `ble scan 5` in the Serial Monitor or open **BLE -> GATT Explorer** in the UI.
    - Connect to a legacy BLE 4.2 peripheral or an Android/iOS device using `ble connect <MAC>`.
    - Verify that connection establishes successfully without `0x0D` or `0x3E` errors, and that GATT services and characteristics are enumerated.

2. **GATT Server:**
    - Execute `ble server start dis_bat` or `ble server start nus`.
    - Connect using *nRF Connect for Mobile* or *LightBlue* from a smartphone.
    - Verify advertised services and read/write characteristic values.

3. **Memory & Stability:**
    - Start and stop BLE modules repeatedly; verify no heap corruption panics or watchdog resets occur on deinit.

I used a small setup with a M5Stack Cardputer ADV and a CYD-2432W328C, debugging each other using serial and BLE.  

#### Testing ####

- **Hardware Tested:** M5Stack Cardputer (ESP32-S3) and CYD-2432W328C.
- **Peer Targets Tested:** Android 14 (Pixel/AOSP), standard ESP32 BLE 4.2 GATT server fixtures.
- **Tools Used:** *nRF Connect for Mobile*, USB CDC Serial Monitor, AI.
- **Build Status:** Verified compilation across target environments with PlatformIO (`pio run`).

#### Linked Issues ####

This PR resolves the underlying driver- and protocol-level root causes that persisted in `dev` despite previous fixes in v1.16:

- **Resolves persistent root cause for #2674 & #1877:** Fixes ESP32-S3 / Cardputer ADV BLE connection drops (`HCI 0x0D` / `0x3E`) by forcing legacy 1M PHY fallback and removing strict CE length constraints.
- **Resolves persistent root cause for #2587:** Corrects NimBLE 2.x `setConnectTimeout` unit mismatch (ms vs. s) across all BLE modules.
- **Resolves persistent root cause for #2367:** Adds proper RPA / Random Address type preservation from scan results.
- **Resolves #2664:** Fixes static callback heap corruption on BLE deinitialization and replaces critical sections with FreeRTOS mutexes.
- **Fulfills feature requests #581, #2802 & #1482:** Implements interactive GATT Explorer, serial CLI commands (`ble scan`, `ble connect`, `ble server`), and multi-profile GATT Server.

#### User-Facing Change ####

- Added interactive BLE GATT Explorer to scan, inspect, and connect to GATT services and characteristics.
- Added configurable GATT Server supporting Device Info, Battery, Echo, and Nordic UART Service (NUS) profiles.
- Added serial CLI commands: `ble scan`, `ble connect <mac>`, and `ble server <start|stop|status>`.
- Fixed BLE connection drops (HCI 0x0D / 0x3E) on ESP32-S3 and Cardputer ADV when connecting to legacy BLE 4.2 or RPA devices.
- Corrected NimBLE 2.x connection timeout scaling from seconds to milliseconds.
- Fixed heap corruption on BLE deinitialization with static callbacks.