### PR TITLE
Reaper Fixes - LEDs, GPS and IR

### DIFF
--- a/boards/reaper/pins_arduino.h
+++ b/boards/reaper/pins_arduino.h
@@ -103,15 +103,17 @@ static const uint8_t SCK = SPI_SCK_PIN;
 #define SDCARD_MOSI SPI_MOSI_PIN
 
 // RGB LED
-
 #define HAS_RGB_LED 1
 #define RGB_LED 45
 #define LED_TYPE WS2812B
 #define LED_ORDER GRB
 #define LED_TYPE_IS_RGBW 0
 #define LED_COUNT 16
-
 #define LED_COLOR_STEP 5
+
+// GPS Bus
+#define GPS_SERIAL_RX 44
+#define GPS_SERIAL_TX 43
 
 // PMIC
 // #define XPOWERS_CHIP_BQ25896

--- a/boards/reaper/pins_arduino.h
+++ b/boards/reaper/pins_arduino.h
@@ -107,7 +107,7 @@ static const uint8_t SCK = SPI_SCK_PIN;
 #define HAS_RGB_LED 1
 #define RGB_LED 45
 #define LED_TYPE WS2812B
-#define LED_ORDER RGB
+#define LED_ORDER GRB
 #define LED_TYPE_IS_RGBW 0
 #define LED_COUNT 16
 

--- a/boards/reaper/reaper.ini
+++ b/boards/reaper/reaper.ini
@@ -14,8 +14,8 @@ build_flags =
 	-DCORE_DEBUG_LEVEL=0
 
 	;Infrared Led default pin and state
-	-DIR_TX_PINS='{{"GPIO 2", 2}, {"GPIO 4", 4}, {"GPIO 5", 5}, {"GPIO 42", 42}}'
-	-DIR_RX_PINS='{{"GPIO 1", 1}, {"GPIO 4", 4}, {"GPIO 5", 5}, {"GPIO 42", 42}}'
+	-DIR_TX_PINS='{{"Default", 2}, {"GPIO 4", 4}, {"GPIO 5", 5}, {"GPIO 42", 42}}'
+	-DIR_RX_PINS='{{"Default", 1}, {"GPIO 4", 4}, {"GPIO 5", 5}, {"GPIO 42", 42}}'
     -DRF_TX_PINS='{{"GPIO 4", 4}, {"GPIO 5", 5}, {"GPIO 42", 42}}'
 	-DRF_RX_PINS='{{"GPIO 4", 4}, {"GPIO 5", 5}, {"GPIO 42", 42}}'
 

--- a/boards/reaper/reaper.ini
+++ b/boards/reaper/reaper.ini
@@ -9,7 +9,7 @@ build_flags =
 	-DARDUINO_USB_MODE=1
 	-DBUZZ_PIN=10
     -D USE_HSPI_PORT=1
-    -DDEVICE_NAME='"reaper board"'
+    -DDEVICE_NAME='"Reaper RF"'
 
 	-DCORE_DEBUG_LEVEL=0
 


### PR DESCRIPTION
#### Proposed Changes ####

* LEDs were outputting using the wrong colour order
* GPS pins were not defined so wrong defaults were used
* Changed name of the 'default' IR pins to be 'Default' so follow other boards configuration (tested and these pins 1/2 are correct)
* Renamed board to `Reaper RF` rather than `reaper board`

#### Types of Changes ####

Bugfix

#### Verification ####

## LED Colour (red and green were swapped)

### Before

#### Red
<img width="4032" height="3024" alt="26-09-06 02-12-38 3354" src="https://github.com/user-attachments/assets/56d17d9e-9b81-40cb-99d3-ff1f2c5868b8" />

#### Green
<img width="4032" height="3024" alt="26-09-06 02-12-50 3355" src="https://github.com/user-attachments/assets/f1dcfd3d-0958-4e75-afc8-4c433d209899" />

#### Magenta
<img width="4032" height="3024" alt="26-09-06 02-17-33 3356" src="https://github.com/user-attachments/assets/8a8b2356-30b4-4b15-952f-bb167ae835ee" />


### After

#### Red
<img width="4032" height="3024" alt="26-09-06 12-25-08 3358" src="https://github.com/user-attachments/assets/f898557d-9496-4bea-9cc9-c5273dc26dad" />

#### Green
<img width="4032" height="3024" alt="26-09-06 12-25-14 3359" src="https://github.com/user-attachments/assets/22f48b89-f22c-430e-8e58-924b2fcaba85" />

#### Magenta
<img width="4032" height="3024" alt="26-09-06 12-25-29 3361" src="https://github.com/user-attachments/assets/96671ce9-c28f-4f20-8367-db0a7d8991f4" />


### Other changes 'just work'.


#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

