### PR TITLE
Add compiled JS support

### DIFF
--- a/src/modules/bjs_interpreter/interpreter.cpp
+++ b/src/modules/bjs_interpreter/interpreter.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include "globals_js.h"
 
 char *script = NULL;
+size_t scriptSize = 0;
 char *scriptDirpath = NULL;
 char *scriptName = NULL;
 
@@ -62,6 +63,20 @@ void interpreterHandler(void *pvParameters) {
     JSContext *ctx = JS_NewContext(mem_buf, mem_size, &js_stdlib);
     JS_SetLogFunc(ctx, js_log_func);
 
+    log_d("Script length: %zu\n", scriptSize);
+
+    // JS_LoadBytecode requires no atoms to have been defined in RAM yet, so bytecode
+    // must be loaded before any global variables/functions are registered below.
+    bool isBytecode = JS_IsBytecode((const uint8_t *)script, scriptSize);
+    JSValue val = JS_UNDEFINED;
+    if (isBytecode) {
+        if (JS_RelocateBytecode(ctx, (uint8_t *)script, scriptSize) != 0) {
+            print_errorMessage("Invalid or incompatible bytecode file");
+        } else {
+            val = JS_LoadBytecode(ctx, (const uint8_t *)script);
+        }
+    }
+
     js_timers_init(ctx);
 
     // Set global variables
@@ -86,10 +101,11 @@ void interpreterHandler(void *pvParameters) {
 
     printMemoryUsage("context created");
 
-    size_t scriptSize = strlen(script);
-    log_d("Script length: %zu\n", scriptSize);
-
-    JSValue val = JS_Eval(ctx, (const char *)script, scriptSize, scriptName, 0);
+    if (isBytecode) {
+        if (!JS_IsException(val)) { val = JS_Run(ctx, val); }
+    } else {
+        val = JS_Eval(ctx, (const char *)script, scriptSize, scriptName, 0);
+    }
 
     run_timers(ctx);
 
@@ -144,7 +160,7 @@ void run_bjs_script() {
         };
         loopOptions(options);
     }
-    filename = loopSD(*fs, true, "BJS|JS");
+    filename = loopSD(*fs, true, "BJS|JS|BIN");
     vTaskDelay(pdMS_TO_TICKS(200));
     if (filename == "") { return; }
     run_bjs_script_headless(*fs, filename);
@@ -153,6 +169,7 @@ void run_bjs_script() {
 bool run_bjs_script_headless(char *code) {
     script = code;
     if (script == NULL) { return false; }
+    scriptSize = strlen(code);
     scriptDirpath = strdup("/scripts");
     scriptName = strdup("index.js");
 
@@ -163,7 +180,7 @@ bool run_bjs_script_headless(char *code) {
 }
 
 bool run_bjs_script_headless(FS &fs, const String &filename) {
-    script = readBigFile(&fs, filename);
+    script = readBigFile(&fs, filename, true, &scriptSize);
     if (script == NULL) { return false; }
 
     int slash = filename.lastIndexOf('/');
@@ -249,7 +266,7 @@ getScriptsOptionsList(const String &currentPath, bool saveStartupScript, int rem
             int dotIndex = nameOnly.lastIndexOf(".");
             String ext = dotIndex >= 0 ? nameOnly.substring(dotIndex + 1) : "";
             ext.toUpperCase();
-            if (ext != "JS" && ext != "BJS") continue;
+            if (ext != "JS" && ext != "BJS" && ext != "BIN") continue;
 
             String entry_title = nameOnly.substring(0, nameOnly.lastIndexOf(".")); // remove the extension
             opt.push_back({entry_title.c_str(), [=]() {


### PR DESCRIPTION
#### Proposed Changes ####

Add support for running compiled JS.

This is a supported feature of [mquickjs](https://github.com/bellard/mquickjs)

I have setup a docker container for easy complication of `.js` files as part of a repositories workflow (document in README).
This does need the package to be setup to public which I cannot do due to [permissions](https://github.com/orgs/BruceDevices/packages/container/compile-js/settings).

I have used the compilation workflow in the App Store repo, however it has not yet successfully run due to the package permissions.
https://github.com/BruceDevices/App-Store/blob/main/.github/workflows/minify-and-compile.yml


A future PR will get the 'Install App Store' menu item to download the new `.bin` version of the App Store.


#### Types of Changes ####

New feature

#### Verification ####

### Running Standard (minified) App Store JS

<img width="320" height="152" alt="image" src="https://github.com/user-attachments/assets/9a4c21f9-9fff-4461-8c72-d04ec7bc7bbf" />


Text reads `stack overflow`

<img width="377" height="172" alt="image" src="https://github.com/user-attachments/assets/6710e28f-0578-474e-8c53-58748a9213b6" />


### Now when running the compiled version

<img width="285" height="136" alt="image" src="https://github.com/user-attachments/assets/757be1d3-f2e9-482b-886c-d9fd3df2e826" />


It runs with no errors.

<img width="292" height="136" alt="image" src="https://github.com/user-attachments/assets/a8894efc-a9cc-413d-8ab0-ae7b64a6628e" />



#### Testing ####

Standard `.js` still work (except for ones that error due to memory issues).

Tested on Cardputer ADV so far, will wait for it to be on beta before testing all my other low memory devices.


#### Linked Issues ####

https://github.com/BruceDevices/firmware/issues/2853
https://github.com/BruceDevices/firmware/issues/2830

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Compiled JavaScript can be run on devices, helps with low memory devices.
```

#### Further Comments ####

