### PR TITLE
feat(cardputer): add GPS module selector to fix pin reset bug

### DIFF
--- a/boards/m5stack-cardputer/interface.cpp
+++ b/boards/m5stack-cardputer/interface.cpp
@@ -129,9 +129,21 @@ void _post_setup_gpio() {
     bruceConfigPins.sys_i2c.sda = (gpio_num_t)8;
     bruceConfigPins.sys_i2c.scl = (gpio_num_t)9;
 
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+    // GPS pins are managed by the gpsModule config selector (GPS > Config > GPS Module).
+    // Only apply the LoRa cap preset if the module has not been explicitly configured yet.
+    // This prevents the config from being overwritten on every boot (fixes GPS pin reset bug).
+    if (bruceConfigPins.gpsModule == GPS_MODULE_CUSTOM &&
+        bruceConfigPins.gps_bus.rx == GPIO_NUM_NC) {
+        // First boot with new firmware: preserve old default (LoRa cap behavior)
+        bruceConfigPins.gpsModule = GPS_MODULE_LORA_CAP;
+        bruceConfigPins.applyGpsModulePreset();
+    }
+#else
     bruceConfigPins.gps_bus.rx = (gpio_num_t)15;
     bruceConfigPins.gps_bus.tx = (gpio_num_t)13;
     bruceConfigPins.gpsBaudrate = 115200;
+#endif
 
     bruceConfigPins.CC1101_bus.sck = (gpio_num_t)40;
     bruceConfigPins.CC1101_bus.miso = (gpio_num_t)39;

--- a/boards/m5stack-cardputer/m5stack-cardputer.ini
+++ b/boards/m5stack-cardputer/m5stack-cardputer.ini
@@ -13,149 +13,152 @@ board = m5stack-cardputer
 board_build.partitions = custom_8Mb.csv
 build_src_filter =${env.build_src_filter} +<../boards/m5stack-cardputer>
 build_flags =
-	${env.build_flags}
-	-Iboards/m5stack-cardputer
-	-DCORE_DEBUG_LEVEL=0
+        ${env.build_flags}
+        -Iboards/m5stack-cardputer
+        -DCORE_DEBUG_LEVEL=0
 
-	-D ANALOG_BAT_PIN=10
+        -D ANALOG_BAT_PIN=10
 
-	-DTCA8418_INT_PIN=11
-	-DTCA8418_I2C_ADDR=0x34
-	-DTCA8418_SDA_PIN=8
-	-DTCA8418_SCL_PIN=9
+        -DTCA8418_INT_PIN=11
+        -DTCA8418_I2C_ADDR=0x34
+        -DTCA8418_SDA_PIN=8
+        -DTCA8418_SCL_PIN=9
 
-	;Features Enabled
-	;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
-	; ES8311 Codec (ADV)
-	-D ES8311_CODEC=1
-	-D ES8311_ADDR=0x18
+        ;Features Enabled
+        ;-DLITE_VERSION=1 ;limits some features to save space for M5Launcher Compatibility
+        ; ES8311 Codec (ADV)
+        -D ES8311_CODEC=1
+        -D ES8311_ADDR=0x18
 
-	;Microphone
-	-DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
-	-DPIN_CLK=43
-	-DI2S_SCLK_PIN=43
-	-DI2S_DATA_PIN=46
-	-DPIN_DATA=46
+        ;Microphone
+        -DMIC_SPM1423=1 ;uncomment to enable Applicable for SPM1423 device
+        -DPIN_CLK=43
+        -DI2S_SCLK_PIN=43
+        -DI2S_DATA_PIN=46
+        -DPIN_DATA=46
 
-	;FM Radio
-	-DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
-	-DFM_RSTPIN=40
+        ;FM Radio
+        -DFM_SI4713=1 ;Uncomment to activate FM Radio using Adafruit Si4713
+        -DFM_RSTPIN=40
 
-	;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
-	-DHAS_RGB_LED=1
-	-DRGB_LED=21
+        ;RGB LED runned by xylopyrographer/LiteLED@^1.2.0 library
+        -DHAS_RGB_LED=1
+        -DRGB_LED=21
 
-	;Speaker to run music, compatible with NS4168
-	-DHAS_NS4168_SPKR=1 ;uncomment to enable
-	-DBCLK=41
-	-DWCLK=43
-	-DDOUT=42
-	-DMCLK=43 # Microphone CLK or WCLK
+        ;Speaker to run music, compatible with NS4168
+        -DHAS_NS4168_SPKR=1 ;uncomment to enable
+        -DBCLK=41
+        -DWCLK=43
+        -DDOUT=42
+        -DMCLK=43 # Microphone CLK or WCLK
 
-	;Can run USB as HID
-	-DUSB_as_HID=1
+        ;Can run USB as HID
+        -DUSB_as_HID=1
 
-	;Buttons configuration
-	-DHAS_BTN=0
-	-DBTN_ALIAS='"Ok"'
-	-DBTN_PIN=0
-	-DBTN_ACT=LOW
+        ;Buttons configuration
+        -DHAS_BTN=0
+        -DBTN_ALIAS='"Ok"'
+        -DBTN_PIN=0
+        -DBTN_ACT=LOW
 
-	;Font sizes, depending on device
-	-DFP=1
-	-DFM=2
-	-DFG=3
+        ;Font sizes, depending on device
+        -DFP=1
+        -DFM=2
+        -DFG=3
 
-	;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
+        ;-DALLOW_ALL_GPIO_FOR_IR_RF=1 ; Set this option to make use of all GPIOs, from 1 to 44 to be chosen, except TFT and SD pins
 
-	;Infrared Led default pin and state
-	-DIR_TX_PINS='{ {"Default", TXLED}, {"M5 IR Mod", GROVE_SDA}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA}, {"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15} }'
-	-DIR_RX_PINS='{ {"M5 IR Mod", GROVE_SCL}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA},{"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15}}'
-	-DTXLED=44
-	-DLED_ON=HIGH
-	-DLED_OFF=LOW
+        ;Infrared Led default pin and state
+        -DIR_TX_PINS='{ {"Default", TXLED}, {"M5 IR Mod", GROVE_SDA}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA}, {"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15} }'
+        -DIR_RX_PINS='{ {"M5 IR Mod", GROVE_SCL}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA},{"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15}}'
+        -DTXLED=44
+        -DLED_ON=HIGH
+        -DLED_OFF=LOW
 
-	;Radio Frequency (one pin modules) pin setting
-	-DRF_TX_PINS='{ {"M5 RF433T", GROVE_SDA}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA},{"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15}}'
-	-DRF_RX_PINS='{ {"M5 RF433R", GROVE_SCL}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA},{"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15}}'
-	; connection pins using microSD sniffer module https://www.sparkfun.com/products/9419 https://docs.m5stack.com/en/core/Cardputer
-	-DUSE_CC1101_VIA_SPI
-	-DCC1101_GDO0_PIN=GROVE_SDA
-	-DCC1101_SS_PIN=SPI_SS_PIN
-	-DCC1101_MOSI_PIN=SPI_MOSI_PIN
-	-DCC1101_SCK_PIN=SPI_SCK_PIN
-	-DCC1101_MISO_PIN=SPI_MISO_PIN
-	;-DCC1101_GDO2_PIN=-1
+        ;Radio Frequency (one pin modules) pin setting
+        -DRF_TX_PINS='{ {"M5 RF433T", GROVE_SDA}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA},{"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15}}'
+        -DRF_RX_PINS='{ {"M5 RF433R", GROVE_SCL}, {"Grove W", GROVE_SCL}, {"Grove Y", GROVE_SDA},{"ADV 3", 3},{"ADV 4", 4},{"ADV 5", 5},{"ADV 6", 6},{"ADV 13", 13},{"ADV 15", 15}}'
+        ; connection pins using microSD sniffer module https://www.sparkfun.com/products/9419 https://docs.m5stack.com/en/core/Cardputer
+        -DUSE_CC1101_VIA_SPI
+        -DCC1101_GDO0_PIN=GROVE_SDA
+        -DCC1101_SS_PIN=SPI_SS_PIN
+        -DCC1101_MOSI_PIN=SPI_MOSI_PIN
+        -DCC1101_SCK_PIN=SPI_SCK_PIN
+        -DCC1101_MISO_PIN=SPI_MISO_PIN
+        ;-DCC1101_GDO2_PIN=-1
 
-	; connections are the same as CC1101
-	-DUSE_NRF24_VIA_SPI
-	-DNRF24_CE_PIN=GROVE_SDA
-	-DNRF24_SS_PIN=SPI_SS_PIN
-	-DNRF24_MOSI_PIN=SPI_MOSI_PIN
-	-DNRF24_SCK_PIN=SPI_SCK_PIN
-	-DNRF24_MISO_PIN=SPI_MISO_PIN
+        ; connections are the same as CC1101
+        -DUSE_NRF24_VIA_SPI
+        -DNRF24_CE_PIN=GROVE_SDA
+        -DNRF24_SS_PIN=SPI_SS_PIN
+        -DNRF24_MOSI_PIN=SPI_MOSI_PIN
+        -DNRF24_SCK_PIN=SPI_SCK_PIN
+        -DNRF24_MISO_PIN=SPI_MISO_PIN
 
-	-DUSE_W5500_VIA_SPI
-	-DW5500_SS_PIN=SPI_SS_PIN
-	-DW5500_MOSI_PIN=SPI_MOSI_PIN
-	-DW5500_SCK_PIN=SPI_SCK_PIN
-	-DW5500_MISO_PIN=SPI_MISO_PIN
-	-DW5500_INT_PIN=GROVE_SDA
+        -DUSE_W5500_VIA_SPI
+        -DW5500_SS_PIN=SPI_SS_PIN
+        -DW5500_MOSI_PIN=SPI_MOSI_PIN
+        -DW5500_SCK_PIN=SPI_SCK_PIN
+        -DW5500_MISO_PIN=SPI_MISO_PIN
+        -DW5500_INT_PIN=GROVE_SDA
 
-	;Lora setup pins
-	-DLORA_SCK=SPI_SCK_PIN
-	-DLORA_MISO=SPI_MISO_PIN
-	-DLORA_MOSI=SPI_MOSI_PIN
-	-DLORA_CS=5
-	-DLORA_RST=3
-	-DLORA_DIO0=4
+        ;Lora setup pins
+        -DLORA_SCK=SPI_SCK_PIN
+        -DLORA_MISO=SPI_MISO_PIN
+        -DLORA_MOSI=SPI_MOSI_PIN
+        -DLORA_CS=5
+        -DLORA_RST=3
+        -DLORA_DIO0=4
 
-	;Screen Setup
-	-DHAS_SCREEN=1
-	-DROTATION=1
-	-DBACKLIGHT=38
-	-DMINBRIGHT=160
+        ;Screen Setup
+        -DHAS_SCREEN=1
+        -DROTATION=1
+        -DBACKLIGHT=38
+        -DMINBRIGHT=160
 
-	;TFT_eSPI Setup
-	-DUSER_SETUP_LOADED=1
-	-DUSE_HSPI_PORT=1
-	-DST7789_2_DRIVER=1
-	-DTFT_RGB_ORDER=1
-	-DTFT_WIDTH=135
-	-DTFT_HEIGHT=240
-	-DTFT_BACKLIGHT_ON=1
-	-DTFT_BL=38
-	-DTFT_RST=33
-	-DTFT_DC=34
-	-DTFT_MOSI=35
-	-DTFT_SCLK=36
-	-DTFT_CS=37
-	-DTOUCH_CS=-1
-	-DSMOOTH_FONT=1
-	-DSPI_FREQUENCY=20000000
-	-DSPI_READ_FREQUENCY=20000000
-	-DSPI_TOUCH_FREQUENCY=2500000
+        ;TFT_eSPI Setup
+        -DUSER_SETUP_LOADED=1
+        -DUSE_HSPI_PORT=1
+        -DST7789_2_DRIVER=1
+        -DTFT_RGB_ORDER=1
+        -DTFT_WIDTH=135
+        -DTFT_HEIGHT=240
+        -DTFT_BACKLIGHT_ON=1
+        -DTFT_BL=38
+        -DTFT_RST=33
+        -DTFT_DC=34
+        -DTFT_MOSI=35
+        -DTFT_SCLK=36
+        -DTFT_CS=37
+        -DTOUCH_CS=-1
+        -DSMOOTH_FONT=1
+        -DSPI_FREQUENCY=20000000
+        -DSPI_READ_FREQUENCY=20000000
+        -DSPI_TOUCH_FREQUENCY=2500000
 
-	;SD Card Setup pins
-	-DSDCARD_CS=12
-	-DSDCARD_SCK=40
-	-DSDCARD_MISO=39
-	-DSDCARD_MOSI=14
+        ;SD Card Setup pins
+        -DSDCARD_CS=12
+        -DSDCARD_SCK=40
+        -DSDCARD_MISO=39
+        -DSDCARD_MOSI=14
 
-	;Default I2C port
-	-DGROVE_SDA=2
-	-DGROVE_SCL=1
-	-D SYS_I2C_SDA=-1 #8 on ADV Only
-	-D SYS_I2C_SCL=-1 #9 on ADV Only
+        ;Default I2C port
+        -DGROVE_SDA=2
+        -DGROVE_SCL=1
+        -D SYS_I2C_SDA=-1 #8 on ADV Only
+        -D SYS_I2C_SCL=-1 #9 on ADV Only
 
-	;Default SPI port
-	-DSPI_SCK_PIN=40
-	-DSPI_MOSI_PIN=14
-	-DSPI_MISO_PIN=39
-	-DSPI_SS_PIN=GROVE_SCL
+        ;Cardputer GPS Module Selector (fixes GPS pin reset bug)
+        -DCARDPUTER_GPS_MODULE_SELECT=1
 
-	-DDEVICE_NAME='"M5Stack Cardputer"'
+        ;Default SPI port
+        -DSPI_SCK_PIN=40
+        -DSPI_MOSI_PIN=14
+        -DSPI_MISO_PIN=39
+        -DSPI_SS_PIN=GROVE_SCL
+
+        -DDEVICE_NAME='"M5Stack Cardputer"'
 
 lib_deps =
-	${env.lib_deps}
-	adafruit/Adafruit TCA8418 @ ^1.0.2
+        ${env.lib_deps}
+        adafruit/Adafruit TCA8418 @ ^1.0.2

--- a/src/core/configPins.cpp
+++ b/src/core/configPins.cpp
@@ -125,6 +125,15 @@ void BruceConfigPins::fromJson(JsonObject obj) {
         log_e("Fail");
     }
 
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+    if (!root["gpsModule"].isNull()) {
+        gpsModule = (GPSModules)root["gpsModule"].as<int>();
+    } else {
+        count++;
+        log_e("Fail");
+    }
+#endif
+
     if (!root["CC1101_Pins"].isNull()) {
         SPIPins def = CC1101_bus;
         CC1101_bus.fromJson(root["CC1101_Pins"].as<JsonObject>());
@@ -256,6 +265,10 @@ void BruceConfigPins::toJson(JsonObject obj) const {
     root["rfidModule"] = rfidModule;
     root["gpsBaudrate"] = gpsBaudrate;
     root["iButton"] = iButton;
+
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+    root["gpsModule"] = (int)gpsModule;
+#endif
 
     JsonObject _CC1101 = root["CC1101_Pins"].to<JsonObject>();
     CC1101_bus.toJson(_CC1101);
@@ -389,6 +402,9 @@ void BruceConfigPins::validateConfig() {
     validateRfModuleValue();
     validateRfidModuleValue();
     validateGpsBaudrateValue();
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+    validateGpsModuleValue();
+#endif
 #if !defined(LITE_VERSION)
     validateSpiPins(ST25R_bus);
     validateSpiPins(LoRa_bus);
@@ -584,3 +600,37 @@ void BruceConfigPins::validateGpsBaudrateValue() {
         gpsBaudrate != 115200)
         gpsBaudrate = 9600;
 }
+
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+void BruceConfigPins::setGpsModule(GPSModules value) {
+    gpsModule = value;
+    validateGpsModuleValue();
+    applyGpsModulePreset();
+    saveFile();
+}
+
+void BruceConfigPins::validateGpsModuleValue() {
+    if (gpsModule != GPS_MODULE_LORA_CAP && gpsModule != GPS_MODULE_GROVE_PORT &&
+        gpsModule != GPS_MODULE_CUSTOM) {
+        gpsModule = GPS_MODULE_CUSTOM;
+    }
+}
+
+void BruceConfigPins::applyGpsModulePreset() {
+    switch (gpsModule) {
+        case GPS_MODULE_LORA_CAP:
+            gps_bus.rx = (gpio_num_t)15;
+            gps_bus.tx = (gpio_num_t)13;
+            gpsBaudrate = 115200;
+            break;
+        case GPS_MODULE_GROVE_PORT:
+            gps_bus.rx = (gpio_num_t)2;
+            gps_bus.tx = (gpio_num_t)1;
+            gpsBaudrate = 9600;
+            break;
+        case GPS_MODULE_CUSTOM:
+            // Preserve whatever the user has set
+            break;
+    }
+}
+#endif

--- a/src/core/configPins.h
+++ b/src/core/configPins.h
@@ -24,6 +24,14 @@ enum RFModules {
     CC1101_SPI_MODULE = 1,
 };
 
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+enum GPSModules {
+    GPS_MODULE_LORA_CAP = 0,   // pins 15/13, baud 115200
+    GPS_MODULE_GROVE_PORT = 1, // pins 2/1, baud 9600
+    GPS_MODULE_CUSTOM = 2,     // user-defined pins
+};
+#endif
+
 class BruceConfigPins {
 public:
     struct UARTPins {
@@ -241,6 +249,11 @@ public:
     // GPS
     int gpsBaudrate = 9600;
 
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+    // GPS Module Selector (Cardputer-specific)
+    GPSModules gpsModule = GPS_MODULE_CUSTOM;
+#endif
+
     /////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     /////////////////////////////////////////////////////////////////////////////////////
@@ -305,4 +318,11 @@ public:
     // GPS
     void setGpsBaudrate(int value);
     void validateGpsBaudrateValue();
+
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+    // GPS Module Selector
+    void setGpsModule(GPSModules value);
+    void validateGpsModuleValue();
+    void applyGpsModulePreset();
+#endif
 };

--- a/src/core/menu_items/GpsMenu.cpp
+++ b/src/core/menu_items/GpsMenu.cpp
@@ -32,13 +32,38 @@ void GpsMenu::wardrivingMenu() {
 }
 void GpsMenu::configMenu() {
     options = {
-        {"Baudrate", setGpsBaudrateMenu                                 },
-        {"GPS Pins", [=]() { setUARTPinsMenu(bruceConfigPins.gps_bus); }},
-        {"Back",     [this]() { optionsMenu(); }                        },
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+        {"GPS Module", [this]() { gpsModuleMenu(); }                    },
+#endif
+        {"Baudrate",   setGpsBaudrateMenu                               },
+        {"GPS Pins",   [=]() { setUARTPinsMenu(bruceConfigPins.gps_bus); }},
+        {"Back",       [this]() { optionsMenu(); }                      },
     };
 
     loopOptions(options, MENU_TYPE_SUBMENU, "GPS Config");
 }
+
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+void GpsMenu::gpsModuleMenu() {
+    options = {
+        {"LoRa Cap (15/13)", [this]() {
+             bruceConfigPins.setGpsModule(GPS_MODULE_LORA_CAP);
+             configMenu();
+         }},
+        {"Grove Port (2/1)", [this]() {
+             bruceConfigPins.setGpsModule(GPS_MODULE_GROVE_PORT);
+             configMenu();
+         }},
+        {"Custom",           [this]() {
+             bruceConfigPins.setGpsModule(GPS_MODULE_CUSTOM);
+             configMenu();
+         }},
+        {"Back",             [this]() { configMenu(); }},
+    };
+
+    loopOptions(options, MENU_TYPE_SUBMENU, "GPS Module");
+}
+#endif
 
 void GpsMenu::drawIcon(float scale) {
     clearIconArea();

--- a/src/core/menu_items/GpsMenu.h
+++ b/src/core/menu_items/GpsMenu.h
@@ -15,6 +15,9 @@ public:
 
 private:
     void configMenu(void);
+#ifdef CARDPUTER_GPS_MODULE_SELECT
+    void gpsModuleMenu(void);
+#endif
 };
 
 #endif


### PR DESCRIPTION
### Proposed Changes ###

Adds a GPS Module selector to the Cardputer's GPS config menu, allowing users to choose their GPS hardware once and have the pins persist across reboots.

Fixes a bug where boards/m5stack-cardputer/interface.cpp hardcoded GPS pins to 15/13 on every boot. Because this code runs after the config file is loaded, it overwrote any saved GPS configuration, making external GPS modules wired to the Grove port (pins 2/1) impossible to use persistently.

Problem in detail:

```
// In _post_setup_gpio() — runs on every boot
bruceConfigPins.gps_bus.rx = (gpio_num_t)15;
bruceConfigPins.gps_bus.tx = (gpio_num_t)13;
bruceConfigPins.gpsBaudrate = 115200;
```

These values were likely intended for the M5Stack LoRa cap, but they prevent any other GPS configuration from surviving a reboot.

Solution:
Follow the existing project pattern for module selectors — the same approach already used for rfidModule and rfModule. Add a gpsModule config field with three presets:

· LoRa Cap — pins 15/13, baud 115200
· Grove Port — pins 2/1, baud 9600
· Custom — user-defined pins (preserves current behavior)

The user picks their hardware once from GPS > Config > GPS Module, and the preset is applied and persisted. No more forced overrides on every boot.

All changes are guarded behind CARDPUTER_GPS_MODULE_SELECT, defined only for the m5stack-cardputer environment. No other boards are affected — they compile with zero new symbols, zero new config fields, and zero new menu options.

### Types of Changes ###

· Bugfix — resolves persistent GPS pin reset on Cardputer
· New Feature — GPS Module selector (guarded, Cardputer-only)
· Backward Compatible — existing configs preserved, LoRa cap behavior maintained

### Verification ###

On Cardputer with external GPS module wired to Grove port:

1. Build for m5stack-cardputer
2. Flash device
3. Navigate to GPS > Config > GPS Module
4. Select "Grove Port (2/1)"
5. Reboot
6. Verify in brucePins.conf that gpsModule = 1 (GROVE_PORT) and GPS pins are rx=2, tx=1
7. Wire GPS module to Grove port (pin 1 = TX, pin 2 = RX, 5V, GND)
8. Open GPS menu → verify data reception (satellites, fix)

Verify no side effects on other boards:

```
pio run -e m5stack-cores3
```

Should build cleanly with zero gpsModule-related symbols.

Verify backward compatibility:

· Existing Cardputer users: on first boot after update, pins stay at 15/13 (LoRa cap default preserved)
· Users who then select "Grove Port": pins update to 2/1 and persist forever
· Users who select "Custom": their existing pins are untouched

### Testing ###


☑ Builds cleanly for m5stack-cardputer
☑ Builds cleanly for m5stack-cores3 (verifies no cross-board impact)
☑ First boot preserves old behavior (LoRa Cap defaults applied if unconfigured)
☑ Selecting "Grove Port" sets pins to 2/1, baud 9600
☑ Reboot: selection and pins persist in brucePins.conf
☑ GPS data received on Grove port (confirmed NMEA output)
☑ Switching to "LoRa Cap" sets pins back to 15/13, baud 115200
☑ Switching to "Custom" preserves user-set pins
☑ Other modules (RF, IR, RFID, keyboard) unaffected
☑ Config file backward compatible (existing brucePins.conf loads without errors)

No automated tests added — this is a config-plumbing change, verified manually on hardware. If a hardware-in-the-loop test framework exists, happy to add coverage on request.


### User-Facing Change ###

```release-note
Cardputer: Added GPS Module selector (GPS > Config > GPS Module) with presets for LoRa Cap, Grove Port, and Custom wiring. Fixes a bug where GPS pins were reset to 15/13 on every boot, making it impossible to use external GPS modules on the Grove port persistently. No changes for other boards.
```

###0  Further Comments ###

Design notes:

· The flag CARDPUTER_GPS_MODULE_SELECT follows the existing board-name convention already used in platformio.ini.
· The default value of gpsModule is GPS_MODULE_CUSTOM, which preserves current behavior for users who never touch the new menu.
· interface.cpp only applies the LoRa Cap preset on first boot (when gps_bus.rx == GPIO_NUM_NC) — after that, the config file is authoritative.
· No changes to shared files (settings.cpp, precompiler_flags.h, pins_arduino.h) are required.

Future extensibility:

The enum and guard make it trivial to add new presets later (e.g., specific M5Stack GPS modules, other LoRa cap revisions, or boards that adopt the same pattern). Each new preset is a single case in applyGpsModulePreset().