### PR TITLE
UI/rf waterfall sdr style

### DIFF
--- a/src/core/spectrum_plot.cpp
+++ b/src/core/spectrum_plot.cpp
@@ -58,6 +58,30 @@ void SpectrumPlot::buildGeometry() {
     _wfTop = _specBot + 3;
 }
 
+// Classic SDR waterfall colourmap (à la GQRX / SDR# / SDRPlay): the noise floor
+// blends with the panel, then the signal climbs through blue, cyan, green,
+// yellow and red to a white-hot peak. Grounded in the common SDR gradients.
+static void sp_build_sdr_palette() {
+    static const uint8_t stopPos[] = {0, 30, 60, 105, 150, 195, 225, 255};
+    static const uint8_t stopR[] = {0, 0, 0, 0, 40, 235, 235, 255};
+    static const uint8_t stopG[] = {0, 0, 40, 180, 205, 235, 70, 255};
+    static const uint8_t stopB[] = {0, 90, 175, 200, 60, 0, 0, 255};
+    const int NS = sizeof(stopPos) / sizeof(stopPos[0]);
+
+    sp_heat[0] = bruceConfig.bgColor; // "no signal" blends with the panel
+    for (int i = 1; i < SP_HEAT_N; i++) {
+        int t = i * 255 / (SP_HEAT_N - 1);
+        int s = 0;
+        while (s < NS - 2 && t > stopPos[s + 1]) s++;
+        int span = stopPos[s + 1] - stopPos[s];
+        int f = span ? (t - stopPos[s]) * 255 / span : 0;
+        int r = stopR[s] + (stopR[s + 1] - stopR[s]) * f / 255;
+        int g = stopG[s] + (stopG[s + 1] - stopG[s]) * f / 255;
+        int b = stopB[s] + (stopB[s + 1] - stopB[s]) * f / 255;
+        sp_heat[i] = tft.color565(r, g, b);
+    }
+}
+
 void SpectrumPlot::buildPalette() {
     uint16_t pri = bruceConfig.priColor;
     _bg = bruceConfig.bgColor;
@@ -67,10 +91,12 @@ void SpectrumPlot::buildPalette() {
     _peak = blendColors(pri, TFT_WHITE, 150);
     _grid = blendColors(_bg, pri, 55);
     _label = blendColors(_bg, pri, 170);
-    buildHeatPalette(sp_heat, SP_HEAT_N);
+    if (_sdr) sp_build_sdr_palette();
+    else buildHeatPalette(sp_heat, SP_HEAT_N);
 }
 
-bool SpectrumPlot::begin(const String &title) {
+bool SpectrumPlot::begin(const String &title, bool sdrWaterfall) {
+    _sdr = sdrWaterfall;
     buildGeometry();
     buildPalette();
 

--- a/src/core/spectrum_plot.h
+++ b/src/core/spectrum_plot.h
@@ -24,7 +24,11 @@
 //     plot.end();
 class SpectrumPlot {
 public:
-    bool begin(const String &title);
+    // `sdrWaterfall` swaps the waterfall's theme heat ramp for a classic SDR
+    // colourmap (noise floor -> blue -> cyan -> green -> yellow -> red -> white),
+    // for screens that want the look of GQRX/SDR#. The trace on top stays
+    // theme-coloured either way. Defaults off so existing callers are unchanged.
+    bool begin(const String &title, bool sdrWaterfall = false);
     void end();
     bool ready() const { return _ok; }
 
@@ -58,6 +62,7 @@ private:
     void drawWaterfall();
 
     bool _ok = false;
+    bool _sdr = false; // waterfall uses the SDR colourmap instead of the theme ramp
 
     int _plotL = 0, _plotW = 0;
     int _specTop = 0, _specBot = 0, _specH = 0;

--- a/src/modules/rf/rf_waterfall.cpp
+++ b/src/modules/rf/rf_waterfall.cpp
@@ -1,4 +1,5 @@
 #include "rf_waterfall.h"
+#include "core/spectrum_plot.h"
 #ifndef TFT_MOSI
 #define TFT_MOSI -1
 #endif
@@ -56,157 +57,156 @@ void rf_waterfall_boundary_freq(float &boundary) {
     options.clear();
 }
 
-uint16_t swapBytes(uint16_t c) { return (c >> 8) | (c << 8); }
+
+// ── SDR-style waterfall ─────────────────────────────────────────
+// Rebuilt on the shared SpectrumPlot so it matches NRF Spectrum: a live filled
+// trace with peak-hold across the top, and a theme-coloured waterfall below fed
+// by the very same envelope, so the falls track the waveform above them.
+//
+// The band is swept in a modest number of bins (not one per pixel): retuning a
+// CC1101 needs a few ms for the PLL/RSSI to settle before getRssi() is valid
+// (see rf_CC1101_rssi), so sampling every pixel with a sub-ms wait would just
+// read the noise floor. We sample WF_BINS points with a real settle and then
+// interpolate the envelope across the plot columns for a continuous trace.
+#define WF_BINS 64
+#define WF_SETTLE_MS 3
 
 void rf_waterfall_run() {
-    float f_start = m_rf_waterfall_start_freq;
-    float f_end = m_rf_waterfall_end_freq;
-    const int screen_width = tft.width();
-    const int screen_height = tft.height();
-    const int display_top = screen_height / 5;
-    float f_freq_step;
-
-    // Alloc framebuffer
-    uint16_t frameBuffer[screen_width] = {0};
-
-    int current_line = display_top;
-    initRfModule("rx", f_start);
-
-    float max_freq = f_start;
-    int max_rssi = -100;
-    unsigned long lastMaxUpdate = millis();
-
-    tft.fillRect(0, 0, screen_width, display_top, TFT_BLACK);
-
-    int selected_item = 0;
-    bool exitting = false;
-    unsigned long exit_time = 0;
-
-    while (1) {
-        for (int i = 0; i < 4; i++) {
-            int x = i * (screen_width / 4);
-            float f_freq = f_start + (f_end - f_start) * i / 4.0;
-            tft.setCursor(x, 0);
-            tft.setTextSize(FP);
-
-            if (i == 0 && selected_item == 0) {
-                tft.setTextColor(TFT_PINK, TFT_BLACK);
-            } else if (i == 3 && selected_item == 1) {
-                tft.setTextColor(TFT_PINK, TFT_BLACK);
-            } else {
-                tft.setTextColor(TFT_WHITE, TFT_BLACK);
-            }
-
-            tft.drawFastVLine(x, 0, tft.height(), TFT_DARKGREY);
-            tft.print(String(f_freq, 1));
-        }
-
-        f_freq_step = (f_end - f_start) / screen_width;
-
-        float temp_max_freq = f_start;
-        int temp_max_rssi = -100;
-
-        float range = abs(f_end - f_start);
-        float step;
-
-        if (range > 100) step = 10;
-        else if (range > 10) step = 1;
-        else if (range > 1) step = 0.1;
-        else if (range > 0.1) step = 0.01;
-        else step = 0.001;
-
-        for (int i = 0; i < screen_width; ++i) {
-            float f_freq = f_start + i * f_freq_step;
-            setMHZ(f_freq);
-            // To make sure CC1101 shared with TFT works properly on T-Embed
-            if (bruceConfigPins.CC1101_bus.mosi == TFT_MOSI) {
-                tft.drawPixel(0, 0, 0);
-                delayMicroseconds(150); // T-Embed case, need more time to process
-            } else delayMicroseconds(100);
-
-            int i_rssi = ELECHOUSE_cc1101.getRssi();
-            // To make sure CC1101 shared with TFT works properly on T-Embed
-            if (bruceConfigPins.CC1101_bus.mosi == TFT_MOSI) tft.drawPixel(0, 0, 0);
-            if (i_rssi > temp_max_rssi) {
-                temp_max_rssi = i_rssi;
-                temp_max_freq = f_freq;
-            }
-
-            int rawLevel = map(i_rssi, -100, -30, 0, 255);
-            int level = 255 - constrain(rawLevel, 0, 255);
-
-            uint8_t r = 0, g = 0, b = 0;
-            if (level <= 63) {
-                b = map(level, 0, 63, 64, 255);
-            } else if (level <= 127) {
-                g = map(level, 64, 127, 0, 255);
-                b = map(level, 64, 127, 255, 0);
-            } else if (level <= 191) {
-                r = map(level, 128, 191, 0, 255);
-                g = 255;
-            } else {
-                r = 255;
-                g = map(level, 192, 255, 255, 0);
-            }
-
-            uint16_t color = tft.color565(r, g, b);
-            frameBuffer[i] = swapBytes(color);
-            if (check(SelPress)) {
-                selected_item++;
-                if (selected_item > 2) selected_item = 0;
-            }
-
-            if (check(UpPress) || check(NextPress)) {
-                switch (selected_item) {
-                    case 0: f_start += step; break;
-                    case 1: f_end += step; break;
-                    case 2: return;
-                }
-                delay(100);
-            } else if (check(DownPress) || check(PrevPress)) {
-                switch (selected_item) {
-                    case 0: f_start -= step; break;
-                    case 1: f_end -= step; break;
-                    case 2: return;
-                }
-                if (EscPress) EscPress = false; // Reset for StickCs
-                delay(100);
-            }
-        }
-        tft.drawPixel(0, 0, 0); // Cardputer Case, need to call something to the tft.
-        tft.pushImage(0, current_line, screen_width, 1, frameBuffer);
-        tft.drawFastHLine(0, current_line + 1, screen_width, TFT_DARKGREY);
-
-        if (millis() - lastMaxUpdate >= 5000) {
-            max_rssi = temp_max_rssi;
-            max_freq = temp_max_freq;
-            tft.fillRect(0, 10, screen_width, 10, TFT_BLACK);
-            tft.setCursor(3, 10);
-            tft.setTextSize(FP);
-            tft.setTextColor(TFT_YELLOW, TFT_BLACK);
-            tft.printf("%d dBm @ %.3f", max_rssi, max_freq);
-
-            lastMaxUpdate = millis();
-        }
-
-        tft.setCursor(3, 20);
-        tft.setTextColor(TFT_DARKCYAN);
-        tft.print("[OK] Item [PREV/NEXT] Value ");
-
-        if (selected_item == 2) {
-            tft.setTextColor(TFT_RED);
-            tft.print("EXIT");
-        } else {
-            tft.setTextColor(TFT_WHITE);
-            tft.print("EXIT");
-        }
-
-        if (check(EscPress)) break;
-
-        current_line++;
-        if (current_line >= screen_height) current_line = display_top;
+    SpectrumPlot plot;
+    if (!plot.begin("RF Waterfall", /*sdrWaterfall=*/true)) { // SDR colourmap below
+        displayError("Out of memory", true);
+        return;
     }
 
+    const int plotW = plot.width();
+    uint8_t *env = (uint8_t *)malloc(plotW);     // freshly measured envelope
+    uint8_t *disp = (uint8_t *)malloc(plotW);    // eased envelope drawn on top
+    uint8_t *envPeak = (uint8_t *)malloc(plotW); // peak-hold line
+    if (!env || !disp || !envPeak) {
+        free(env);
+        free(disp);
+        free(envPeak);
+        plot.end();
+        displayError("Out of memory", true);
+        return;
+    }
+    memset(env, 0, plotW);
+    memset(disp, 0, plotW);
+    memset(envPeak, 0, plotW);
+
+    float f_start = m_rf_waterfall_start_freq;
+    float f_end = m_rf_waterfall_end_freq;
+    if (f_end < f_start) {
+        float t = f_start;
+        f_start = f_end;
+        f_end = t;
+    }
+
+    initRfModule("rx", f_start);
+    ELECHOUSE_cc1101.setRxBW(200);
+
+    // Five evenly spaced frequency ticks under the plot; redrawn when panning.
+    const int tickCount = 5;
+    int cols[tickCount];
+    String labels[tickCount];
+    auto drawRuler = [&]() {
+        for (int i = 0; i < tickCount; i++) {
+            cols[i] = i * (plotW - 1) / (tickCount - 1);
+            float f = f_start + (f_end - f_start) * i / (tickCount - 1);
+            labels[i] = String(f, 2);
+        }
+        plot.ruler(cols, labels, tickCount);
+    };
+    drawRuler();
+    plot.status("scanning...");
+
+    // Pan step scales with the span, matching the old boundary stepping.
+    float range = f_end - f_start;
+    float step;
+    if (range > 100) step = 10;
+    else if (range > 10) step = 1;
+    else if (range > 1) step = 0.1f;
+    else if (range > 0.1f) step = 0.01f;
+    else step = 0.001f;
+
+    const bool sharedBus = (bruceConfigPins.CC1101_bus.mosi == TFT_MOSI);
+    uint8_t bins[WF_BINS];
+
+    uint32_t lastStatus = 0;
+    while (!check(EscPress)) {
+        // Sweep the band once — WF_BINS RSSI samples with a real settle so the
+        // reading reflects the tuned frequency instead of the noise floor.
+        int maxBin = 0;
+        int maxRssi = -128;
+        for (int b = 0; b < WF_BINS; b++) {
+            float f = f_start + (f_end - f_start) * b / (WF_BINS - 1);
+            setMHZ(f);
+            vTaskDelay(pdMS_TO_TICKS(WF_SETTLE_MS)); // let the PLL/RSSI settle
+            int rssi = ELECHOUSE_cc1101.getRssi();
+            if (sharedBus) tft.drawPixel(0, 0, 0); // keep CC1101/TFT shared SPI happy
+
+            int v = map(rssi, -100, -30, 0, 100);
+            v = constrain(v, 0, 100);
+            bins[b] = (uint8_t)v;
+            if (rssi > maxRssi) {
+                maxRssi = rssi;
+                maxBin = b;
+            }
+            if (check(EscPress)) break;
+        }
+
+        // Interpolate the bins across the plot columns for a continuous trace,
+        // and peak-hold with slow decay so brief bursts stay visible (as in NRF).
+        int maxCol = maxBin * (plotW - 1) / (WF_BINS - 1);
+        for (int i = 0; i < plotW; i++) {
+            int32_t pos = (int32_t)i * (WF_BINS - 1) * 256 / (plotW - 1);
+            int bi = pos >> 8;
+            int frac = pos & 0xff;
+            if (bi >= WF_BINS - 1) {
+                bi = WF_BINS - 2;
+                frac = 256;
+            }
+            int v = bins[bi] + (bins[bi + 1] - bins[bi]) * frac / 256;
+            env[i] = (uint8_t)(v < 0 ? 0 : (v > 100 ? 100 : v));
+            if (env[i] > envPeak[i]) envPeak[i] = env[i];
+            else if (envPeak[i]) envPeak[i]--;
+
+            // Ease the drawn trace toward the measurement so the top glides
+            // instead of snapping, matching Jam Detect's animated sweep.
+            int d = (int)env[i] - (int)disp[i];
+            if (d) disp[i] = (uint8_t)((int)disp[i] + (d > 0 ? max(1, d / 3) : min(-1, d / 3)));
+        }
+
+        int hlSpan = plotW / 40;
+        plot.trace(disp, envPeak, maxCol - hlSpan, maxCol + hlSpan); // eased trace on top
+        plot.pushRow(env); // waterfall shows the true measurement
+
+        if (millis() - lastStatus >= 350) {
+            lastStatus = millis();
+            float peakFreq = f_start + (f_end - f_start) * maxBin / (WF_BINS - 1);
+            plot.status(String(maxRssi) + "dBm @" + String(peakFreq, 3) + "MHz  UP/DN pan");
+        }
+
+        // Pan the whole window and refresh the ruler + peak history.
+        if (check(UpPress) || check(NextPress)) {
+            f_start += step;
+            f_end += step;
+            memset(envPeak, 0, plotW);
+            drawRuler();
+            delay(80);
+        } else if (check(DownPress) || check(PrevPress)) {
+            f_start -= step;
+            f_end -= step;
+            memset(envPeak, 0, plotW);
+            drawRuler();
+            delay(80);
+        }
+    }
+
+    free(env);
+    free(disp);
+    free(envPeak);
+    plot.end();
     returnToMenu = true;
     deinitRfModule();
     delay(10);


### PR DESCRIPTION
#### Proposed Changes ####

This reworks RF Waterfall onto the shared SpectrumPlot component and adds an
opt-in SDR colourmap to that component, so the screen reads like desktop SDR
software while its chrome stays consistent with the rest of Bruce.

Two parts:

1. SpectrumPlot gains an optional SDR waterfall colourmap:

       bool begin(const String &title, bool sdrWaterfall = false);

   When true, the waterfall ramp is the classic SDR gradient (noise floor
   blended into the panel, then blue, cyan, green, yellow, red, up to a
   white-hot peak) instead of the theme heat ramp. The trace on top stays
   theme-coloured. The parameter defaults to false, so NRF Spectrum, Jam Detect
   and Channel Analyzer are unchanged and keep the theme ramp.

2. RF Waterfall is rebuilt on that component. It previously swept the CC1101 one
   pixel-column at a time, mapped RSSI through a hand-rolled rainbow with an
   inverted ramp (strong signals came out dark, the noise floor bright red),
   scrolled a manual framebuffer and drew its labels in literal TFT_* colours
   with no border, title or status bar. Now:

   - the top is SpectrumPlot's filled trace with a peak-hold line and animated
     noise floor; the drawn envelope eases toward each measurement (as Jam
     Detect does) so the trace glides instead of snapping
   - the waterfall below is fed by the same envelope, so the falls track the
     waveform above them, drawn with the new SDR colourmap
   - a five-tick frequency ruler and a status line naming the peak dBm and
     frequency, all theme-consistent
   - UP/DOWN (or PREV/NEXT) pan the whole window; the ruler and peak-hold reset
     to follow

   The sweep itself is fixed too. In the scan path setMHZ only rewrites the
   frequency, and the CC1101 needs a few milliseconds for the PLL/RSSI to settle
   before getRssi() is valid (the working RF RSSI view waits 5ms). The old
   per-pixel 100us wait was far too short, so a real signal never rose above the
   noise floor - the rainbow only ever showed noise. It now samples WF_BINS
   points with a real settle and interpolates the envelope across the plot, so a
   transmitter actually paints the trace and the waterfall.

#### Types of Changes ####

Bugfix (RSSI never settled, so nothing was detected; the colour ramp was
inverted) plus a UI rework onto the shared component and an opt-in rendering
option on that component. No behaviour change for existing SpectrumPlot callers,
no breaking change.

#### Verification ####

    pio run -e m5stack-cardputer

Flash and open RF -> Waterfall on a device with a CC1101. Expect:

  - a filled trace with peak-hold across the top, gliding as it updates
  - a waterfall below in the SDR gradient (dark for the noise floor, climbing
    through blue/green/yellow to red/white on a strong signal) that follows the
    trace
  - a frequency ruler and a status line naming the peak dBm and frequency
  - UP/DOWN pans the band

Transmitting on a frequency inside the band should raise the trace at the
matching column and leave a bright streak falling down the waterfall.

NRF Spectrum, Jam Detect and Channel Analyzer should be visually unchanged
(they keep the theme ramp).

#### Testing ####

No unit test harness exists for this layer. Compiled clean for m5stack-cardputer.
Not yet verified on hardware by me - a reviewer with a CC1101 should confirm a
known transmitter paints the trace and that the pan controls track.

#### Linked Issues ####

None.

#### User-Facing Change ####
```release-note
RF Waterfall now renders on the shared spectrum plot with a gliding peak-hold trace and an SDR-style colour waterfall, follows the theme for its chrome, and actually detects signals (the sweep now lets the CC1101 settle before reading RSSI).
```

#### Further Comments ####

WF_BINS (64) and WF_SETTLE_MS (3) trade sweep resolution against refresh rate;
they are #defines at the top of the run function so they are easy to tune on
hardware. The SDR gradient stops follow the common SDR waterfall colourmaps
(GQRX, SDR#, SDRPlay); index 0 is the panel background so a dead band blends
with the frame rather than showing a hard black bar.

<img width="1968" height="1596" alt="waterfall" src="https://github.com/user-attachments/assets/69250944-44d6-4c11-ba09-48c42449ba20" />

